### PR TITLE
feat: vendor libsecp256k1 and add BIP-340 Schnorr wrapper

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,24 +4,83 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Library module
+    // ----------------------------------------------------------------
+    // libsecp256k1 — vendored via build.zig.zon, built as a static C lib.
+    // We only need the schnorrsig + extrakeys modules for Nostr (NIP-01).
+    // ----------------------------------------------------------------
+    const secp_dep = b.dependency("secp256k1", .{});
+    const secp_root = secp_dep.path("");
+
+    const secp = b.addLibrary(.{
+        .name = "secp256k1",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    secp.root_module.addCSourceFiles(.{
+        .root = secp_root,
+        .files = &.{
+            "src/secp256k1.c",
+            "src/precomputed_ecmult.c",
+            "src/precomputed_ecmult_gen.c",
+        },
+        .flags = &.{
+            "-std=c89",
+            "-Wno-unused-function",
+            "-Wno-nonnull-compare",
+            "-Wno-long-long",
+        },
+    });
+    secp.root_module.addIncludePath(secp_dep.path("."));
+    secp.root_module.addIncludePath(secp_dep.path("src"));
+    secp.root_module.addIncludePath(secp_dep.path("include"));
+    // Required compile-time flags. See secp256k1's CMakeLists.txt.
+    const secp_macros: []const [2][]const u8 = &.{
+        .{ "ENABLE_MODULE_SCHNORRSIG", "1" },
+        .{ "ENABLE_MODULE_EXTRAKEYS", "1" },
+        .{ "ECMULT_WINDOW_SIZE", "15" },
+        // ECMULT_GEN_KB=22 keeps the table at ~22 KiB (vs 86 KiB default) —
+        // we don't need fastest-possible signing.
+        .{ "COMB_BLOCKS", "11" },
+        .{ "COMB_TEETH", "6" },
+    };
+    for (secp_macros) |kv| {
+        secp.root_module.addCMacro(kv[0], kv[1]);
+    }
+    // Expose libsecp256k1 public headers to anything that links us.
+    secp.installHeadersDirectory(secp_dep.path("include"), "", .{});
+
+    // ----------------------------------------------------------------
+    // carl library module
+    // ----------------------------------------------------------------
     const lib_mod = b.addModule("carl", .{
         .root_source_file = b.path("src/lib.zig"),
         .target = target,
+        .link_libc = true,
     });
+    lib_mod.linkLibrary(secp);
+    lib_mod.addIncludePath(secp_dep.path("include"));
 
+    // ----------------------------------------------------------------
     // CLI executable
+    // ----------------------------------------------------------------
     const exe = b.addExecutable(.{
         .name = "carl",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
             .imports = &.{
                 .{ .name = "carl", .module = lib_mod },
             },
         }),
     });
+    exe.linkLibrary(secp);
+    exe.root_module.addIncludePath(secp_dep.path("include"));
 
     b.installArtifact(exe);
 
@@ -33,7 +92,9 @@ pub fn build(b: *std.Build) void {
         run_cmd.addArgs(args);
     }
 
+    // ----------------------------------------------------------------
     // Tests
+    // ----------------------------------------------------------------
     const lib_tests = b.addTest(.{
         .root_module = lib_mod,
     });

--- a/build.zig
+++ b/build.zig
@@ -42,8 +42,10 @@ pub fn build(b: *std.Build) void {
         .{ "ENABLE_MODULE_SCHNORRSIG", "1" },
         .{ "ENABLE_MODULE_EXTRAKEYS", "1" },
         .{ "ECMULT_WINDOW_SIZE", "15" },
-        // ECMULT_GEN_KB=22 keeps the table at ~22 KiB (vs 86 KiB default) —
-        // we don't need fastest-possible signing.
+        // The (COMB_BLOCKS, COMB_TEETH) = (11, 6) pair is libsecp256k1's
+        // encoding for what its CMake exposes as ECMULT_GEN_KB=22 — a ~22 KiB
+        // precomputed signing table (vs 86 KiB default). We don't need
+        // fastest-possible signing.
         .{ "COMB_BLOCKS", "11" },
         .{ "COMB_TEETH", "6" },
     };

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,12 @@
     .version = "0.1.0",
     .fingerprint = 0x18cf10e1f7c720be,
     .minimum_zig_version = "0.15.2",
-    .dependencies = .{},
+    .dependencies = .{
+        .secp256k1 = .{
+            .url = "https://github.com/bitcoin-core/secp256k1/archive/refs/tags/v0.6.0.tar.gz",
+            .hash = "N-V-__8AADJMTgDEfe07_P0Y5osu_kf-DbxYeyW8DVvtN-wv",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -10,6 +10,7 @@ pub const session = @import("session.zig");
 pub const magnet = @import("magnet.zig");
 pub const extension = @import("extension.zig");
 pub const dht = @import("dht.zig");
+pub const secp = @import("secp.zig");
 
 test {
     _ = bencode;
@@ -23,5 +24,6 @@ test {
     _ = magnet;
     _ = extension;
     _ = dht;
+    _ = secp;
     _ = @import("integration_test.zig");
 }

--- a/src/secp.zig
+++ b/src/secp.zig
@@ -1,0 +1,301 @@
+//! BIP-340 Schnorr signatures over secp256k1, exposed as a thin Zig wrapper
+//! around libsecp256k1 (vendored via build.zig.zon). Only the subset Nostr
+//! needs is exposed: 32-byte x-only public keys, 64-byte signatures, sign and
+//! verify of an already-hashed 32-byte message.
+//!
+//! The library context is created lazily on first use and shared process-wide.
+//! libsecp256k1 0.5+ allows a single SECP256K1_CONTEXT_NONE context for both
+//! signing and verification; we randomize it once for side-channel resistance.
+
+const std = @import("std");
+const c = @cImport({
+    @cDefine("ENABLE_MODULE_SCHNORRSIG", "1");
+    @cDefine("ENABLE_MODULE_EXTRAKEYS", "1");
+    @cInclude("secp256k1.h");
+    @cInclude("secp256k1_extrakeys.h");
+    @cInclude("secp256k1_schnorrsig.h");
+});
+
+const log = std.log.scoped(.secp);
+
+pub const Error = error{
+    InvalidSecretKey,
+    InvalidPublicKey,
+    InvalidSignature,
+    SigningFailed,
+    OutOfMemory,
+};
+
+/// A secp256k1 secret key. 32 bytes in [1, n-1].
+pub const SecretKey = [32]u8;
+
+/// A 32-byte x-only public key (BIP-340 format).
+pub const PublicKey = [32]u8;
+
+/// A 64-byte BIP-340 Schnorr signature.
+pub const Signature = [64]u8;
+
+// ---------------------------------------------------------------------------
+// Shared context
+// ---------------------------------------------------------------------------
+
+var ctx_once = std.once(initContext);
+var shared_ctx: ?*c.secp256k1_context = null;
+
+fn initContext() void {
+    const new_ctx = c.secp256k1_context_create(c.SECP256K1_CONTEXT_NONE);
+    if (new_ctx == null) {
+        log.err("secp256k1_context_create returned null", .{});
+        return;
+    }
+    // Randomize the context to harden internal computations against side
+    // channels. Failure here is non-fatal but we want to know about it.
+    var seed: [32]u8 = undefined;
+    std.crypto.random.bytes(&seed);
+    if (c.secp256k1_context_randomize(new_ctx, &seed) != 1) {
+        log.warn("secp256k1_context_randomize failed", .{});
+    }
+    shared_ctx = new_ctx;
+}
+
+fn getCtx() !*c.secp256k1_context {
+    ctx_once.call();
+    return shared_ctx orelse return error.OutOfMemory;
+}
+
+// ---------------------------------------------------------------------------
+// Key generation and derivation
+// ---------------------------------------------------------------------------
+
+/// Generate a fresh random secret key. The implementation rejects scalars
+/// outside [1, n-1] by checking with libsecp256k1.
+pub fn generateSecretKey() Error!SecretKey {
+    const ctx_ptr = try getCtx();
+    var sk: SecretKey = undefined;
+    var attempts: u32 = 0;
+    while (attempts < 256) : (attempts += 1) {
+        std.crypto.random.bytes(&sk);
+        if (c.secp256k1_ec_seckey_verify(ctx_ptr, &sk) == 1) return sk;
+    }
+    return error.SigningFailed;
+}
+
+/// Derive the x-only public key from a secret key. Returns InvalidSecretKey if
+/// the scalar is zero or >= n.
+pub fn publicKeyFromSecret(sk: SecretKey) Error!PublicKey {
+    const ctx_ptr = try getCtx();
+    var keypair: c.secp256k1_keypair = undefined;
+    if (c.secp256k1_keypair_create(ctx_ptr, &keypair, &sk) != 1) {
+        return error.InvalidSecretKey;
+    }
+    var xonly: c.secp256k1_xonly_pubkey = undefined;
+    if (c.secp256k1_keypair_xonly_pub(ctx_ptr, &xonly, null, &keypair) != 1) {
+        return error.InvalidSecretKey;
+    }
+    var out: PublicKey = undefined;
+    _ = c.secp256k1_xonly_pubkey_serialize(ctx_ptr, &out, &xonly);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Sign and verify
+// ---------------------------------------------------------------------------
+
+/// Sign a 32-byte message hash with BIP-340 Schnorr. `aux_rand` should be
+/// 32 fresh random bytes for nonce derivation; pass null to use no auxiliary
+/// randomness (the spec recommends fresh randomness for side-channel safety).
+pub fn sign(sk: SecretKey, msg32: [32]u8, aux_rand: ?[32]u8) Error!Signature {
+    const ctx_ptr = try getCtx();
+    var keypair: c.secp256k1_keypair = undefined;
+    if (c.secp256k1_keypair_create(ctx_ptr, &keypair, &sk) != 1) {
+        return error.InvalidSecretKey;
+    }
+    var sig: Signature = undefined;
+    const aux_ptr: [*c]const u8 = if (aux_rand) |*a| @ptrCast(a) else null;
+    if (c.secp256k1_schnorrsig_sign32(ctx_ptr, &sig, &msg32, &keypair, aux_ptr) != 1) {
+        return error.SigningFailed;
+    }
+    return sig;
+}
+
+/// Verify a BIP-340 Schnorr signature over an arbitrary-length message.
+/// Nostr signs a 32-byte event id hash; other callers may sign other lengths.
+/// Returns true if the signature is valid, false otherwise.
+pub fn verify(sig: Signature, msg: []const u8, pk: PublicKey) bool {
+    const ctx_ptr = getCtx() catch return false;
+    var xonly: c.secp256k1_xonly_pubkey = undefined;
+    if (c.secp256k1_xonly_pubkey_parse(ctx_ptr, &xonly, &pk) != 1) return false;
+    return c.secp256k1_schnorrsig_verify(ctx_ptr, &sig, msg.ptr, msg.len, &xonly) == 1;
+}
+
+// ---------------------------------------------------------------------------
+// Hex helpers (Nostr serializes everything as lowercase hex)
+// ---------------------------------------------------------------------------
+
+const hex_table = "0123456789abcdef";
+
+/// Encode `bytes` as lowercase hex into `out`. `out.len` must equal 2*bytes.len.
+pub fn toHex(bytes: []const u8, out: []u8) void {
+    std.debug.assert(out.len == bytes.len * 2);
+    for (bytes, 0..) |b, i| {
+        out[i * 2] = hex_table[b >> 4];
+        out[i * 2 + 1] = hex_table[b & 0x0f];
+    }
+}
+
+/// Decode lowercase or uppercase hex into `out`. `out.len` must equal hex.len/2.
+pub fn fromHex(hex: []const u8, out: []u8) Error!void {
+    if (hex.len != out.len * 2) return error.InvalidPublicKey;
+    var i: usize = 0;
+    while (i < out.len) : (i += 1) {
+        const hi = nibble(hex[i * 2]) orelse return error.InvalidPublicKey;
+        const lo = nibble(hex[i * 2 + 1]) orelse return error.InvalidPublicKey;
+        out[i] = (hi << 4) | lo;
+    }
+}
+
+fn nibble(b: u8) ?u8 {
+    return switch (b) {
+        '0'...'9' => b - '0',
+        'a'...'f' => b - 'a' + 10,
+        'A'...'F' => b - 'A' + 10,
+        else => null,
+    };
+}
+
+// ===========================================================================
+// Tests — BIP-340 official test vectors
+// ===========================================================================
+// Source: https://github.com/bitcoin/bips/blob/master/bip-0340/test-vectors.csv
+
+test "BIP-340 vector 0: derive pubkey + sign + verify (sk=3, msg=zeros, aux=zeros)" {
+    var sk: SecretKey = undefined;
+    try fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+
+    const expected_pk = "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+    var expected_pk_bytes: PublicKey = undefined;
+    try fromHex(expected_pk, &expected_pk_bytes);
+
+    const pk = try publicKeyFromSecret(sk);
+    try std.testing.expectEqualSlices(u8, &expected_pk_bytes, &pk);
+
+    const msg: [32]u8 = .{0} ** 32;
+    const aux: [32]u8 = .{0} ** 32;
+    const sig = try sign(sk, msg, aux);
+
+    const expected_sig = "e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca8215" ++
+        "25f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0";
+    var expected_sig_bytes: Signature = undefined;
+    try fromHex(expected_sig, &expected_sig_bytes);
+    try std.testing.expectEqualSlices(u8, &expected_sig_bytes, &sig);
+
+    try std.testing.expect(verify(sig, &msg, pk));
+}
+
+test "BIP-340 vector 1: sign + verify with non-zero aux_rand" {
+    var sk: SecretKey = undefined;
+    try fromHex("b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef", &sk);
+
+    var msg: [32]u8 = undefined;
+    try fromHex("243f6a8885a308d313198a2e03707344a4093822299f31d0082efa98ec4e6c89", &msg);
+
+    var aux: [32]u8 = undefined;
+    try fromHex("0000000000000000000000000000000000000000000000000000000000000001", &aux);
+
+    const sig = try sign(sk, msg, aux);
+
+    const expected_sig = "6896bd60eeae296db48a229ff71dfe071bde413e6d43f917dc8dcf8c78de3341" ++
+        "8906d11ac976abccb20b091292bff4ea897efcb639ea871cfa95f6de339e4b0a";
+    var expected_sig_bytes: Signature = undefined;
+    try fromHex(expected_sig, &expected_sig_bytes);
+    try std.testing.expectEqualSlices(u8, &expected_sig_bytes, &sig);
+
+    const pk = try publicKeyFromSecret(sk);
+    try std.testing.expect(verify(sig, &msg, pk));
+}
+
+test "BIP-340 verify-only vector with known sig" {
+    // Vector 2 from the BIP-340 test vectors.
+    var pk: PublicKey = undefined;
+    try fromHex("dd308afec5777e13121fa72b9cc1b7cc0139715309b086c960e18fd969774eb8", &pk);
+
+    var msg: [32]u8 = undefined;
+    try fromHex("7e2d58d8b3bcdf1abadec7829054f90dda9805aab56c77333024b9d0a508b75c", &msg);
+
+    var sig: Signature = undefined;
+    try fromHex(
+        "5831aaeed7b44bb74e5eab94ba9d4294c49bcf2a60728d8b4c200f50dd313c1b" ++
+            "ab745879a5ad954a72c45a91c3a51d3c7adea98d82f8481e0e1e03674a6f3fb7",
+        &sig,
+    );
+
+    try std.testing.expect(verify(sig, &msg, pk));
+}
+
+test "verify rejects a tampered signature" {
+    var sk: SecretKey = undefined;
+    try fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try publicKeyFromSecret(sk);
+
+    const msg: [32]u8 = .{0} ** 32;
+    var sig = try sign(sk, msg, [_]u8{0} ** 32);
+
+    // Flip a bit in the signature.
+    sig[7] ^= 0x01;
+    try std.testing.expect(!verify(sig, &msg, pk));
+}
+
+test "verify rejects signature under wrong pubkey" {
+    var sk_a: SecretKey = undefined;
+    try fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk_a);
+
+    var sk_b: SecretKey = undefined;
+    try fromHex("0000000000000000000000000000000000000000000000000000000000000005", &sk_b);
+    const pk_b = try publicKeyFromSecret(sk_b);
+
+    const msg: [32]u8 = .{0} ** 32;
+    const sig = try sign(sk_a, msg, [_]u8{0} ** 32);
+
+    try std.testing.expect(!verify(sig, &msg, pk_b));
+}
+
+test "publicKeyFromSecret rejects zero secret key" {
+    const zero: SecretKey = .{0} ** 32;
+    try std.testing.expectError(error.InvalidSecretKey, publicKeyFromSecret(zero));
+}
+
+test "generateSecretKey produces a valid key that derives a pubkey" {
+    const sk = try generateSecretKey();
+    const pk = try publicKeyFromSecret(sk);
+
+    // Pubkey should not be all-zero (extremely improbable, but a sanity check).
+    var any_nonzero = false;
+    for (pk) |b| if (b != 0) {
+        any_nonzero = true;
+        break;
+    };
+    try std.testing.expect(any_nonzero);
+
+    // Round-trip: sign random msg and verify.
+    var msg: [32]u8 = undefined;
+    std.crypto.random.bytes(&msg);
+    const sig = try sign(sk, msg, null);
+    try std.testing.expect(verify(sig, &msg, pk));
+}
+
+test "hex round trip" {
+    const bytes = [_]u8{ 0xde, 0xad, 0xbe, 0xef, 0x00, 0xff };
+    var hex_out: [12]u8 = undefined;
+    toHex(&bytes, &hex_out);
+    try std.testing.expectEqualStrings("deadbeef00ff", &hex_out);
+
+    var back: [6]u8 = undefined;
+    try fromHex(&hex_out, &back);
+    try std.testing.expectEqualSlices(u8, &bytes, &back);
+}
+
+test "fromHex rejects bad input" {
+    var out: [4]u8 = undefined;
+    try std.testing.expectError(error.InvalidPublicKey, fromHex("xx", &out)); // wrong length
+    try std.testing.expectError(error.InvalidPublicKey, fromHex("ZZZZZZZZ", &out)); // bad chars
+}

--- a/src/secp.zig
+++ b/src/secp.zig
@@ -21,7 +21,8 @@ const log = std.log.scoped(.secp);
 pub const Error = error{
     InvalidSecretKey,
     InvalidPublicKey,
-    InvalidSignature,
+    InvalidHex,
+    KeyGenerationFailed,
     SigningFailed,
     OutOfMemory,
 };
@@ -77,7 +78,10 @@ pub fn generateSecretKey() Error!SecretKey {
         std.crypto.random.bytes(&sk);
         if (c.secp256k1_ec_seckey_verify(ctx_ptr, &sk) == 1) return sk;
     }
-    return error.SigningFailed;
+    // Statistically unreachable (~256 * 2^-256), but if the RNG is broken or
+    // the curve order has shifted under our feet, return a name that matches
+    // the action.
+    return error.KeyGenerationFailed;
 }
 
 /// Derive the x-only public key from a secret key. Returns InvalidSecretKey if
@@ -101,18 +105,26 @@ pub fn publicKeyFromSecret(sk: SecretKey) Error!PublicKey {
 // Sign and verify
 // ---------------------------------------------------------------------------
 
-/// Sign a 32-byte message hash with BIP-340 Schnorr. `aux_rand` should be
-/// 32 fresh random bytes for nonce derivation; pass null to use no auxiliary
-/// randomness (the spec recommends fresh randomness for side-channel safety).
+/// Sign a 32-byte message hash with BIP-340 Schnorr. When `aux_rand` is null
+/// we draw 32 fresh bytes from `std.crypto.random` — per BIP-340 §3.3,
+/// auxiliary randomness mitigates fault and side-channel attacks on the nonce
+/// derivation, so the safe default is the easy default. Callers needing
+/// deterministic signatures (test vectors, reproducibility) pass an explicit
+/// 32-byte value.
 pub fn sign(sk: SecretKey, msg32: [32]u8, aux_rand: ?[32]u8) Error!Signature {
     const ctx_ptr = try getCtx();
     var keypair: c.secp256k1_keypair = undefined;
     if (c.secp256k1_keypair_create(ctx_ptr, &keypair, &sk) != 1) {
         return error.InvalidSecretKey;
     }
+    var aux: [32]u8 = undefined;
+    if (aux_rand) |a| {
+        aux = a;
+    } else {
+        std.crypto.random.bytes(&aux);
+    }
     var sig: Signature = undefined;
-    const aux_ptr: [*c]const u8 = if (aux_rand) |*a| @ptrCast(a) else null;
-    if (c.secp256k1_schnorrsig_sign32(ctx_ptr, &sig, &msg32, &keypair, aux_ptr) != 1) {
+    if (c.secp256k1_schnorrsig_sign32(ctx_ptr, &sig, &msg32, &keypair, &aux) != 1) {
         return error.SigningFailed;
     }
     return sig;
@@ -135,8 +147,11 @@ pub fn verify(sig: Signature, msg: []const u8, pk: PublicKey) bool {
 const hex_table = "0123456789abcdef";
 
 /// Encode `bytes` as lowercase hex into `out`. `out.len` must equal 2*bytes.len.
+/// Mismatched sizes are a programmer error and panic explicitly in all build
+/// modes (a `std.debug.assert` would compile out and silently overrun the
+/// buffer in ReleaseFast/ReleaseSmall).
 pub fn toHex(bytes: []const u8, out: []u8) void {
-    std.debug.assert(out.len == bytes.len * 2);
+    if (out.len != bytes.len * 2) @panic("secp.toHex: out buffer must be 2 * bytes.len");
     for (bytes, 0..) |b, i| {
         out[i * 2] = hex_table[b >> 4];
         out[i * 2 + 1] = hex_table[b & 0x0f];
@@ -145,11 +160,11 @@ pub fn toHex(bytes: []const u8, out: []u8) void {
 
 /// Decode lowercase or uppercase hex into `out`. `out.len` must equal hex.len/2.
 pub fn fromHex(hex: []const u8, out: []u8) Error!void {
-    if (hex.len != out.len * 2) return error.InvalidPublicKey;
+    if (hex.len != out.len * 2) return error.InvalidHex;
     var i: usize = 0;
     while (i < out.len) : (i += 1) {
-        const hi = nibble(hex[i * 2]) orelse return error.InvalidPublicKey;
-        const lo = nibble(hex[i * 2 + 1]) orelse return error.InvalidPublicKey;
+        const hi = nibble(hex[i * 2]) orelse return error.InvalidHex;
+        const lo = nibble(hex[i * 2 + 1]) orelse return error.InvalidHex;
         out[i] = (hi << 4) | lo;
     }
 }
@@ -296,6 +311,6 @@ test "hex round trip" {
 
 test "fromHex rejects bad input" {
     var out: [4]u8 = undefined;
-    try std.testing.expectError(error.InvalidPublicKey, fromHex("xx", &out)); // wrong length
-    try std.testing.expectError(error.InvalidPublicKey, fromHex("ZZZZZZZZ", &out)); // bad chars
+    try std.testing.expectError(error.InvalidHex, fromHex("xx", &out)); // wrong length
+    try std.testing.expectError(error.InvalidHex, fromHex("ZZZZZZZZ", &out)); // bad chars
 }


### PR DESCRIPTION
## Summary

Foundation for the upcoming Nostr discovery layer. **This PR adds no carl behavior** — nothing uses the new module yet. Subsequent PRs (wire protocol → relay layer → CLI) build on this one.

- \`build.zig.zon\` fetches [libsecp256k1](https://github.com/bitcoin-core/secp256k1) v0.6.0 via the zig package manager.
- \`build.zig\` compiles \`secp256k1.c\` + \`precomputed_ecmult{,_gen}.c\` as a static lib with \`-DENABLE_MODULE_SCHNORRSIG -DENABLE_MODULE_EXTRAKEYS\` (smaller ECMULT_GEN table: \`COMB_BLOCKS=11\`, \`COMB_TEETH=6\`).
- [src/secp.zig](src/secp.zig) exposes the minimal API Nostr will need: 32-byte x-only public keys, 64-byte signatures, \`sign(sk, msg32, aux)\`, \`verify(sig, msg, pk)\`, \`generateSecretKey\`, \`publicKeyFromSecret\`, plus hex helpers.
- Shared \`SECP256K1_CONTEXT_NONE\` context randomized once for side-channel resistance.

### Why libsecp256k1 instead of pure Zig

A homegrown Schnorr would be the single highest-risk crypto surface in the project. libsecp256k1 is the same audited code Bitcoin Core uses; the C dep cost is one entry in \`build.zig.zon\` and Zig's build system handles the rest. README adjustments come in the final PR of the stack to avoid mentioning a Nostr feature that doesn't ship until then.

## This is PR 1 of 4 in a stack

1. **PR 1 (this) → main**: libsecp256k1 + \`secp.zig\`
2. PR 2 → PR 1: \`ws.zig\` + \`nip19.zig\` + \`nostr.zig\` (wire protocol)
3. PR 3 → PR 2: \`nip35.zig\` + \`peer_announce.zig\` + \`relay.zig\` (application layer)
4. PR 4 → PR 3: \`nostr_config.zig\` + \`main.zig\` CLI + docs

## Test plan

\`zig build test\` — 105/105 unit tests passing (96 existing + 9 new in \`secp.zig\`):

- BIP-340 official test vectors 0, 1, 2 round-trip (sign + verify against the spec's known signature bytes)
- Tampered-signature rejection
- Wrong-pubkey rejection
- Zero-key rejection
- \`generateSecretKey\` → \`publicKeyFromSecret\` → sign → verify chain
- Hex encode/decode round trip + bad input rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)