### PR TITLE
fix: improve magnet link handling and DHT peer discovery

### DIFF
--- a/src/dht.zig
+++ b/src/dht.zig
@@ -167,45 +167,61 @@ pub const Dht = struct {
             }
         }
 
-        // Collect responses
+        // Iterative lookup: collect responses and query closer nodes we discover.
         var recv_buf: [8192]u8 = undefined;
         const sock = self.sock orelse return peers.toOwnedSlice(allocator) catch return error.OutOfMemory;
 
-        var rounds: usize = 0;
-        while (rounds < 5) : (rounds += 1) {
-            var src_addr: std.posix.sockaddr = undefined;
-            var addr_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
-            const n = std.posix.recvfrom(sock, &recv_buf, 0, &src_addr, &addr_len) catch break;
-            if (n == 0) break;
+        var iterations: usize = 0;
+        while (iterations < 3) : (iterations += 1) {
+            // Drain responses for this iteration
+            var rounds: usize = 0;
+            while (rounds < 8) : (rounds += 1) {
+                var src_addr: std.posix.sockaddr = undefined;
+                var addr_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
+                const n = std.posix.recvfrom(sock, &recv_buf, 0, &src_addr, &addr_len) catch break;
+                if (n == 0) break;
 
-            // Parse response
-            const resp = bencode.decode(allocator, recv_buf[0..n]) catch continue;
-            defer resp.deinit(allocator);
+                // Parse response
+                const resp = bencode.decode(allocator, recv_buf[0..n]) catch continue;
+                defer resp.deinit(allocator);
 
-            // Check for "values" (peers)
-            if (resp.dictGet("r")) |r_dict| {
-                if (r_dict.dictGet("values")) |values| {
-                    if (values.asList()) |peer_list| {
-                        for (peer_list) |peer_val| {
-                            if (peer_val.asString()) |compact| {
-                                if (compact.len == 6) {
-                                    const peer = tracker_mod.Peer{
-                                        .ip = .{ compact[0], compact[1], compact[2], compact[3] },
-                                        .port = @as(u16, compact[4]) << 8 | @as(u16, compact[5]),
-                                    };
-                                    peers.append(allocator, peer) catch continue;
+                // Check for "values" (peers)
+                if (resp.dictGet("r")) |r_dict| {
+                    if (r_dict.dictGet("values")) |values| {
+                        if (values.asList()) |peer_list| {
+                            for (peer_list) |peer_val| {
+                                if (peer_val.asString()) |compact| {
+                                    if (compact.len == 6) {
+                                        const peer = tracker_mod.Peer{
+                                            .ip = .{ compact[0], compact[1], compact[2], compact[3] },
+                                            .port = @as(u16, compact[4]) << 8 | @as(u16, compact[5]),
+                                        };
+                                        peers.append(allocator, peer) catch continue;
+                                    }
                                 }
                             }
                         }
                     }
-                }
 
-                // Process "nodes" for routing table
-                if (r_dict.dictGet("nodes")) |nodes_val| {
-                    if (nodes_val.asString()) |compact_nodes| {
-                        self.addCompactNodes(compact_nodes);
+                    // Process "nodes" for routing table
+                    if (r_dict.dictGet("nodes")) |nodes_val| {
+                        if (nodes_val.asString()) |compact_nodes| {
+                            self.addCompactNodes(compact_nodes);
+                        }
                     }
                 }
+            }
+
+            // If we found peers, we're done
+            if (peers.items.len > 0) break;
+
+            // Otherwise, query the closer nodes we just learned about
+            var next_closest = self.findClosest(info_hash, k);
+            defer next_closest.deinit(self.allocator);
+            if (next_closest.items.len == 0) break;
+
+            for (next_closest.items) |node| {
+                self.sendGetPeers(node.address, info_hash) catch continue;
             }
         }
 

--- a/src/dht.zig
+++ b/src/dht.zig
@@ -217,12 +217,15 @@ pub const Dht = struct {
 
             // Otherwise, query the closer nodes we just learned about
             var next_closest = self.findClosest(info_hash, k);
-            defer next_closest.deinit(self.allocator);
-            if (next_closest.items.len == 0) break;
+            if (next_closest.items.len == 0) {
+                next_closest.deinit(self.allocator);
+                break;
+            }
 
             for (next_closest.items) |node| {
                 self.sendGetPeers(node.address, info_hash) catch continue;
             }
+            next_closest.deinit(self.allocator);
         }
 
         return peers.toOwnedSlice(allocator) catch return error.OutOfMemory;

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,6 +44,8 @@ pub fn main() !void {
         }
         // Reassemble magnet URIs that the shell may have split on '&'.
         // e.g. magnet:?xt=...&dn=... becomes multiple argv entries when unquoted.
+        // Note: consumed fragments remain in args[3..] but are harmless —
+        // parseFlag only matches "--output-dir" / "--port" which can't collide.
         const source = blk: {
             if (!std.mem.startsWith(u8, args[2], "magnet:")) break :blk args[2];
             var parts: std.ArrayList(u8) = .empty;

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,9 +42,23 @@ pub fn main() !void {
             log.err("usage: carl download <source> [--output-dir <dir>] [--port <port>]", .{});
             std.process.exit(1);
         }
+        // Reassemble magnet URIs that the shell may have split on '&'.
+        // e.g. magnet:?xt=...&dn=... becomes multiple argv entries when unquoted.
+        const source = blk: {
+            if (!std.mem.startsWith(u8, args[2], "magnet:")) break :blk args[2];
+            var parts: std.ArrayList(u8) = .empty;
+            defer parts.deinit(allocator);
+            parts.appendSlice(allocator, args[2]) catch @panic("OOM");
+            for (args[3..]) |a| {
+                if (std.mem.startsWith(u8, a, "--")) break;
+                parts.append(allocator, '&') catch @panic("OOM");
+                parts.appendSlice(allocator, a) catch @panic("OOM");
+            }
+            break :blk @as([]const u8, allocator.dupe(u8, parts.items) catch @panic("OOM"));
+        };
         const output_dir = parseFlag(args[3..], "--output-dir") orelse ".";
         const port = parsePort(args[3..]);
-        try cmdDownload(allocator, args[2], output_dir, port);
+        try cmdDownload(allocator, source, output_dir, port);
     } else if (std.mem.eql(u8, command, "seed")) {
         if (args.len < 4) {
             log.err("usage: carl seed <file.torrent> <data-dir> [--port <port>]", .{});

--- a/src/session.zig
+++ b/src/session.zig
@@ -972,12 +972,15 @@ pub const Session = struct {
         // Run choking algorithm
         self.runChokingAlgorithm();
 
-        // Re-announce / DHT retry
-        // Use a shorter interval when we have no peers (e.g. DHT-only magnet)
-        const base_interval = std.math.cast(i64, self.tracker_interval) orelse 1800;
-        const interval_secs = if (self.peers.items.len == 0) @min(base_interval, 30) else base_interval;
+        // Re-announce to trackers at the tracker-provided interval
+        const interval_secs = std.math.cast(i64, self.tracker_interval) orelse 1800;
         if (now - self.last_announce_time > interval_secs) {
             self.doMultiTrackerAnnounce(.none) catch {};
+        }
+
+        // DHT: retry more aggressively when we have zero peers
+        if (self.peers.items.len == 0 and now - self.last_announce_time > 30) {
+            self.tryDhtPeerDiscovery() catch {};
         }
     }
 

--- a/src/session.zig
+++ b/src/session.zig
@@ -79,6 +79,7 @@ pub const Session = struct {
 
     // BEP 5 DHT
     dht_instance: ?dht_mod.Dht,
+    dht_failed: bool,
 
     // Progress tracking
     start_time: i64,
@@ -169,6 +170,7 @@ pub const Session = struct {
             .metadata_download = null,
             .metadata_only = false,
             .dht_instance = null,
+            .dht_failed = false,
             .start_time = now,
             .last_progress_time = now,
             .last_progress_bytes = 0,
@@ -208,10 +210,15 @@ pub const Session = struct {
         };
         std.posix.sigaction(std.posix.SIG.INT, &act, null);
 
-        // Multi-tracker announce (BEP 12)
-        stderr.print("announcing to tracker...\n", .{}) catch {};
+        // Multi-tracker announce (BEP 12) / DHT peer discovery
+        const has_trackers = (self.meta.announce.len > 0) or (self.meta.announce_list != null);
+        if (has_trackers) {
+            stderr.print("announcing to tracker...\n", .{}) catch {};
+        }
         self.doMultiTrackerAnnounce(.started) catch |err| {
-            stderr.print("all trackers failed: {}\n", .{err}) catch {};
+            if (has_trackers) {
+                stderr.print("all trackers failed: {}\n", .{err}) catch {};
+            }
         };
 
         stdout.print("session started: {d} pieces, {d} bytes\n", .{ self.num_pieces, self.total_length }) catch {};
@@ -965,8 +972,10 @@ pub const Session = struct {
         // Run choking algorithm
         self.runChokingAlgorithm();
 
-        // Re-announce
-        const interval_secs = std.math.cast(i64, self.tracker_interval) orelse 1800;
+        // Re-announce / DHT retry
+        // Use a shorter interval when we have no peers (e.g. DHT-only magnet)
+        const base_interval = std.math.cast(i64, self.tracker_interval) orelse 1800;
+        const interval_secs = if (self.peers.items.len == 0) @min(base_interval, 30) else base_interval;
         if (now - self.last_announce_time > interval_secs) {
             self.doMultiTrackerAnnounce(.none) catch {};
         }
@@ -1156,11 +1165,15 @@ pub const Session = struct {
     // --- BEP 5: DHT peer discovery ---
 
     fn tryDhtPeerDiscovery(self: *Session) !void {
+        // Don't retry if DHT previously failed to start (e.g. port busy)
+        if (self.dht_failed) return;
+
         // Initialize DHT on first use
         if (self.dht_instance == null) {
             var d = dht_mod.Dht.init(self.allocator, self.listen_port + 1);
             d.start() catch {
                 log.warn("DHT failed to start", .{});
+                self.dht_failed = true;
                 return;
             };
             self.dht_instance = d;


### PR DESCRIPTION
## Summary
- **CLI**: Reassemble magnet URIs that the shell splits on `&` when unquoted (e.g. `carl download magnet:?xt=...&dn=...`)
- **Session**: Suppress "announcing to tracker..." / "all trackers failed" noise for trackerless torrents; retry DHT every 30s when no peers are connected; track DHT init failure to avoid spamming warnings
- **DHT**: Implement iterative lookup in `getPeers` per BEP 5 — after draining responses, query newly-discovered closer nodes (up to 3 iterations) to converge on the target info_hash

## Test plan
- [ ] `carl download magnet:?xt=urn:btih:...&dn=...` (unquoted) no longer errors from shell splitting
- [ ] Trackerless torrents (e.g. Arch Linux ISO) no longer print "all trackers failed"
- [ ] DHT failure warning appears at most once per session
- [ ] `zig build test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)