### PR TITLE
feat(mse): MSE/PE crypto and handshake module (PR 1/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,29 @@ carl seed file.torrent /path/to/data --nostr --external-ip 203.0.113.7 \
     --description "My release notes"
 ```
 
+### Seed behind Tor (hidden service)
+
+Requires a running `tor` with ControlPort and cookie auth (default
+`127.0.0.1:9051`, cookie at `~/.tor/control_auth_cookie`):
+
+```sh
+carl seed file.torrent /path/to/data --tor-seed --nostr \
+    --description "Seeded over Tor"
+
+# Leechers must use Tor SOCKS (remote DNS)
+carl download file.torrent --nostr --proxy socks5h://127.0.0.1:9050
+```
+
+Carl creates an ephemeral v3 onion, listens on `127.0.0.1`, publishes the
+`.onion` endpoint in kind 30078 (no public IPv4), and routes Nostr `wss`
+through `--tor-socks` (default `socks5h://127.0.0.1:9050`). Tracker/DHT
+announces are disabled in this mode so your real IP is not leaked to trackers.
+
 ### Download using Nostr peer-discovery
 
 ```sh
-# Subscribes to kind 30078 events filtered by infohash and feeds the IPs
-# back into the session alongside tracker/DHT peers. Routable IPs only —
-# private/loopback/multicast addresses from relays are rejected.
+# Subscribes to kind 30078 events filtered by infohash and dials IPv4 or
+# `.onion` peers (onion requires --proxy socks5h://…). Routable IPv4 only.
 carl download file.torrent --nostr
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,11 @@ carl download file.torrent --nostr --proxy socks5h://127.0.0.1:9050
 
 Carl creates an ephemeral v3 onion, listens on `127.0.0.1`, and publishes the
 `.onion` endpoint in kind 30078 (no public IPv4). Leechers dial the onion via
-`--proxy socks5h://127.0.0.1:9050`. Nostr relay `wss` uses clearnet today
-(proxied `wss` is not implemented); tracker/DHT announces are disabled in
-tor-seed mode so your real IP is not leaked to trackers.
+`--proxy socks5h://127.0.0.1:9050`. Tracker/DHT announces are disabled so your
+real IP is not leaked to trackers.
+
+Full details (proxy split, security, E2E test, troubleshooting):
+[docs/tor-hidden-service.md](docs/tor-hidden-service.md).
 
 ### Download using Nostr peer-discovery
 
@@ -209,6 +211,7 @@ src/
   nip19.zig        Bech32 codec for npub/nsec/note + TLV decoder
   nip35.zig        Kind 2003 torrent index event builder/parser
   peer_announce.zig  Kind 30078 peer-announce builder/parser + IP safety filter
+  tor_control.zig  Tor ControlPort ADD_ONION / DEL_ONION for v3 hidden services
   relay.zig        Connect to a relay, subscribe-collect-until-EOSE, publish-and-wait
   nostr_config.zig  ~/.config/carl/{nsec,relays} read/write
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A BitTorrent client written in pure Zig. The BitTorrent core has zero Zig packag
 - **Multi-file torrents** -- single and multi-file torrent support with proper file mapping
 - **Seeding** -- upload mode with incoming connection support
 - **Proxy / anonymous mode** -- route peers and trackers through a SOCKS5/SOCKS5h or HTTP proxy, hiding your real IP from the swarm ([docs](docs/proxy.md))
+- **MSE/PE (in progress)** -- Vuze message-stream encryption module landed in [#27](https://github.com/vincenzopalazzo/carl/pull/27); not wired to the CLI yet ([docs](docs/mse-pe.md), issue [#12](https://github.com/vincenzopalazzo/carl/issues/12))
 - **Nostr discovery** -- publish torrents you seed as NIP-35 events and find others' torrents via `carl search`; per-seeder peer-announces over a custom kind 30078 feed peers into download sessions
 
 ## Protocol Support
@@ -203,6 +204,7 @@ src/
   dht.zig          Kademlia DHT (BEP 5)
   extension.zig    Extension protocol / metadata exchange (BEP 9/10)
   proxy.zig        SOCKS5/SOCKS5h + HTTP CONNECT proxy tunneling
+  mse.zig          Vuze MSE/PE handshake + RC4 stream (library only until peer wiring)
 
   # Nostr (optional discovery layer)
   secp.zig         BIP-340 Schnorr wrapper over vendored libsecp256k1

--- a/README.md
+++ b/README.md
@@ -161,10 +161,11 @@ carl seed file.torrent /path/to/data --tor-seed --nostr \
 carl download file.torrent --nostr --proxy socks5h://127.0.0.1:9050
 ```
 
-Carl creates an ephemeral v3 onion, listens on `127.0.0.1`, publishes the
-`.onion` endpoint in kind 30078 (no public IPv4), and routes Nostr `wss`
-through `--tor-socks` (default `socks5h://127.0.0.1:9050`). Tracker/DHT
-announces are disabled in this mode so your real IP is not leaked to trackers.
+Carl creates an ephemeral v3 onion, listens on `127.0.0.1`, and publishes the
+`.onion` endpoint in kind 30078 (no public IPv4). Leechers dial the onion via
+`--proxy socks5h://127.0.0.1:9050`. Nostr relay `wss` uses clearnet today
+(proxied `wss` is not implemented); tracker/DHT announces are disabled in
+tor-seed mode so your real IP is not leaked to trackers.
 
 ### Download using Nostr peer-discovery
 

--- a/docs/brainstorms/2026-06-03-tor-hidden-service-peer-announce.md
+++ b/docs/brainstorms/2026-06-03-tor-hidden-service-peer-announce.md
@@ -1,0 +1,211 @@
+# Tor hidden-service seeding + onion peer announce
+
+Brainstorm for Carl: seed behind a Tor v3 hidden service, publish the endpoint on Nostr (kind 30078), and let remote leechers discover and connect only via Tor.
+
+**Context:** Today `carl seed --nostr` requires `--external-ip` (IPv4). Kind 30078 uses `ip` + `port` tags. With `--proxy`, the inbound listener is disabled (fail-closed anonymity), so classic seeding over Tor outbound-only does not work. Remote confirmation (Hetzner `65.108.246.14`) showed Nostr discovery works but `45.80.136.155:6881` is unreachable from the internet (firewall/NAT).
+
+**Relevant code today:**
+
+- `src/peer_announce.zig` — kind 30078, IPv4-only schema
+- `src/main.zig` — `publishNostr`, `collectNostrPeers` (dials `initIp4` only)
+- `src/session.zig` — listener on `0.0.0.0` when not proxied; no listener when `--proxy`
+- `src/proxy.zig` — `connectThroughProxyHost` (socks5h domain connect; suitable for `.onion`)
+- `src/ws.zig` — direct `wss` to relays (no proxy)
+- `docs/proxy.md` — Tor as SOCKS5 for download; notes exit nodes often block BT
+
+---
+
+## Decisions (from brainstorm Q&A)
+
+| Topic | Choice |
+|-------|--------|
+| Tor setup | Carl talks to **Tor ControlPort** (`ADD_ONION` / read v3 address) |
+| Kind 30078 schema | **Onion-only** in tor mode: `["host", "<v3.onion>"]` + `["port", "<n>"]` — no `ip` tag |
+| CLI model | Single **`--tor-seed`** flag: loopback listener + HS + publish; leechers need **`--proxy`** |
+| Listen bind | **`127.0.0.1`** only in hidden-service mode |
+| Nostr path | **`wss` tunnels through SOCKS5** when tor-seed / proxy workflow is active |
+
+---
+
+## Clarified Problem Statement
+
+**Goal:** Let Carl seed behind a Tor v3 hidden service, publish that endpoint on Nostr (kind 30078), and let remote leechers discover and connect only via Tor (`--proxy socks5h`), without exposing a public IPv4 listener or `--external-ip`.
+
+**Constraints:**
+
+- Must not break existing IPv4 peer announces (`ip` + `port`) for `carl seed --nostr --external-ip`.
+- Fail-closed anonymity preserved: no `0.0.0.0` listener in `--tor-seed` mode; generic `--proxy` seed still has no inbound listener.
+- Reuse `proxy.connectThroughProxyHost` for `.onion` dials over `socks5h`.
+- Zig 0.15; no heavy new deps (Tor control = line protocol over TCP or unix socket).
+
+**Non-goals (v1):**
+
+- I2P, IPv6, or dual `ip` + `host` in one event
+- UDP trackers / DHT / web seeds over Tor
+- Embedding the `tor` binary (optional follow-up)
+- Formal NIP beyond Carl’s existing kind 30078 convention
+
+**Success criteria:**
+
+1. `carl seed <torrent> <data> --tor-seed --nostr` → ControlPort returns v3 hostname; publishes kind 30078 with `host`/`port`; listens on `127.0.0.1:<port>`.
+2. Remote host: `carl download <magnet> --nostr --proxy socks5h://127.0.0.1:9050` → finds announce, connects through Tor, completes a small torrent.
+3. Inbound probe to the machine’s public IP on the BT port fails while `--tor-seed` is active.
+4. Nostr publish/search in tor-seed workflow uses Tor (no direct `wss` leak).
+5. Unit tests: onion announce build/parse, malformed host rejected; IPv4 path unchanged.
+
+---
+
+## Approaches Considered
+
+### Approach A: Attach to existing Tor (ControlPort client)
+
+**Sketch:** New `src/tor_control.zig` connects to `127.0.0.1:9051` (or `--tor-control`). `ADD_ONION PORT=…,127.0.0.1:…` → parse `ServiceID`. On exit, `DEL_ONION`. `--tor-seed` binds loopback, `peer_announce.buildOnion`, publishes over proxied `wss`. Downloaders: `collectNostrPeers` → `connectThroughProxyHost` when `--proxy` is set.
+
+**Affected files:** `tor_control.zig` (new), `peer_announce.zig`, `main.zig`, `session.zig`, `ws.zig`, `relay.zig`, `proxy.zig`, `docs/proxy.md`, README.
+
+**Tradeoffs:**
+
+- Gains: matches `apt install tor`; small surface; ops-familiar.
+- Costs: user must run `tor` with ControlPort + cookie auth; clear errors if tor is down.
+- Does not solve: zero-config on hosts without tor installed.
+
+**Effort:** M
+
+---
+
+### Approach B: Carl spawns Tor subprocess
+
+**Sketch:** `--tor-seed` writes a temp torrc (`DataDirectory`, `ControlPort`, `CookieAuthFile`), execs `tor -f …`, waits for bootstrap, then same ControlPort flow as A. `deinit` kills tor and `DEL_ONION`.
+
+**Affected files:** Approach A plus spawn/lifecycle in `tor_control.zig` or `tor_spawn.zig`.
+
+**Tradeoffs:**
+
+- Gains: one command; good for demos.
+- Costs: process management, temp dirs, cleanup on crash; platform-specific `tor` paths; heavier CI.
+- Does not solve: environments without a `tor` binary.
+
+**Effort:** L
+
+---
+
+### Approach C: Phased delivery (schema + dial, then ControlPort)
+
+**Sketch:** PR1: `host`/`port` tags, `parseOnion`, downloader dial via `--proxy`, optional manual `--onion` for dev. PR2: ControlPort + `--tor-seed` + `wss` over SOCKS.
+
+**Affected files:** PR1: `peer_announce.zig`, `main.zig`, `session.zig`. PR2: `tor_control.zig`, `ws.zig`.
+
+**Tradeoffs:**
+
+- Gains: smaller reviews; test onion dial without tor in CI (mock host).
+- Costs: two CLI stories temporarily; delays full ControlPort UX.
+
+**Effort:** M total (S + M split)
+
+---
+
+## Recommendation
+
+**Ship Approach A for v1**, implemented in the order of Approach C internally:
+
+1. Extend `PeerAnnounce` → `enum { ipv4, onion }` in `peer_announce.zig`.
+2. `collectNostrPeers` → onion branch → `proxy.connectThroughProxyHost` (require `--proxy` or exit with a clear error).
+3. `session.zig`: `--tor-seed` → bind `127.0.0.1` only; mutually exclusive with `--proxy` on seed.
+4. `tor_control.zig`: `ADD_ONION` / `DEL_ONION` + cookie auth (`~/.tor/control_auth_cookie` or `--tor-cookie`).
+5. `ws.zig`: optional SOCKS path for `wss` (may share patterns with HTTPS-over-proxy in `proxy.zig`).
+6. Manual integration test: tor + `carl seed --tor-seed` locally; `carl download` from VPS with `--proxy`.
+
+**Defer Approach B** (spawn tor) unless attach-to-existing-tor proves too painful in practice.
+
+---
+
+## Proposed CLI (v1)
+
+```sh
+# Seeder (tor daemon running with ControlPort)
+carl seed file.torrent ./data --tor-seed --nostr \
+  [--tor-control 127.0.0.1:9051] [--port 6881]
+
+# Leecher (must use Tor SOCKS)
+carl download "magnet:?xt=urn:btih:…" --output-dir ./out \
+  --nostr --proxy socks5h://127.0.0.1:9050
+```
+
+**Incompatibilities:**
+
+- `--tor-seed` + `--proxy` on seed: error (tor-seed owns listen path; proxy remains download/outbound-only elsewhere).
+- `--tor-seed` + `--external-ip`: error (onion-only announce).
+- Onion peer without `--proxy` on download: error (not silent skip).
+
+---
+
+## Kind 30078 schema (onion mode)
+
+```json
+{
+  "kind": 30078,
+  "tags": [
+    ["d", "<infohash_hex>"],
+    ["host", "<56-char-v3-onion>.onion"],
+    ["port", "<port>"],
+    ["client", "carl/0.1"]
+  ],
+  "content": ""
+}
+```
+
+**Validation:**
+
+- `host` ends with `.onion`, v3 length (56 chars + suffix), charset check
+- `port` non-zero u16
+- No `ip` tag in events we publish in tor mode; parsers accept legacy `ip` events for backward compatibility
+
+---
+
+## Tor ControlPort sketch
+
+```
+AUTHENTICATE <cookie-hex>
+ADD_ONION NEW:ED25519-V3 Port=80,127.0.0.1:6881
+→ 250-ServiceID=…
+→ 250 PrivateKey=…
+… on shutdown …
+DEL_ONION <ServiceID>
+```
+
+Open question: virtual port on the onion (`80` → local `6881` is common) vs exposing `6881` on the onion — affects published `port` tag and `ADD_ONION` line.
+
+---
+
+## Open questions
+
+- **Onion virtual port:** HS port 80 vs 6881 mapping to local listener?
+- **Control auth:** cookie file only, or password / `HASCOOKIE` flag?
+- **Replaceable events:** after restart, new `ADD_ONION` + republish same `d=infohash` (NIP-33 replaceable).
+- **Trackers in tor-seed mode:** disable public tracker announce of real IP, or HTTP tracker only via proxy?
+- **`wss` over SOCKS:** full TLS+WS handshake through tunnel (largest implementation risk).
+
+---
+
+## Test plan (acceptance)
+
+- [ ] Unit: build/parse onion announce; reject bad host; IPv4 round-trip unchanged
+- [ ] Unit: `isRoutable` / IPv4 parse unchanged
+- [ ] Local: tor running → `carl seed --tor-seed --nostr` logs onion + publish acks
+- [ ] Remote VPS: `carl download … --nostr --proxy socks5h://127.0.0.1:9050` completes small fixture torrent
+- [ ] Negative: `nc <public-ip> <bt-port>` fails during tor-seed
+- [ ] Negative: download onion peer without `--proxy` → clear error
+
+---
+
+## Next step
+
+```
+/ship --from-brainstorm docs/brainstorms/2026-06-03-tor-hidden-service-peer-announce.md
+```
+
+or:
+
+```
+/ship --plan-only implement Tor hidden-service seeding per brainstorm doc
+```

--- a/docs/brainstorms/2026-06-03-tor-hidden-service-peer-announce.md
+++ b/docs/brainstorms/2026-06-03-tor-hidden-service-peer-announce.md
@@ -1,5 +1,9 @@
 # Tor hidden-service seeding + onion peer announce
 
+> **Canonical documentation:** [tor-hidden-service.md](../tor-hidden-service.md)
+> (setup, proxy split, security, E2E test, limitations). This file is the
+> original design brainstorm.
+
 Brainstorm for Carl: seed behind a Tor v3 hidden service, publish the endpoint on Nostr (kind 30078), and let remote leechers discover and connect only via Tor.
 
 **Context:** Today `carl seed --nostr` requires `--external-ip` (IPv4). Kind 30078 uses `ip` + `port` tags. With `--proxy`, the inbound listener is disabled (fail-closed anonymity), so classic seeding over Tor outbound-only does not work. Remote confirmation (Hetzner `65.108.246.14`) showed Nostr discovery works but `45.80.136.155:6881` is unreachable from the internet (firewall/NAT).

--- a/docs/mse-pe.md
+++ b/docs/mse-pe.md
@@ -1,0 +1,89 @@
+# Message Stream Encryption (MSE/PE)
+
+Carl support for [Vuze MSE/PE v1.0](https://web.archive.org/web/20161231215426/http://wiki.vuze.com/w/Message_Stream_Encryption) (issue [#12](https://github.com/vincenzopalazzo/carl/issues/12)). This is **protocol obfuscation** on peer TCP connections: reduce passive BitTorrent fingerprinting and ISP shaping. It is not a substitute for Tor (`--proxy`, `--tor-seed`) or TLS on trackers.
+
+**Plan and PR stack:** [plans/2026-06-03-mse-pe-protocol-encryption.md](plans/2026-06-03-mse-pe-protocol-encryption.md)  
+**Design notes:** [brainstorms/2026-06-03-mse-pe-protocol-encryption.md](brainstorms/2026-06-03-mse-pe-protocol-encryption.md)
+
+---
+
+## Impact of PR #27 (PR 1/6 — crypto module)
+
+[PR #27](https://github.com/vincenzopalazzo/carl/pull/27) adds the **foundation only**. It does **not** turn on encryption for `carl download` / `carl seed` yet.
+
+### What changes when this PR merges
+
+| Area | Impact |
+|------|--------|
+| **New code** | `src/mse.zig` (~610 lines): 768-bit DH, SHA-1 key derivation, RC4 (+ 1024-byte discard), Vuze 5-step handshake, `mse.Stream` encrypt/decrypt wrapper |
+| **Library export** | `carl.mse` from `src/lib.zig` for tests and future peer/session wiring |
+| **Tests** | Unit tests: DH vectors, RC4 discard, TCP loopback initiator↔responder handshake |
+| **Docs** | Implementation plan in `docs/plans/2026-06-03-mse-pe-protocol-encryption.md` |
+| **Binary / CLI** | **No change** — no new flags, no behavior change for end users |
+| **Peer I/O** | **No change** — `peer.zig`, `session.zig`, `wire.zig` still use cleartext `std.net.Stream` |
+| **Trackers** | **No change** — no `supportcrypto` / `crypto_flags` on announce yet |
+| **Tor / proxy** | **No change** — design is `[SOCKS/Tor tunnel] → [MSE RC4] → [BEP 3]`; wiring is PR 2–4 |
+| **Dependencies** | **None** — pure Zig (RC4 and DH in-tree; SHA-1 via `std.crypto.hash.Sha1`) |
+| **Issue #12** | **Not closed** — integration and tracker extension are follow-up PRs |
+
+### Intended stack (after full feature lands)
+
+```
+TCP (direct, or SOCKS CONNECT / .onion)
+  → MSE/PE handshake (DH + optional RC4 full stream, crypto_select 0x02)
+  → BEP 3 handshake + length-prefixed messages (unchanged wire format, encrypted bytes if RC4)
+```
+
+### Public API added (for integrators)
+
+- `mse.handshakeInitiator` / `mse.handshakeResponder` — complete negotiation on a connected `std.net.Stream`
+- `mse.Stream` — `read` / `write` / `writeAll` / `close` over RC4 or plaintext payload mode
+- `mse.Options` — `skey` (info_hash), `crypto_provide`, optional `ia` (e.g. serialized BEP 3 handshake in step 3)
+- Crypto helpers: `hashReq1`, `dhPublicKey`, `dhSharedSecret`, `initRc4FromShared`, etc.
+
+### Security and privacy posture (unchanged for users today)
+
+- **MSE is obfuscation**, not authentication. Anyone who knows the torrent **info_hash** can complete the handshake (SKEY). Effective strength is on the order of tens of bits against passive observers, not modern AEAD.
+- **Tor / proxy** still hide IP; MSE hides that the bytes look like BitTorrent once peers are connected.
+- **Do not log** shared secrets `S`, RC4 keys, or DH pads in production paths (module is written with that in mind).
+
+### Operational impact today
+
+- **CPU:** No extra cost in normal `carl` runs until peer integration enables MSE on connections.
+- **CI:** `zig build test` runs new `mse` tests; existing integration tests unchanged.
+- **Interop:** Not validated against libtorrent/qBittorrent until PR 2+ and manual/PCAP tests; PR 27 only proves Carl↔Carl loopback handshake.
+
+### Known gaps in PR 27 (before merge)
+
+Review on PR #27 flagged **RC4 resync** in step 3/4 when data arrives in multiple `read()` chunks: trial decrypt loops must not advance the live `dec` stream or mutate ciphertext in place. Fix before relying on this module with real swarms.
+
+### What comes next (user-visible impact)
+
+| PR | User-visible effect |
+|----|-------------------|
+| 2 `peer.zig` | Outbound: try MSE first, fall back to plaintext BEP 3 (Vuze mode 2) |
+| 3 `session.zig` | Inbound: accept MSE or detect plaintext handshake |
+| 4 CLI | `--mse`, `--prefer-encryption`, optional `--require-encryption` |
+| 5 `tracker.zig` | `supportcrypto=1`, peer `crypto_flags` bias |
+| 6 | This doc expanded + end-to-end integration test |
+
+Until PR 4, **`carl` behaves exactly as before** with respect to encryption.
+
+---
+
+## Protocol summary (reference)
+
+| Piece | Detail |
+|-------|--------|
+| DH | 768-bit safe prime P (fixed), G=2, 96-byte big-endian Ya/Yb |
+| SKEY | BitTorrent **info_hash** (20 bytes) |
+| Keys | `HASH('keyA'/'keyB', S, SKEY)` → RC4; discard first **1024** keystream bytes |
+| Mode | Target **0x02** RC4 full stream after handshake |
+| Handshake | 5 steps; step 3 sends `HASH('req1',S)` and SKEY hash **in plaintext**, then `ENCRYPT(VC, crypto_provide, …, IA)` |
+
+---
+
+## Related docs
+
+- [proxy.md](proxy.md) — Tor SOCKS for peer TCP; clearnet `wss` split when `--proxy` is set
+- [tor-hidden-service.md](tor-hidden-service.md) — onion seeding; MSE applies on top of the tunneled stream when enabled

--- a/docs/plans/2026-06-03-mse-pe-protocol-encryption.md
+++ b/docs/plans/2026-06-03-mse-pe-protocol-encryption.md
@@ -1,0 +1,30 @@
+# Plan: MSE/PE protocol encryption (issue #12)
+
+Source: `docs/brainstorms/2026-06-03-mse-pe-protocol-encryption.md`
+
+## Goal
+
+Vuze MSE/PE on peer TCP: DH + RC4 full stream (`0x02`), then existing BEP 3. Prefer encrypted peers; plaintext fallback (mode 2). Tracker `supportcrypto` in v1.
+
+## PR stack
+
+| PR | Branch | Scope |
+|----|--------|--------|
+| 1 | `feat/mse-crypto` | `src/mse.zig`: DH, SHA1, RC4, handshake, unit tests |
+| 2 | `feat/mse-peer-outbound` | `peer.zig`: MSE-first outbound + plaintext fallback |
+| 3 | `feat/mse-session-inbound` | `session.zig`: accept detect + responder |
+| 4 | `feat/mse-cli` | `main.zig` flags `--mse`, `--prefer-encryption` |
+| 5 | `feat/mse-tracker` | `tracker.zig`: supportcrypto / crypto_flags |
+| 6 | `feat/mse-docs` | `docs/mse-pe.md` + integration test |
+
+## PR 1 acceptance
+
+- Fixed 768-bit DH prime; modpow; Ya/Yb 96-byte BE wire form
+- RC4 with 1024-byte keystream discard
+- `HASH('req1'|'req2'|'req3'|'keyA'|'keyB', …)` per Vuze spec
+- Initiator/responder complete 5-step handshake over `std.net.Stream`
+- Unit tests: DH vectors, RC4 discard, req hashes, loopback handshake
+
+## Non-goals (v1)
+
+AES, BEP 8, UDP encryption, DHT crypto_flags.

--- a/docs/plans/2026-06-03-mse-pe-protocol-encryption.md
+++ b/docs/plans/2026-06-03-mse-pe-protocol-encryption.md
@@ -15,7 +15,7 @@ Vuze MSE/PE on peer TCP: DH + RC4 full stream (`0x02`), then existing BEP 3. Pre
 | 3 | `feat/mse-session-inbound` | `session.zig`: accept detect + responder |
 | 4 | `feat/mse-cli` | `main.zig` flags `--mse`, `--prefer-encryption` |
 | 5 | `feat/mse-tracker` | `tracker.zig`: supportcrypto / crypto_flags |
-| 6 | `feat/mse-docs` | `docs/mse-pe.md` + integration test |
+| 6 | `feat/mse-docs` | Expand `docs/mse-pe.md` + integration test (impact doc started in PR 1) |
 
 ## PR 1 acceptance
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -184,6 +184,27 @@ still works, carl *must* be tunneling; if it leaked, it would have no
 connectivity at all. This is the gold-standard fail-closed check (`ip netns` +
 a single veth route to the proxy host).
 
+## Tor hidden-service seeding (`--tor-seed`)
+
+For seeding without a public IP, Carl can create an ephemeral v3 onion via Tor
+ControlPort and publish it on Nostr (kind 30078 `host` + `port` tags, no IPv4).
+
+```sh
+# tor must be running with ControlPort (default 9051) and cookie auth
+carl seed file.torrent /data --tor-seed --nostr
+
+# Remote leecher (onion dials require Tor SOCKS)
+carl download file.torrent --nostr --proxy socks5h://127.0.0.1:9050
+```
+
+`--tor-seed` binds the BitTorrent listener to `127.0.0.1` only, disables
+tracker/DHT announces, and tunnels Nostr `wss` via `--tor-socks` (default
+`socks5h://127.0.0.1:9050`). It is mutually exclusive with `--proxy` on seed.
+
+Optional flags: `--tor-control host:port`, `--tor-cookie path`,
+`--tor-onion-port` (virtual port on the onion, default 80),
+`--tor-socks url`.
+
 ## Limitations
 
 - **Web seeds are not tunneled yet** -- they're disabled when proxied (a

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -40,6 +40,8 @@ with an error instead of silently running unproxied.
 | Path | Without `--proxy` | With `--proxy` |
 |------|-------------------|----------------|
 | Peer connections | direct TCP | **tunneled** through the proxy |
+| `.onion` peer connections | not used | **tunneled** (requires `socks5h://`; see [tor-hidden-service.md](tor-hidden-service.md)) |
+| Nostr relay `wss://` | direct (TLS) | **clearnet** (proxy not applied; see [tor-hidden-service.md](tor-hidden-service.md)) |
 | `http://` trackers | direct | **tunneled** through the proxy |
 | `https://` trackers | direct (TLS) | **tunneled** -- TLS runs over the proxied stream, with certificate verification |
 | UDP trackers (BEP 15) | direct UDP | **disabled** (UDP can't traverse a CONNECT tunnel) |
@@ -197,16 +199,25 @@ carl seed file.torrent /data --tor-seed --nostr
 carl download file.torrent --nostr --proxy socks5h://127.0.0.1:9050
 ```
 
-`--tor-seed` binds the BitTorrent listener to `127.0.0.1` only, disables
-tracker/DHT announces, and tunnels Nostr `wss` via `--tor-socks` (default
-`socks5h://127.0.0.1:9050`). It is mutually exclusive with `--proxy` on seed.
+`--tor-seed` binds the BitTorrent listener to `127.0.0.1` only and disables
+tracker/DHT announces. It is mutually exclusive with `--proxy` on seed.
+
+**Proxy split:** when a leecher passes `--proxy`, BitTorrent peer TCP (including
+`.onion` hosts) uses the proxy, but Nostr relay `wss://` connections use
+**clearnet** today (proxied WebSocket+TLS is not implemented). See
+[tor-hidden-service.md](tor-hidden-service.md) for setup, security, E2E test
+results, and limitations.
 
 Optional flags: `--tor-control host:port`, `--tor-cookie path`,
 `--tor-onion-port` (virtual port on the onion, default 80),
-`--tor-socks url`.
+`--tor-socks url` (reserved for future proxied Nostr; peer traffic uses
+`--proxy` on download).
 
 ## Limitations
 
+- **Nostr `wss` over `--proxy` is not tunneled** -- relay subscribe/publish uses
+  clearnet `wss` while peer TCP (including `.onion`) uses the proxy. See
+  [tor-hidden-service.md](tor-hidden-service.md).
 - **Web seeds are not tunneled yet** -- they're disabled when proxied (a
   proxied + Range-aware path is a planned follow-up).
 - **No UDP** -- DHT and UDP trackers are disabled; SOCKS5 UDP `ASSOCIATE` is not

--- a/docs/tor-hidden-service.md
+++ b/docs/tor-hidden-service.md
@@ -1,0 +1,219 @@
+# Tor hidden-service seeding
+
+Carl can seed a torrent behind an **ephemeral Tor v3 hidden service** and publish
+the `.onion` endpoint on Nostr (NIP-35 kind 30078). Remote leechers discover the
+onion via `carl download --nostr` and connect through Tor SOCKS — no public
+BitTorrent port or routable IPv4 is required on the seeder.
+
+This document covers setup, the **relay vs peer proxy split**, security
+properties, a verified end-to-end test, and known limitations.
+
+## Quick start
+
+### Seeder (Mac or Linux)
+
+Tor must expose **ControlPort** with **cookie authentication** and **SOCKS5**:
+
+```sh
+# Example minimal torrc (adjust DataDirectory for your install)
+# ControlPort 9051
+# CookieAuthentication 1
+# SocksPort 9050
+
+carl seed file.torrent /path/to/data \
+  --tor-seed --nostr \
+  --description "My release"
+```
+
+Optional flags:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--tor-control` | `127.0.0.1:9051` | Tor ControlPort `host:port` |
+| `--tor-cookie` | `~/.tor/control_auth_cookie` | Control cookie file |
+| `--tor-onion-port` | `80` | Virtual port on the onion (maps to local `--port`) |
+| `--tor-socks` | `socks5h://127.0.0.1:9050` | Parsed for API symmetry; see [Proxy split](#proxy-split-nostr-wss-vs-bitTorrent-tcp) |
+| `--port` | `6881` | Local BitTorrent listen port (bound to loopback only) |
+
+`--tor-seed` requires `--nostr` and is **mutually exclusive** with `--proxy` and
+`--external-ip` on `carl seed`.
+
+### Leecher (any host with Tor SOCKS)
+
+```sh
+# Install tor, ensure SOCKS on 127.0.0.1:9050
+carl download file.torrent --output-dir ./out \
+  --nostr --proxy socks5h://127.0.0.1:9050
+```
+
+Use a `.torrent` file or magnet with a known infohash. For magnet-only downloads,
+metadata exchange over Tor peers can be slow; prefer a `.torrent` when testing.
+
+## How it works
+
+```mermaid
+sequenceDiagram
+  participant S as Seeder (carl)
+  participant T as Tor
+  participant N as Nostr relays (wss)
+  participant L as Leecher (carl)
+
+  S->>T: ADD_ONION (ControlPort, loopback only)
+  T-->>S: v3 .onion + port map (80 → 127.0.0.1:6881)
+  S->>N: kind 2003 + kind 30078 (host, port) clearnet wss
+  L->>N: REQ kind 30078 (clearnet wss when --proxy set)
+  N-->>L: peer announce (.onion:80)
+  L->>T: SOCKS5h connect to .onion:80
+  T->>S: BitTorrent over hidden service
+```
+
+1. **`tor_control.zig`** — `ADD_ONION NEW:ED25519-V3`, parse `ServiceID`, build
+   `{service_id}.onion`, `DEL_ONION` on shutdown.
+2. **`session.zig`** — listener on `127.0.0.1` only; tracker/DHT announces
+   disabled (`tor_hidden` mode).
+3. **`peer_announce.zig`** — kind 30078 with `host` + `port` tags (no `ip` tag).
+4. **`peer.zig`** — `connectThroughProxyHost` for `.onion` when `--proxy` is set.
+5. **`relay.zig`** — Nostr relay connections use clearnet `wss` when `--proxy` is
+   set (see below).
+
+## Kind 30078 schema
+
+| Mode | Tags | Example |
+|------|------|---------|
+| IPv4 seed (`--external-ip`) | `d`, `ip`, `port`, `client` | `ip=203.0.113.7`, `port=6881` |
+| Tor seed (`--tor-seed`) | `d`, `host`, `port`, `client` | `host=….onion`, `port=80` |
+
+- `d` — 40-char hex infohash (NIP-33 replaceable key).
+- `port` — BitTorrent port as seen by leechers (onion virtual port, default 80).
+- `client` — `carl/0.1`.
+
+**Parsing rule:** if a valid v3 `host` (`.onion`) tag is present, it **wins**
+over an `ip` tag. That prevents a signed event from advertising a routable IPv4
+alongside an onion and tricking proxied leechers into clearnet dials.
+
+IPv4 addresses in `ip` tags must pass `isRoutable()` (no loopback, private, or
+multicast ranges).
+
+## Proxy split: Nostr `wss` vs BitTorrent TCP
+
+When `--proxy` (or leecher Tor SOCKS) is active, Carl applies the proxy **only
+where it is safe and implemented today**:
+
+| Traffic | With `--proxy` | Notes |
+|---------|----------------|-------|
+| BitTorrent peer TCP (IPv4) | Tunneled via SOCKS5h | Standard proxied mode |
+| BitTorrent peer TCP (`.onion`) | **Required** — tunneled via SOCKS5h | Without `--proxy`, onion peers are skipped with a warning |
+| `http(s)://` trackers | Tunneled | Same as [proxy.md](proxy.md) |
+| Nostr relay `wss://` | **Clearnet** (proxy stripped) | Proxied WebSocket+TLS is not implemented; avoids crashes |
+| UDP / DHT | Disabled | Fail-closed with `--proxy` |
+
+Implementation: `relay.effectiveRelayProxy()` returns `null` for `wss://` and
+`ws://` URLs so `ws.Conn` uses `std.http.Client` (stable on Zig 0.15). Direct
+`ws.Conn.connect(..., .{ .proxy = px })` on `wss://` returns `ConnectFailed`.
+
+**Privacy implication:** `--tor-seed` hides your BitTorrent endpoint behind Tor,
+but **Nostr relay subscriptions and publishes still use clearnet `wss`** today.
+Your IP may be visible to relay operators. `--tor-socks` does not change that
+until proxied `wss` is implemented.
+
+## Tor ControlPort security
+
+Production hardening in `tor_control.zig`:
+
+- **Loopback only** — `--tor-control` must resolve to `127.0.0.1`, `localhost`,
+  or `::1`. Non-loopback hosts are refused (cookie auth is cleartext on the wire).
+- **ServiceID validation** — 56-character base32 before `DEL_ONION` (no `\r\n`
+  injection in control commands).
+- **Cookie read** — up to 256 bytes; `AUTHENTICATE` command built in a growable
+  buffer (large cookies do not truncate silently).
+
+Use a dedicated Tor instance or torrc for Carl; Homebrew Tor may use
+`/opt/homebrew/var/lib/tor/control_auth_cookie` instead of `~/.tor/`.
+
+## Leecher requirements
+
+1. **Tor SOCKS** — `socks5h://127.0.0.1:9050` (remote DNS; required for `.onion`).
+2. **`--nostr`** — subscribe to kind 30078 for the torrent infohash.
+3. **No inbound listener** — proxied download mode does not bind a public port
+   (same as [proxy.md](proxy.md)).
+4. **Peer source** — with `--proxy`, DHT and UDP trackers are off; peers come from
+   Nostr (and any `http(s)://` tracker in the torrent). Trackerless magnets need
+   Nostr peers or an HTTP tracker.
+
+Carl logs `added N peers from nostr` when kind 30078 events are found.
+
+## Verified end-to-end test (2026-06-03)
+
+| Step | Environment | Result |
+|------|-------------|--------|
+| Build | `zig build` / `zig build test` | Pass |
+| Seed | macOS, `--tor-seed --nostr`, custom torrc + cookie | Onion created; kind 2003/30078 on Damus + nos.lol |
+| Search | VPS `65.108.246.14`, `carl search "bitcoin"` | Found `bitcoin.pdf` |
+| Download | VPS, `.torrent` + `--nostr --proxy socks5h://127.0.0.1:9050` | Complete; SHA-256 matched seeder file |
+| Integrity | `b1674191…f4f553` | Match |
+
+**Infohash tested:** `08d72b48f0799bbf62a2dc54cb66cb1ed14f9431` (bitcoin.org whitepaper).
+
+**Not required:** public `6881` on the seeder; `nc <public-ip> 6881` from the VPS.
+
+**Caveats observed:**
+
+- First download attempt with a pre-allocated sparse file showed zeros until a
+  clean run completed — use a fresh `--output-dir` when re-testing.
+- Magnet-only download may stall on ut_metadata over slow Tor paths; `.torrent`
+  file download is more reliable for tests.
+
+## What is disabled in `--tor-seed` mode
+
+- Public IPv4 in kind 30078 (`--external-ip` forbidden).
+- BitTorrent listener on `0.0.0.0` (loopback only).
+- Tracker and DHT announces (no real IP leaked to trackers).
+- Incoming peers from the public internet (only Tor circuits to the onion).
+- `--proxy` on seed (use Tor hidden service instead).
+
+## Known limitations and follow-ups
+
+| Item | Status |
+|------|--------|
+| Proxied `wss://` (Nostr over Tor SOCKS) | **Not implemented** — clearnet fallback in `relay.zig` |
+| `--tor-socks` tunneling Nostr | Documented; same as above until `wss` over SOCKS works |
+| Magnet metadata only over onion | May be slow; prefer `.torrent` for reliability |
+| Web seeds over proxy | Disabled ([proxy.md](proxy.md)) |
+| UDP / DHT with `--proxy` | Disabled |
+| IPv6 | Not supported |
+| Persistent onion | Ephemeral `ADD_ONION` only; new onion each run |
+| Multi-file torrents in magnet metadata mode | Limited ([session.zig](../src/session.zig)) |
+
+**Follow-up work:** implement stable `wss` over SOCKS (or HTTP-client WebSocket
+upgrade over a CONNECT tunnel) so relay traffic can match BitTorrent anonymity
+expectations when using `--tor-seed` / `--tor-socks`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `tor hidden service setup failed: AuthFailed` | Wrong `--tor-cookie` path (check Homebrew `DataDirectory`) |
+| `refusing non-loopback Tor control host` | `--tor-control` must be local |
+| `ADD_ONION error` / `InvalidResponse` | Tor not bootstrapped, ControlPort disabled, or two Tor instances fighting |
+| `nostr peer … is a .onion host; use --proxy` | Leecher missing `--proxy socks5h://…` |
+| Search with `--proxy` works but no peers | Use `--nostr` on download; check kind 30078 on relays |
+| Download 0 bytes / wrong hash | Stale output dir; retry with empty directory |
+| Segfault on `wss` + `--proxy` | Fixed: upgrade to branch with `relay.effectiveRelayProxy` |
+
+## Related docs
+
+- [proxy.md](proxy.md) — SOCKS5h, fail-closed proxied mode, leak verification
+- [brainstorms/2026-06-03-tor-hidden-service-peer-announce.md](brainstorms/2026-06-03-tor-hidden-service-peer-announce.md) — design notes
+- [README.md](../README.md) — CLI examples
+
+## Source files
+
+| File | Role |
+|------|------|
+| `src/tor_control.zig` | ControlPort cookie auth, `ADD_ONION` / `DEL_ONION` |
+| `src/peer_announce.zig` | Kind 30078 build/parse (IPv4 and onion) |
+| `src/main.zig` | `--tor-seed` CLI, `publishNostrOnion`, `collectNostrPeers` |
+| `src/session.zig` | Loopback bind, `tor_hidden`, `connectOnionPeer` |
+| `src/relay.zig` | `effectiveRelayProxy` (clearnet `wss` when `--proxy` set) |
+| `src/ws.zig` | `wss` via `std.http.Client`; rejects direct `wss`+proxy |
+| `src/proxy.zig` | SOCKS5h host connect (used for `.onion` peers) |

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -248,6 +248,8 @@ fn seederThread(args: SeederArgs) void {
         .seed,
         args.port,
         null,
+        .any,
+        false,
     ) catch return;
     defer sess.deinit();
 
@@ -323,6 +325,8 @@ test "full session seed and download over loopback" {
         .download,
         test_port + 1,
         null,
+        .any,
+        false,
     ) catch {
         session_mod.shutdown_requested.store(true, .release);
         seeder_handle.join();

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -20,6 +20,7 @@ pub const peer_announce = @import("peer_announce.zig");
 pub const tor_control = @import("tor_control.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
+pub const mse = @import("mse.zig");
 
 test {
     _ = bencode;
@@ -43,5 +44,6 @@ test {
     _ = tor_control;
     _ = relay;
     _ = nostr_config;
+    _ = mse;
     _ = @import("integration_test.zig");
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -17,6 +17,7 @@ pub const nip19 = @import("nip19.zig");
 pub const nostr = @import("nostr.zig");
 pub const nip35 = @import("nip35.zig");
 pub const peer_announce = @import("peer_announce.zig");
+pub const tor_control = @import("tor_control.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
 
@@ -39,6 +40,7 @@ test {
     _ = nostr;
     _ = nip35;
     _ = peer_announce;
+    _ = tor_control;
     _ = relay;
     _ = nostr_config;
     _ = @import("integration_test.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,14 +64,24 @@ pub fn main() !void {
         try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr);
     } else if (std.mem.eql(u8, command, "seed")) {
         if (args.len < 4) {
-            log.err("usage: carl seed <file.torrent> <data-dir> [--port <port>] [--nostr] [--external-ip <ip>]", .{});
+            log.err("usage: carl seed <file.torrent> <data-dir> [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--description \"...\"]", .{});
             std.process.exit(1);
         }
         const port = parsePort(args[4..]);
         const want_nostr = parseFlagPresent(args[4..], "--nostr");
+        const tor_seed = parseFlagPresent(args[4..], "--tor-seed");
         const external_ip = parseFlag(args[4..], "--external-ip");
         const description = parseFlag(args[4..], "--description") orelse "";
-        try cmdSeed(allocator, args[2], args[3], port, parseProxy(args[4..]), want_nostr, external_ip, description);
+        const tor_control = parseFlag(args[4..], "--tor-control") orelse "127.0.0.1:9051";
+        const tor_cookie = parseFlag(args[4..], "--tor-cookie");
+        const tor_onion_port: u16 = parsePortFlag(args[4..], "--tor-onion-port", 80);
+        const tor_socks_url = parseFlag(args[4..], "--tor-socks") orelse "socks5h://127.0.0.1:9050";
+        try cmdSeed(allocator, args[2], args[3], port, parseProxy(args[4..]), want_nostr, tor_seed, external_ip, description, .{
+            .control_addr = tor_control,
+            .cookie_path = tor_cookie,
+            .onion_port = tor_onion_port,
+            .socks_url = tor_socks_url,
+        });
     } else if (std.mem.eql(u8, command, "search")) {
         if (args.len < 3) {
             log.err("usage: carl search <query> [--limit <n>] [--relay <url>]", .{});
@@ -79,7 +89,7 @@ pub fn main() !void {
         }
         const limit = parseUnsignedFlag(args[3..], "--limit", 50);
         const single_relay = parseFlag(args[3..], "--relay");
-        try cmdSearch(allocator, stdout, args[2], limit, single_relay);
+        try cmdSearch(allocator, stdout, args[2], limit, single_relay, parseProxy(args[3..]));
     } else if (std.mem.eql(u8, command, "nostr-keygen")) {
         try cmdNostrKeygen(allocator, stdout);
     } else {
@@ -99,9 +109,12 @@ fn printUsage() void {
         \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr]
         \\           source: file.torrent, magnet:?..., or http(s):// URL
         \\           --nostr: also subscribe to nostr peer-announce events
-        \\  seed <file.torrent> <data-dir> [--port p] [--proxy url] [--nostr] [--external-ip <ip>] [--description "..."]
+        \\  seed <file.torrent> <data-dir> [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
+        \\           [--tor-seed] [--tor-control host:port] [--tor-cookie path]
+        \\           [--tor-onion-port p] [--tor-socks url] [--description "..."]
         \\           --nostr: publish NIP-35 torrent event + peer-announce
-        \\           --external-ip: required with --nostr; the IP peers should dial
+        \\           --external-ip: public IPv4 for peer-announce (classic seeding)
+        \\           --tor-seed: hidden service via Tor ControlPort; requires --nostr
         \\  search <query> [--limit n] [--relay <wss://...>]
         \\           search nostr relays for kind-2003 torrent events
         \\  nostr-keygen                                     generate a fresh nostr key
@@ -281,7 +294,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         defer mi.deinit(allocator);
 
         std.fs.cwd().makePath(output_dir) catch {};
-        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy) catch |err| {
+        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false) catch |err| {
             log.err("failed to initialize session: {}", .{err});
             std.process.exit(1);
         };
@@ -321,7 +334,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
 
 fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool) void {
     std.fs.cwd().makePath(output_dir) catch {};
-    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -372,6 +385,13 @@ fn fetchUrl(allocator: std.mem.Allocator, url: []const u8, proxy: ?carl.proxy.Pr
     return response_body.toOwnedSlice(allocator);
 }
 
+const TorSeedOptions = struct {
+    control_addr: []const u8,
+    cookie_path: ?[]const u8,
+    onion_port: u16,
+    socks_url: []const u8,
+};
+
 fn cmdSeed(
     allocator: std.mem.Allocator,
     torrent_path: []const u8,
@@ -379,39 +399,73 @@ fn cmdSeed(
     port: u16,
     proxy: ?carl.proxy.Proxy,
     want_nostr: bool,
+    tor_seed: bool,
     external_ip: ?[]const u8,
     description: []const u8,
+    tor_opts: TorSeedOptions,
 ) !void {
+    if (tor_seed and proxy != null) {
+        log.err("--tor-seed and --proxy are mutually exclusive on seed", .{});
+        std.process.exit(1);
+    }
+    if (tor_seed and !want_nostr) {
+        log.err("--tor-seed requires --nostr", .{});
+        std.process.exit(1);
+    }
+    if (tor_seed and external_ip != null) {
+        log.err("--tor-seed uses a Tor hidden service; do not pass --external-ip", .{});
+        std.process.exit(1);
+    }
+    if (want_nostr and !tor_seed and external_ip == null) {
+        log.err("--nostr requires --external-ip <ip> or --tor-seed", .{});
+        std.process.exit(1);
+    }
+
     const mi = readTorrent(allocator, torrent_path);
     defer mi.deinit(allocator);
 
+    var hidden: ?carl.tor_control.HiddenService = null;
+    defer if (hidden) |*h| h.deinit();
+
+    const nostr_proxy: ?carl.proxy.Proxy = if (tor_seed)
+        parseTorSocksProxy(tor_opts.socks_url)
+    else
+        null;
+
     if (want_nostr) {
-        if (external_ip == null) {
-            log.err("--nostr requires --external-ip <ip> so peers know how to dial you", .{});
-            std.process.exit(1);
+        if (tor_seed) {
+            hidden = carl.tor_control.addOnion(allocator, .{
+                .control_addr = tor_opts.control_addr,
+                .cookie_path = tor_opts.cookie_path,
+                .local_port = port,
+                .onion_port = tor_opts.onion_port,
+            }) catch |err| {
+                log.err("tor hidden service setup failed: {}", .{err});
+                std.process.exit(1);
+            };
+            publishNostrOnion(allocator, mi, hidden.?.onion_host, hidden.?.onion_port, description, nostr_proxy) catch |err| {
+                log.warn("nostr publish failed: {} (continuing seed)", .{err});
+            };
+        } else {
+            const ip = parseIpv4(external_ip.?) orelse {
+                log.err("invalid --external-ip: {s}", .{external_ip.?});
+                std.process.exit(1);
+            };
+            if (!carl.peer_announce.isRoutable(ip)) {
+                log.err(
+                    "--external-ip {d}.{d}.{d}.{d} is not routable; refusing to publish peer-announce",
+                    .{ ip[0], ip[1], ip[2], ip[3] },
+                );
+                std.process.exit(1);
+            }
+            publishNostrIpv4(allocator, mi, ip, port, description, null) catch |err| {
+                log.warn("nostr publish failed: {} (continuing seed)", .{err});
+            };
         }
-        const ip = parseIpv4(external_ip.?) orelse {
-            log.err("invalid --external-ip: {s}", .{external_ip.?});
-            std.process.exit(1);
-        };
-        // Run the seeder's own IP through the same safety filter we apply to
-        // peers we'd download from. Publishing a peer-announce for 127.0.0.1
-        // or 192.168.x.y is always a mistake — every receiving carl will
-        // reject it in peer_announce.parse, so we may as well catch it here
-        // with a useful error instead of silently emitting a dud event.
-        if (!carl.peer_announce.isRoutable(ip)) {
-            log.err(
-                "--external-ip {d}.{d}.{d}.{d} is not a routable public address; refusing to publish peer-announce",
-                .{ ip[0], ip[1], ip[2], ip[3] },
-            );
-            std.process.exit(1);
-        }
-        publishNostr(allocator, mi, ip, port, description) catch |err| {
-            log.warn("nostr publish failed: {} (continuing seed)", .{err});
-        };
     }
 
-    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, proxy) catch |err| {
+    const listen_bind: carl.session.ListenBind = if (tor_seed) .loopback else .any;
+    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -419,6 +473,13 @@ fn cmdSeed(
 
     session.run() catch |err| {
         log.err("session failed: {}", .{err});
+        std.process.exit(1);
+    };
+}
+
+fn parseTorSocksProxy(url: []const u8) carl.proxy.Proxy {
+    return carl.proxy.parseUrl(url) catch |err| {
+        log.err("invalid --tor-socks URL '{s}': {}", .{ url, err });
         std.process.exit(1);
     };
 }
@@ -433,6 +494,7 @@ fn cmdSearch(
     query: []const u8,
     limit: u32,
     single_relay: ?[]const u8,
+    proxy: ?carl.proxy.Proxy,
 ) !void {
     var relay_urls: [][]const u8 = undefined;
     var relays_owned = false;
@@ -480,7 +542,7 @@ fn cmdSearch(
     relay_loop: for (relay_urls) |url| {
         if (printed >= limit) break;
 
-        var r = carl.relay.Relay.connect(allocator, url) catch |err| {
+        var r = carl.relay.Relay.connect(allocator, url, proxy) catch |err| {
             log.warn("relay {s}: {}", .{ url, err });
             continue;
         };
@@ -601,22 +663,15 @@ fn cmdNostrKeygen(allocator: std.mem.Allocator, stdout: anytype) !void {
 // Nostr helpers for seed/download
 // -------------------------------------------------------------------------
 
-fn publishNostr(
+fn publishNostrIpv4(
     allocator: std.mem.Allocator,
     mi: carl.metainfo.Metainfo,
     external_ip: [4]u8,
     port: u16,
     description: []const u8,
+    proxy: ?carl.proxy.Proxy,
 ) !void {
-    const sk = carl.nostr_config.readSecretKey(allocator) catch |err| {
-        switch (err) {
-            error.NoKey => {
-                log.err("no nostr key configured. run `carl nostr-keygen` first", .{});
-                return error.NoKey;
-            },
-            else => return err,
-        }
-    };
+    const sk = try readNostrSecretKey(allocator);
     const pk = try carl.secp.publicKeyFromSecret(sk);
     const info_hash = carl.metainfo.infoHash(mi.raw_info);
 
@@ -625,13 +680,54 @@ fn publishNostr(
     var announce_ev = try carl.peer_announce.build(allocator, sk, pk, info_hash, external_ip, port);
     defer announce_ev.deinit(allocator);
 
+    try publishNostrEvents(allocator, torrent_ev, announce_ev, proxy);
+}
+
+fn publishNostrOnion(
+    allocator: std.mem.Allocator,
+    mi: carl.metainfo.Metainfo,
+    onion_host: []const u8,
+    onion_port: u16,
+    description: []const u8,
+    proxy: ?carl.proxy.Proxy,
+) !void {
+    const sk = try readNostrSecretKey(allocator);
+    const pk = try carl.secp.publicKeyFromSecret(sk);
+    const info_hash = carl.metainfo.infoHash(mi.raw_info);
+
+    var torrent_ev = try carl.nip35.buildFromMetainfo(allocator, sk, pk, mi, info_hash, description);
+    defer torrent_ev.deinit(allocator);
+    var announce_ev = try carl.peer_announce.buildOnion(allocator, sk, pk, info_hash, onion_host, onion_port);
+    defer announce_ev.deinit(allocator);
+
+    try publishNostrEvents(allocator, torrent_ev, announce_ev, proxy);
+}
+
+fn readNostrSecretKey(allocator: std.mem.Allocator) !carl.secp.SecretKey {
+    return carl.nostr_config.readSecretKey(allocator) catch |err| {
+        switch (err) {
+            error.NoKey => {
+                log.err("no nostr key configured. run `carl nostr-keygen` first", .{});
+                return error.NoKey;
+            },
+            else => return err,
+        }
+    };
+}
+
+fn publishNostrEvents(
+    allocator: std.mem.Allocator,
+    torrent_ev: carl.nostr.Event,
+    announce_ev: carl.nostr.Event,
+    proxy: ?carl.proxy.Proxy,
+) !void {
     const relay_urls = try carl.nostr_config.readRelays(allocator);
     defer carl.nostr_config.freeRelays(allocator, relay_urls);
 
     var torrent_acks: usize = 0;
     var announce_acks: usize = 0;
     for (relay_urls) |url| {
-        var r = carl.relay.Relay.connect(allocator, url) catch |err| {
+        var r = carl.relay.Relay.connect(allocator, url, proxy) catch |err| {
             log.warn("nostr publish: {s}: {}", .{ url, err });
             continue;
         };
@@ -672,7 +768,7 @@ fn collectNostrPeers(
 
     var added: usize = 0;
     for (relay_urls) |url| {
-        var r = carl.relay.Relay.connect(allocator, url) catch |err| {
+        var r = carl.relay.Relay.connect(allocator, url, session.proxy) catch |err| {
             log.debug("nostr peer-discover: {s}: {}", .{ url, err });
             continue;
         };
@@ -689,10 +785,25 @@ fn collectNostrPeers(
         for (events) |ev| {
             const ann = carl.peer_announce.parse(ev) catch continue;
             if (!std.mem.eql(u8, &ann.info_hash, &info_hash)) continue;
-            if (added >= 50) break; // cap how many nostr peers we proactively dial
-            const addr = std.net.Address.initIp4(ann.ip, ann.port);
-            session.connectDirectPeer(addr) catch continue;
-            added += 1;
+            if (added >= 50) break;
+            switch (ann.endpoint) {
+                .ipv4 => |ep| {
+                    const addr = std.net.Address.initIp4(ep.ip, ep.port);
+                    session.connectDirectPeer(addr) catch continue;
+                    added += 1;
+                },
+                .onion => |ep| {
+                    if (session.proxy == null) {
+                        log.warn(
+                            "nostr peer {s}:{d} is a .onion host; use --proxy socks5h://127.0.0.1:9050 to connect",
+                            .{ ep.host, ep.port },
+                        );
+                        continue;
+                    }
+                    session.connectOnionPeer(ep.host, ep.port) catch continue;
+                    added += 1;
+                },
+            }
         }
     }
     if (added > 0) log.info("added {d} peers from nostr", .{added});
@@ -730,6 +841,11 @@ fn parseFlag(extra_args: []const [:0]u8, flag: []const u8) ?[]const u8 {
 fn parsePort(extra_args: []const [:0]u8) u16 {
     const port_str = parseFlag(extra_args, "--port") orelse return 6881;
     return std.fmt.parseUnsigned(u16, port_str, 10) catch 6881;
+}
+
+fn parsePortFlag(extra_args: []const [:0]u8, flag: []const u8, default: u16) u16 {
+    const port_str = parseFlag(extra_args, flag) orelse return default;
+    return std.fmt.parseUnsigned(u16, port_str, 10) catch default;
 }
 
 /// Parse `--proxy <url>`. Exits with an error if the URL is malformed or the

--- a/src/mse.zig
+++ b/src/mse.zig
@@ -1,0 +1,610 @@
+/// Vuze Message Stream Encryption / Protocol Encryption (MSE/PE) v1.0.
+///
+/// Obfuscates the BitTorrent wire protocol with a 768-bit DH exchange and RC4
+/// stream encryption. See the archived spec:
+/// https://web.archive.org/web/20161231215426/http://wiki.vuze.com/w/Message_Stream_Encryption
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Sha1 = std.crypto.hash.Sha1;
+const Managed = std.math.big.int.Managed;
+const Mutable = std.math.big.int.Mutable;
+const Const = std.math.big.int.Const;
+
+pub const dh_pubkey_len: usize = 96;
+pub const skey_len: usize = 20;
+pub const hash_len: usize = Sha1.digest_length;
+pub const vc: [8]u8 = .{0} ** 8;
+pub const rc4_discard_len: usize = 1024;
+pub const max_pad_len: usize = 512;
+pub const min_dh_step_bytes: usize = 96;
+pub const max_dh_step_bytes: usize = 608;
+
+pub const crypto_plaintext: u32 = 0x01;
+pub const crypto_rc4: u32 = 0x02;
+
+/// 768-bit safe prime P (big-endian, 96 bytes).
+pub const dh_prime_be: [dh_pubkey_len]u8 = .{
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2, 0x21, 0x68, 0xC2, 0x34,
+    0xC4, 0xC6, 0x62, 0x8B, 0x80, 0xDC, 0x1C, 0xD1, 0x29, 0x02, 0x4E, 0x08, 0x8A, 0x67, 0xCC, 0x74,
+    0x02, 0x0B, 0xBE, 0xA6, 0x3B, 0x13, 0x9B, 0x22, 0x51, 0x4A, 0x08, 0x79, 0x8E, 0x34, 0x04, 0xDD,
+    0xEF, 0x95, 0x19, 0xB3, 0xCD, 0x3A, 0x43, 0x1B, 0x30, 0x2B, 0x0A, 0x6D, 0xF2, 0x5F, 0x14, 0x37,
+    0x4F, 0xE1, 0x35, 0x6D, 0x6D, 0x51, 0xC2, 0x45, 0xE4, 0x85, 0xB5, 0x76, 0x62, 0x5E, 0x7E, 0xC6,
+    0xF4, 0x4C, 0x42, 0xE9, 0xA6, 0x3A, 0x36, 0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x05, 0x63,
+};
+
+pub const CryptoMethod = enum(u32) {
+    plaintext = crypto_plaintext,
+    rc4 = crypto_rc4,
+};
+
+pub const Role = enum {
+    initiator, // A
+    responder, // B
+};
+
+pub const Options = struct {
+    skey: [skey_len]u8,
+    /// Bitfield of offered methods (typically `crypto_rc4` or `crypto_plaintext | crypto_rc4`).
+    crypto_provide: u32 = crypto_rc4,
+    /// Optional bytes sent as IA in step 3 (e.g. serialized BEP 3 handshake).
+    ia: []const u8 = &.{},
+};
+
+/// RC4 stream cipher with Vuze's mandatory 1024-byte keystream discard.
+pub const Rc4 = struct {
+    s: [256]u8,
+    i: u8,
+    j: u8,
+
+    pub fn init(key: []const u8) Rc4 {
+        var rc: Rc4 = undefined;
+        for (0..256) |n| {
+            rc.s[n] = @intCast(n);
+        }
+        var j: u8 = 0;
+        for (0..256) |n| {
+            j = j +% rc.s[n] +% key[n % key.len];
+            std.mem.swap(u8, &rc.s[n], &rc.s[j]);
+        }
+        rc.i = 0;
+        rc.j = 0;
+        return rc;
+    }
+
+    pub fn discardKeystream(self: *Rc4, count: usize) void {
+        var buf: [64]u8 = undefined;
+        var left = count;
+        while (left > 0) {
+            const chunk = @min(left, buf.len);
+            @memset(buf[0..chunk], 0);
+            self.cryptInPlace(buf[0..chunk]);
+            left -= chunk;
+        }
+    }
+
+    pub fn cryptInPlace(self: *Rc4, buf: []u8) void {
+        for (buf) |*byte| {
+            self.i +%= 1;
+            self.j +%= self.s[self.i];
+            std.mem.swap(u8, &self.s[self.i], &self.s[self.j]);
+            const idx = self.s[self.i] +% self.s[self.j];
+            byte.* ^= self.s[idx];
+        }
+    }
+};
+
+/// Established MSE session over a TCP stream.
+///
+/// `close()` shuts down the underlying socket. Do not close the same
+/// `std.net.Stream` again after a successful handshake.
+pub const Stream = struct {
+    inner: std.net.Stream,
+    encrypt: Rc4,
+    decrypt: Rc4,
+    method: CryptoMethod,
+
+    pub fn read(self: *Stream, buf: []u8) !usize {
+        const n = try self.inner.read(buf);
+        if (n > 0 and self.method == .rc4) {
+            self.decrypt.cryptInPlace(buf[0..n]);
+        }
+        return n;
+    }
+
+    pub fn write(self: *Stream, buf: []const u8) !usize {
+        if (buf.len == 0) return 0;
+        if (self.method == .rc4) {
+            var stack_buf: [4096]u8 = undefined;
+            if (buf.len <= stack_buf.len) {
+                @memcpy(stack_buf[0..buf.len], buf);
+                self.encrypt.cryptInPlace(stack_buf[0..buf.len]);
+                return self.inner.write(stack_buf[0..buf.len]);
+            }
+            const tmp = try std.heap.page_allocator.alloc(u8, buf.len);
+            defer std.heap.page_allocator.free(tmp);
+            @memcpy(tmp, buf);
+            self.encrypt.cryptInPlace(tmp);
+            return self.inner.write(tmp);
+        }
+        return self.inner.write(buf);
+    }
+
+    pub fn writeAll(self: *Stream, buf: []const u8) !void {
+        var index: usize = 0;
+        while (index < buf.len) {
+            const n = try self.write(buf[index..]);
+            if (n == 0) return error.EndOfStream;
+            index += n;
+        }
+    }
+
+    pub fn close(self: Stream) void {
+        self.inner.close();
+    }
+};
+
+/// SHA1 HASH(label, parts...) per Vuze MSE.
+pub fn hashParts(out: *[hash_len]u8, parts: []const []const u8) void {
+    var h = Sha1.init(.{});
+    for (parts) |p| h.update(p);
+    h.final(out);
+}
+
+pub fn hashReq1(s_be: *const [dh_pubkey_len]u8, out: *[hash_len]u8) void {
+    hashParts(out, &.{ "req1", s_be[0..] });
+}
+
+pub fn hashReq2(skey: *const [skey_len]u8, out: *[hash_len]u8) void {
+    hashParts(out, &.{ "req2", skey[0..] });
+}
+
+pub fn hashReq3(s_be: *const [dh_pubkey_len]u8, out: *[hash_len]u8) void {
+    hashParts(out, &.{ "req3", s_be[0..] });
+}
+
+pub fn hashStreamKey(role: Role, s_be: *const [dh_pubkey_len]u8, skey: *const [skey_len]u8, out: *[hash_len]u8) void {
+    const label = switch (role) {
+        .initiator => "keyA",
+        .responder => "keyB",
+    };
+    hashParts(out, &.{ label, s_be[0..], skey[0..] });
+}
+
+pub fn initRc4FromShared(role: Role, s_be: *const [dh_pubkey_len]u8, skey: *const [skey_len]u8) Rc4 {
+    var key: [hash_len]u8 = undefined;
+    hashStreamKey(role, s_be, skey, &key);
+    var rc = Rc4.init(&key);
+    rc.discardKeystream(rc4_discard_len);
+    return rc;
+}
+
+fn readManagedBe(allocator: Allocator, bytes: []const u8) !Managed {
+    var m = try Managed.initCapacity(allocator, (bytes.len + 7) / 8 + 1);
+    var mut = m.toMutable();
+    mut.readTwosComplement(bytes, bytes.len * 8, .big, .unsigned);
+    m.setMetadata(mut.positive, mut.len);
+    return m;
+}
+
+fn writeManagedBe(m: Const, out: *[dh_pubkey_len]u8) void {
+    @memset(out, 0);
+    Const.writeTwosComplement(m, out, .big);
+}
+
+fn loadDhPrime(allocator: Allocator) !Managed {
+    return readManagedBe(allocator, &dh_prime_be);
+}
+
+pub fn modPow(
+    allocator: Allocator,
+    result: *Managed,
+    base: *const Managed,
+    exponent: *const Managed,
+    modulus: *const Managed,
+) !void {
+    var acc = try Managed.initSet(allocator, @as(u32, 1));
+    defer acc.deinit();
+    var b = try base.clone();
+    defer b.deinit();
+    var e = try exponent.clone();
+    defer e.deinit();
+    var tmp = try Managed.initCapacity(allocator, modulus.len() * 2 + 4);
+    defer tmp.deinit();
+    var rem = try Managed.initCapacity(allocator, modulus.len() + 2);
+    defer rem.deinit();
+    var q = try Managed.initCapacity(allocator, modulus.len() + 2);
+    defer q.deinit();
+
+    try Managed.divTrunc(&q, &rem, base, modulus);
+    try b.copy(rem.toConst());
+
+    while (!e.eqlZero()) {
+        if (e.isOdd()) {
+            try Managed.mul(&tmp, &acc, &b);
+            try Managed.divTrunc(&q, &rem, &tmp, modulus);
+            try acc.copy(rem.toConst());
+        }
+        try Managed.mul(&tmp, &b, &b);
+        try Managed.divTrunc(&q, &rem, &tmp, modulus);
+        try b.copy(rem.toConst());
+        try Managed.shiftRight(&e, &e, 1);
+    }
+    try result.copy(acc.toConst());
+}
+
+/// Generate a 160-bit private DH exponent (20 random bytes).
+pub fn generatePrivateKey(allocator: Allocator) !Managed {
+    var bytes: [20]u8 = undefined;
+    std.crypto.random.bytes(&bytes);
+    bytes[0] |= 0x80; // ensure top bit set → at least 128 bits
+    return readManagedBe(allocator, &bytes);
+}
+
+pub fn dhPublicKey(allocator: Allocator, private_key: *const Managed, out: *[dh_pubkey_len]u8) !void {
+    var p = try loadDhPrime(allocator);
+    defer p.deinit();
+    var g = try Managed.initSet(allocator, @as(u32, 2));
+    defer g.deinit();
+    var y = try Managed.initCapacity(allocator, dh_pubkey_len);
+    defer y.deinit();
+    try modPow(allocator, &y, &g, private_key, &p);
+    writeManagedBe(y.toConst(), out);
+}
+
+pub fn dhSharedSecret(
+    allocator: Allocator,
+    private_key: *const Managed,
+    peer_pubkey_be: *const [dh_pubkey_len]u8,
+    out: *[dh_pubkey_len]u8,
+) !void {
+    var p = try loadDhPrime(allocator);
+    defer p.deinit();
+    var y_peer = try readManagedBe(allocator, peer_pubkey_be);
+    defer y_peer.deinit();
+    var s = try Managed.initCapacity(allocator, dh_pubkey_len);
+    defer s.deinit();
+    try modPow(allocator, &s, &y_peer, private_key, &p);
+    writeManagedBe(s.toConst(), out);
+}
+
+fn randomPad(allocator: Allocator) ![]u8 {
+    const len = std.crypto.random.intRangeAtMost(usize, 0, max_pad_len);
+    const pad = try allocator.alloc(u8, len);
+    std.crypto.random.bytes(pad);
+    return pad;
+}
+
+fn writeDhStep(stream: *std.net.Stream, pubkey: *const [dh_pubkey_len]u8, pad: []const u8) !void {
+    var hdr: [4]u8 = undefined;
+    std.mem.writeInt(u16, hdr[0..2], dh_pubkey_len, .big);
+    std.mem.writeInt(u16, hdr[2..4], @intCast(pad.len), .big);
+    try writeAll(stream, hdr[0..]);
+    try writeAll(stream, pubkey);
+    if (pad.len > 0) try writeAll(stream, pad);
+}
+
+fn readDhStep(allocator: Allocator, stream: *std.net.Stream, pubkey: *[dh_pubkey_len]u8) ![]u8 {
+    var hdr: [4]u8 = undefined;
+    try readExact(stream, &hdr);
+    const ya_len = std.mem.readInt(u16, hdr[0..2], .big);
+    const pad_len = std.mem.readInt(u16, hdr[2..4], .big);
+    if (ya_len != dh_pubkey_len or pad_len > max_pad_len) return error.InvalidDhStep;
+    try readExact(stream, pubkey);
+    if (pad_len == 0) return &.{};
+    const pad = try allocator.alloc(u8, pad_len);
+    errdefer allocator.free(pad);
+    try readExact(stream, pad);
+    return pad;
+}
+
+fn writeAll(stream: *std.net.Stream, buf: []const u8) !void {
+    var index: usize = 0;
+    while (index < buf.len) {
+        const n = try stream.write(buf[index..]);
+        if (n == 0) return error.EndOfStream;
+        index += n;
+    }
+}
+
+fn readExact(stream: *std.net.Stream, buf: []u8) !void {
+    var index: usize = 0;
+    while (index < buf.len) {
+        const n = try stream.read(buf[index..]);
+        if (n == 0) return error.EndOfStream;
+        index += n;
+    }
+}
+
+fn selectCrypto(crypto_provide: u32, crypto_select: u32) !CryptoMethod {
+    if (crypto_provide == 0) return error.NoCryptoProvided;
+    const selected = crypto_select & crypto_provide;
+    if (selected & crypto_rc4 != 0) return .rc4;
+    if (selected & crypto_plaintext != 0) return .plaintext;
+    return error.UnsupportedCrypto;
+}
+
+/// Run the full 5-step MSE handshake as initiator (A).
+pub fn handshakeInitiator(allocator: Allocator, stream: *std.net.Stream, opts: Options) !Stream {
+    var priv = try generatePrivateKey(allocator);
+    defer priv.deinit();
+
+    var ya: [dh_pubkey_len]u8 = undefined;
+    try dhPublicKey(allocator, &priv, &ya);
+
+    const pad_a = try randomPad(allocator);
+    defer allocator.free(pad_a);
+    try writeDhStep(stream, &ya, pad_a);
+
+    var yb: [dh_pubkey_len]u8 = undefined;
+    const pad_b = try readDhStep(allocator, stream, &yb);
+    defer if (pad_b.len > 0) allocator.free(pad_b);
+
+    var s: [dh_pubkey_len]u8 = undefined;
+    try dhSharedSecret(allocator, &priv, &yb, &s);
+
+    var enc = initRc4FromShared(.initiator, &s, &opts.skey);
+    var dec = initRc4FromShared(.responder, &s, &opts.skey);
+
+    var req1: [hash_len]u8 = undefined;
+    var req2: [hash_len]u8 = undefined;
+    var req3: [hash_len]u8 = undefined;
+    hashReq1(&s, &req1);
+    hashReq2(&opts.skey, &req2);
+    hashReq3(&s, &req3);
+
+    var skey_xor: [hash_len]u8 = undefined;
+    for (0..hash_len) |i| {
+        skey_xor[i] = req2[i] ^ req3[i];
+    }
+
+    const pad_c = try randomPad(allocator);
+    defer allocator.free(pad_c);
+
+    // Step 3: req1 + skey_xor in plaintext, then ENCRYPT(VC, …, IA).
+    try writeAll(stream, &req1);
+    try writeAll(stream, &skey_xor);
+
+    const enc_len = 8 + 4 + 2 + pad_c.len + 2 + opts.ia.len;
+    var enc_part = try allocator.alloc(u8, enc_len);
+    defer allocator.free(enc_part);
+    var off: usize = 0;
+    @memcpy(enc_part[off..][0..8], &vc);
+    off += 8;
+    std.mem.writeInt(u32, enc_part[off..][0..4], opts.crypto_provide, .big);
+    off += 4;
+    std.mem.writeInt(u16, enc_part[off..][0..2], @intCast(pad_c.len), .big);
+    off += 2;
+    if (pad_c.len > 0) {
+        @memcpy(enc_part[off..][0..pad_c.len], pad_c);
+        off += pad_c.len;
+    }
+    std.mem.writeInt(u16, enc_part[off..][0..2], @intCast(opts.ia.len), .big);
+    off += 2;
+    if (opts.ia.len > 0) {
+        @memcpy(enc_part[off..][0..opts.ia.len], opts.ia);
+        off += opts.ia.len;
+    }
+    enc.cryptInPlace(enc_part[0..off]);
+    try writeAll(stream, enc_part[0..off]);
+
+    // Step 4: ENCRYPT(VC, crypto_select, len(PadD), PadD) + ENCRYPT2(payload)
+    var buf: [1024]u8 = undefined;
+    var total: usize = 0;
+    var crypto_select: u32 = 0;
+    var method: CryptoMethod = undefined;
+    while (total < buf.len) {
+        const n = try stream.read(buf[total..]);
+        if (n == 0) return error.EndOfStream;
+        total += n;
+        var trial: usize = 8 + 4 + 2;
+        while (trial <= total) : (trial += 1) {
+            var tmp = buf[0..trial];
+            dec.cryptInPlace(tmp);
+            if (!std.mem.eql(u8, tmp[0..8], &vc)) continue;
+            crypto_select = std.mem.readInt(u32, tmp[8..12], .big);
+            method = selectCrypto(opts.crypto_provide, crypto_select) catch continue;
+            const pad_d_len = std.mem.readInt(u16, tmp[12..14], .big);
+            if (pad_d_len > max_pad_len) continue;
+            const need = 8 + 4 + 2 + pad_d_len;
+            if (total < need) break;
+            if (total > need) {
+                dec.cryptInPlace(buf[need..total]);
+            }
+            return .{
+                .inner = stream.*,
+                .encrypt = enc,
+                .decrypt = dec,
+                .method = method,
+            };
+        }
+    }
+    return error.HandshakeSyncFailed;
+}
+
+/// Run the full 5-step MSE handshake as responder (B).
+pub fn handshakeResponder(allocator: Allocator, stream: *std.net.Stream, opts: Options) !Stream {
+    var priv = try generatePrivateKey(allocator);
+    defer priv.deinit();
+
+    var ya: [dh_pubkey_len]u8 = undefined;
+    const pad_a = try readDhStep(allocator, stream, &ya);
+    defer if (pad_a.len > 0) allocator.free(pad_a);
+
+    var yb: [dh_pubkey_len]u8 = undefined;
+    try dhPublicKey(allocator, &priv, &yb);
+    const pad_b = try randomPad(allocator);
+    defer allocator.free(pad_b);
+    try writeDhStep(stream, &yb, pad_b);
+
+    var s: [dh_pubkey_len]u8 = undefined;
+    try dhSharedSecret(allocator, &priv, &ya, &s);
+
+    var req1: [hash_len]u8 = undefined;
+    hashReq1(&s, &req1);
+
+    var enc = initRc4FromShared(.responder, &s, &opts.skey);
+    var dec = initRc4FromShared(.initiator, &s, &opts.skey);
+
+    var plain: [hash_len * 2]u8 = undefined;
+    try readExact(stream, plain[0..hash_len]);
+    if (!std.mem.eql(u8, plain[0..hash_len], &req1)) return error.HandshakeSyncFailed;
+
+    try readExact(stream, plain[hash_len..]);
+    var req2: [hash_len]u8 = undefined;
+    hashReq2(&opts.skey, &req2);
+    var req3: [hash_len]u8 = undefined;
+    hashReq3(&s, &req3);
+    var expect_xor: [hash_len]u8 = undefined;
+    for (0..hash_len) |i| expect_xor[i] = req2[i] ^ req3[i];
+    if (!std.mem.eql(u8, plain[hash_len..], &expect_xor)) return error.InvalidSkeyHash;
+
+    var enc_buf: [512 + 8 + 4 + 2 + 2 + 65535]u8 = undefined;
+    var enc_total: usize = 0;
+    const min_enc = 8 + 4 + 2 + 2;
+    while (enc_total < enc_buf.len) {
+        const n = try stream.read(enc_buf[enc_total..]);
+        if (n == 0) return error.EndOfStream;
+        enc_total += n;
+        if (enc_total < min_enc) continue;
+        var trial = enc_buf[0..enc_total];
+        dec.cryptInPlace(trial);
+        if (!std.mem.eql(u8, trial[0..8], &vc)) continue;
+        const crypto_provide = std.mem.readInt(u32, trial[8..12], .big);
+        const pad_c_len = std.mem.readInt(u16, trial[12..14], .big);
+        if (pad_c_len > max_pad_len) continue;
+        const need = 8 + 4 + 2 + pad_c_len + 2;
+        if (enc_total < need) continue;
+        const ia_len = std.mem.readInt(u16, trial[14 + pad_c_len ..][0..2], .big);
+        if (ia_len > 65535) continue;
+        if (enc_total < need + ia_len) continue;
+
+        const crypto_select: u32 = crypto_rc4;
+        const method = try selectCrypto(crypto_provide, crypto_select);
+
+        var step4_plain = [_]u8{0} ** (8 + 4 + 2);
+        @memcpy(step4_plain[0..8], &vc);
+        std.mem.writeInt(u32, step4_plain[8..12], crypto_select, .big);
+        std.mem.writeInt(u16, step4_plain[12..14], 0, .big);
+        enc.cryptInPlace(&step4_plain);
+        try writeAll(stream, &step4_plain);
+
+        return .{
+            .inner = stream.*,
+            .encrypt = enc,
+            .decrypt = dec,
+            .method = method,
+        };
+    }
+    return error.HandshakeSyncFailed;
+}
+
+// --- tests ---
+
+const testing = std.testing;
+
+fn hexToBytes(comptime hex_str: []const u8) [dh_pubkey_len]u8 {
+    var out: [dh_pubkey_len]u8 = undefined;
+    var i: usize = 0;
+    var j: usize = 0;
+    while (i < hex_str.len) : (i += 2) {
+        const hi = std.fmt.parseInt(u4, hex_str[i .. i + 1], 16) catch unreachable;
+        const lo = std.fmt.parseInt(u4, hex_str[i + 1 .. i + 2], 16) catch unreachable;
+        out[j] = @as(u8, hi) << 4 | lo;
+        j += 1;
+    }
+    return out;
+}
+
+test "dh shared secret test vector" {
+    const allocator = testing.allocator;
+    const xa_hex = "1234567890abcdef1234567890abcdef12345678";
+    const xb_hex = "fedcba0987654321fedcba0987654321fedcba09";
+    const ya_hex = "c44386497c31c0f76d76479d03a6f40c0cdac6c9a709f493da2c7aa8adb2cbfafe6b7833c0ded4ab5a310db1c2473066f1d3ef0a9e89f1093e7902f72337396dab1d1276ab9e6d447b62e57de71ec5b528209d8fadff8cb9b0d393131aa4a722";
+    const yb_hex = "1264d66dda8e04907145f55a2e069e6fe7b6995abdf21a846f78a72ef3a047ac1893abacd6e08749eb3d313c3513932400d16d22d3003be57dad041c40b07cf9ea5eb0cf1593ac89ba444f17fc66ee7e1d96b5d1fd2136f96b92d50bd174ad6f";
+    const s_hex = "7c1798a6ebab579cdd77e332bbab0901538801b6c73ec83c02a470e4d766ae98d8294d822827ecbac1c0bb7c6c7dea25eb6304393ac9c64e7963ef10cdb532c89da9695e550ced358895ad66b16fae3831b600b2d0e0c032203962b5140224b8";
+
+    var xa = try Managed.initSet(allocator, 0);
+    defer xa.deinit();
+    try xa.setString(16, xa_hex);
+
+    var xb = try Managed.initSet(allocator, 0);
+    defer xb.deinit();
+    try xb.setString(16, xb_hex);
+
+    var ya: [dh_pubkey_len]u8 = undefined;
+    try dhPublicKey(allocator, &xa, &ya);
+    try testing.expectEqualSlices(u8, &hexToBytes(ya_hex), &ya);
+
+    var yb: [dh_pubkey_len]u8 = undefined;
+    try dhPublicKey(allocator, &xb, &yb);
+    try testing.expectEqualSlices(u8, &hexToBytes(yb_hex), &yb);
+
+    var s: [dh_pubkey_len]u8 = undefined;
+    try dhSharedSecret(allocator, &xa, &yb, &s);
+    try testing.expectEqualSlices(u8, &hexToBytes(s_hex), &s);
+
+    var s2: [dh_pubkey_len]u8 = undefined;
+    try dhSharedSecret(allocator, &xb, &ya, &s2);
+    try testing.expectEqualSlices(u8, &s, &s2);
+}
+
+test "rc4 discard keystream" {
+    var rc = Rc4.init("Key");
+    var buf1: [10]u8 = .{0} ** 10;
+    var buf2: [10]u8 = .{0} ** 10;
+    rc.cryptInPlace(&buf1);
+    var rc2 = Rc4.init("Key");
+    rc2.discardKeystream(rc4_discard_len);
+    rc2.cryptInPlace(&buf2);
+    try testing.expect(!std.mem.eql(u8, &buf1, &buf2));
+}
+
+test "hash req1 deterministic" {
+    const s = hexToBytes("7c1798a6ebab579cdd77e332bbab0901538801b6c73ec83c02a470e4d766ae98d8294d822827ecbac1c0bb7c6c7dea25eb6304393ac9c64e7963ef10cdb532c89da9695e550ced358895ad66b16fae3831b600b2d0e0c032203962b5140224b8");
+    var h1: [hash_len]u8 = undefined;
+    var h2: [hash_len]u8 = undefined;
+    hashReq1(&s, &h1);
+    hashReq1(&s, &h2);
+    try testing.expectEqualSlices(u8, &h1, &h2);
+}
+
+test "mse loopback handshake" {
+    const allocator = testing.allocator;
+    const skey: [skey_len]u8 = .{0xAB} ** skey_len;
+
+    const listen_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try listen_addr.listen(.{ .reuse_address = true });
+    defer server.deinit();
+    const port = server.listen_address.in.getPort();
+
+    const ServerCtx = struct {
+        server: *std.net.Server,
+        skey: [skey_len]u8,
+        fn run(ctx: *@This()) void {
+            const conn = ctx.server.accept() catch return;
+            var peer_stream = conn.stream;
+            defer peer_stream.close();
+            _ = handshakeResponder(allocator, &peer_stream, .{
+                .skey = ctx.skey,
+                .crypto_provide = crypto_rc4,
+            }) catch return;
+        }
+    };
+    var ctx = ServerCtx{ .server = &server, .skey = skey };
+    const server_thread = try std.Thread.spawn(.{}, ServerCtx.run, .{&ctx});
+
+    const client_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
+    var stream = try std.net.tcpConnectToAddress(client_addr);
+
+    const ia = "test-ia-payload";
+    var mse_stream = try handshakeInitiator(allocator, &stream, .{
+        .skey = skey,
+        .crypto_provide = crypto_rc4,
+        .ia = ia,
+    });
+    defer mse_stream.close();
+
+    server_thread.join();
+
+    try testing.expect(mse_stream.method == .rc4);
+}

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -26,6 +26,9 @@ pub const PeerConnection = struct {
     /// directly. Set by the session after `init` from its own proxy config.
     proxy: ?proxy_mod.Proxy,
 
+    /// When set with `proxy`, connect via SOCKS to this hostname (e.g. `.onion`).
+    connect_host: ?[]const u8 = null,
+
     // Protocol state
     am_choking: bool,
     am_interested: bool,
@@ -63,6 +66,37 @@ pub const PeerConnection = struct {
             .stream = null,
             .state = .connecting,
             .proxy = null,
+            .connect_host = null,
+            .am_choking = true,
+            .am_interested = false,
+            .peer_choking = true,
+            .peer_interested = false,
+            .peer_bitfield = null,
+            .peer_id = null,
+            .supports_extensions = false,
+            .peer_ut_metadata_id = null,
+            .peer_metadata_size = null,
+            .recv_buf = .empty,
+            .send_buf = .empty,
+            .send_pos = 0,
+            .pending_requests = .empty,
+            .bytes_downloaded = 0,
+            .bytes_uploaded = 0,
+            .last_recv_time = std.time.timestamp(),
+            .last_send_time = std.time.timestamp(),
+        };
+    }
+
+    /// Outbound connection to a Tor hidden service or other proxied hostname.
+    pub fn initOnion(allocator: Allocator, host: []const u8, port: u16) !PeerConnection {
+        const host_owned = try allocator.dupe(u8, host);
+        return .{
+            .allocator = allocator,
+            .address = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, port),
+            .stream = null,
+            .state = .connecting,
+            .proxy = null,
+            .connect_host = host_owned,
             .am_choking = true,
             .am_interested = false,
             .peer_choking = true,
@@ -85,6 +119,7 @@ pub const PeerConnection = struct {
 
     pub fn deinit(self: *PeerConnection) void {
         if (self.stream) |s| s.close();
+        if (self.connect_host) |h| self.allocator.free(h);
         if (self.peer_bitfield) |*bf| bf.deinit(self.allocator);
         self.recv_buf.deinit(self.allocator);
         self.send_buf.deinit(self.allocator);
@@ -99,10 +134,18 @@ pub const PeerConnection = struct {
         // When a proxy is configured, tunnel through it. The handshake is
         // synchronous, so on success the stream is ready for the BT handshake.
         if (self.proxy) |px| {
-            self.stream = proxy_mod.connectThroughProxyAddr(self.allocator, px, self.address) catch {
-                self.state = .disconnected;
-                return error.ConnectionFailed;
-            };
+            if (self.connect_host) |host| {
+                const port = self.address.getPort();
+                self.stream = proxy_mod.connectThroughProxyHost(self.allocator, px, host, port) catch {
+                    self.state = .disconnected;
+                    return error.ConnectionFailed;
+                };
+            } else {
+                self.stream = proxy_mod.connectThroughProxyAddr(self.allocator, px, self.address) catch {
+                    self.state = .disconnected;
+                    return error.ConnectionFailed;
+                };
+            }
             self.state = .handshaking;
             return;
         }

--- a/src/peer_announce.zig
+++ b/src/peer_announce.zig
@@ -3,59 +3,59 @@
 //!
 //! Each seeder publishes one of these per torrent. The `d` tag carries the
 //! V1 infohash hex, making the event replaceable per (pubkey, infohash) so
-//! seeders can refresh `(ip, port)` without spamming the relay. Subscribers
-//! filter on `#d=<infohash>` to find current seeders.
+//! seeders can refresh their endpoint without spamming the relay.
 //!
-//! NIP-33 reserves the 30000-39999 range for parameterized replaceable; 30078
-//! is the same kind nostr's `nostr-tools` uses for "app data" — we tag-scope
-//! by `d=infohash` so it doesn't collide with other apps.
+//! IPv4 schema:
+//!   ["d", "<infohash_hex>"], ["ip", "<ipv4>"], ["port", "<port>"], ["client", "carl/0.1"]
 //!
-//! Schema:
-//!   {
-//!     "kind": 30078,
-//!     "tags": [
-//!       ["d", "<infohash_hex>"],
-//!       ["ip", "<ipv4>"],
-//!       ["port", "<port>"],
-//!       ["client", "carl/0.1"]
-//!     ],
-//!     "content": ""
-//!   }
+//! Tor hidden-service schema (onion-only, no `ip` tag):
+//!   ["d", "<infohash_hex>"], ["host", "<v3.onion>"], ["port", "<port>"], ["client", "carl/0.1"]
 //!
-//! Carl rejects incoming peer-announce events whose IP is loopback, private,
-//! link-local, or unspecified — relays must not be able to redirect peers to
-//! attacker-controlled networks.
+//! Carl rejects incoming IPv4 peer-announces whose IP is loopback, private,
+//! link-local, or unspecified.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const nostr = @import("nostr.zig");
 const secp = @import("secp.zig");
 
-const log = std.log.scoped(.peer_announce);
-
 pub const kind_peer_announce: u32 = 30078;
+
+/// Tor v3 onion hostname: 56 base32 chars + `.onion` (62 bytes total).
+pub const v3_onion_host_len: usize = 62;
 
 pub const Error = error{
     InvalidEvent,
     MissingD,
     BadInfoHash,
     BadIp,
+    BadHost,
     BadPort,
     UnsafeIp,
     OutOfMemory,
 };
 
+pub const Endpoint = union(enum) {
+    ipv4: struct {
+        ip: [4]u8,
+        port: u16,
+    },
+    /// `host` is borrowed from the event tag when parsed from the network.
+    onion: struct {
+        host: []const u8,
+        port: u16,
+    },
+};
+
 /// A peer announce parsed from the network.
 pub const PeerAnnounce = struct {
     info_hash: [20]u8,
-    ip: [4]u8,
-    port: u16,
+    endpoint: Endpoint,
     pubkey: [32]u8,
     created_at: i64,
 };
 
-/// Build and sign a kind-30078 event announcing that `pk` is seeding
-/// `info_hash` at `ip:port`.
+/// Build and sign a kind-30078 event for a public IPv4 endpoint.
 pub fn build(
     allocator: Allocator,
     sk: secp.SecretKey,
@@ -72,13 +72,114 @@ pub fn build(
     var port_buf: [6]u8 = undefined;
     const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch unreachable;
 
+    const d_tag = [_][]const u8{ "d", &infohash_hex };
+    const ip_tag = [_][]const u8{ "ip", ip_str };
+    const port_tag = [_][]const u8{ "port", port_str };
+    const client_tag = [_][]const u8{ "client", "carl/0.1" };
+    const tag_sets = [_][]const []const u8{ d_tag[0..], ip_tag[0..], port_tag[0..], client_tag[0..] };
+    return buildTagged(allocator, sk, pk, &tag_sets);
+}
+
+/// Build and sign a kind-30078 event for a Tor v3 hidden service.
+pub fn buildOnion(
+    allocator: Allocator,
+    sk: secp.SecretKey,
+    pk: secp.PublicKey,
+    info_hash: [20]u8,
+    onion_host: []const u8,
+    port: u16,
+) !nostr.Event {
+    if (!isValidV3OnionHost(onion_host)) return error.BadHost;
+
+    var infohash_hex: [40]u8 = undefined;
+    secp.toHex(&info_hash, &infohash_hex);
+
+    var port_buf: [6]u8 = undefined;
+    const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch unreachable;
+
+    const d_tag = [_][]const u8{ "d", &infohash_hex };
+    const host_tag = [_][]const u8{ "host", onion_host };
+    const port_tag = [_][]const u8{ "port", port_str };
+    const client_tag = [_][]const u8{ "client", "carl/0.1" };
+    const tag_sets = [_][]const []const u8{ d_tag[0..], host_tag[0..], port_tag[0..], client_tag[0..] };
+    return buildTagged(allocator, sk, pk, &tag_sets);
+}
+
+/// Parse and validate a kind-30078 event. Supports legacy `ip` tags and `host`
+/// tags for `.onion` endpoints. Caller must have already verified the signature.
+pub fn parse(event: nostr.Event) Error!PeerAnnounce {
+    if (event.kind != kind_peer_announce) return error.InvalidEvent;
+
+    const d = event.firstTagValue("d") orelse return error.MissingD;
+    if (d.len != 40) return error.BadInfoHash;
+    var info_hash: [20]u8 = undefined;
+    secp.fromHex(d, &info_hash) catch return error.BadInfoHash;
+
+    const port_str = event.firstTagValue("port") orelse return error.BadPort;
+    const port = std.fmt.parseUnsigned(u16, port_str, 10) catch return error.BadPort;
+    if (port == 0) return error.BadPort;
+
+    if (event.firstTagValue("ip")) |ip_str| {
+        const ip = parseIpv4(ip_str) orelse return error.BadIp;
+        if (!isRoutable(ip)) return error.UnsafeIp;
+        return .{
+            .info_hash = info_hash,
+            .endpoint = .{ .ipv4 = .{ .ip = ip, .port = port } },
+            .pubkey = event.pubkey,
+            .created_at = event.created_at,
+        };
+    }
+
+    const host = event.firstTagValue("host") orelse return error.BadHost;
+    if (!isValidV3OnionHost(host)) return error.BadHost;
+
+    return .{
+        .info_hash = info_hash,
+        .endpoint = .{ .onion = .{ .host = host, .port = port } },
+        .pubkey = event.pubkey,
+        .created_at = event.created_at,
+    };
+}
+
+/// True for a Tor v3 `.onion` hostname (56-char base32 label + `.onion`).
+pub fn isValidV3OnionHost(host: []const u8) bool {
+    if (host.len != v3_onion_host_len) return false;
+    if (!std.mem.endsWith(u8, host, ".onion")) return false;
+    const label = host[0 .. host.len - 6];
+    for (label) |c| {
+        const ok = (c >= 'a' and c <= 'z') or (c >= '2' and c <= '7');
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// Reject loopback, private, link-local, CGNAT, unspecified, broadcast, multicast.
+pub fn isRoutable(ip: [4]u8) bool {
+    if (ip[0] == 0) return false;
+    if (ip[0] == 127) return false;
+    if (ip[0] == 10) return false;
+    if (ip[0] == 172 and (ip[1] >= 16 and ip[1] <= 31)) return false;
+    if (ip[0] == 192 and ip[1] == 168) return false;
+    if (ip[0] == 169 and ip[1] == 254) return false;
+    if (ip[0] == 100 and (ip[1] >= 64 and ip[1] <= 127)) return false;
+    if (ip[0] >= 224 and ip[0] <= 239) return false;
+    if (ip[0] >= 240) return false;
+    if (ip[0] == 255 and ip[1] == 255 and ip[2] == 255 and ip[3] == 255) return false;
+    return true;
+}
+
+fn buildTagged(
+    allocator: Allocator,
+    sk: secp.SecretKey,
+    pk: secp.PublicKey,
+    tag_sets: []const []const []const u8,
+) !nostr.Event {
     var tag_list: std.ArrayList(nostr.Tag) = .empty;
     errdefer freeTagList(allocator, &tag_list);
 
-    try appendTag(allocator, &tag_list, &[_][]const u8{ "d", &infohash_hex });
-    try appendTag(allocator, &tag_list, &[_][]const u8{ "ip", ip_str });
-    try appendTag(allocator, &tag_list, &[_][]const u8{ "port", port_str });
-    try appendTag(allocator, &tag_list, &[_][]const u8{ "client", "carl/0.1" });
+    for (tag_sets) |parts| {
+        try appendTag(allocator, &tag_list, parts);
+    }
 
     const tags_owned = tag_list.toOwnedSlice(allocator) catch return error.OutOfMemory;
     errdefer {
@@ -98,52 +199,6 @@ pub fn build(
     };
     nostr.sign(&ev, sk, allocator) catch return error.OutOfMemory;
     return ev;
-}
-
-/// Parse and validate a kind-30078 event. Returns the announce only if the
-/// IP is routable (rejects private/loopback/link-local/unspecified).
-/// Caller must have already signature-verified `event`.
-pub fn parse(event: nostr.Event) Error!PeerAnnounce {
-    if (event.kind != kind_peer_announce) return error.InvalidEvent;
-
-    const d = event.firstTagValue("d") orelse return error.MissingD;
-    if (d.len != 40) return error.BadInfoHash;
-    var info_hash: [20]u8 = undefined;
-    secp.fromHex(d, &info_hash) catch return error.BadInfoHash;
-
-    const ip_str = event.firstTagValue("ip") orelse return error.BadIp;
-    const ip = parseIpv4(ip_str) orelse return error.BadIp;
-    if (!isRoutable(ip)) return error.UnsafeIp;
-
-    const port_str = event.firstTagValue("port") orelse return error.BadPort;
-    const port = std.fmt.parseUnsigned(u16, port_str, 10) catch return error.BadPort;
-    if (port == 0) return error.BadPort;
-
-    return .{
-        .info_hash = info_hash,
-        .ip = ip,
-        .port = port,
-        .pubkey = event.pubkey,
-        .created_at = event.created_at,
-    };
-}
-
-/// Reject loopback (127/8), private (10/8, 172.16/12, 192.168/16), link-local
-/// (169.254/16), CGNAT (100.64/10), unspecified (0.0.0.0), broadcast, and
-/// multicast (224/4). These are not routable on the public Internet and
-/// could be used to redirect a downloader to an attacker-controlled LAN host.
-pub fn isRoutable(ip: [4]u8) bool {
-    if (ip[0] == 0) return false; // 0.0.0.0/8
-    if (ip[0] == 127) return false; // loopback
-    if (ip[0] == 10) return false; // 10/8
-    if (ip[0] == 172 and (ip[1] >= 16 and ip[1] <= 31)) return false; // 172.16/12
-    if (ip[0] == 192 and ip[1] == 168) return false; // 192.168/16
-    if (ip[0] == 169 and ip[1] == 254) return false; // 169.254/16
-    if (ip[0] == 100 and (ip[1] >= 64 and ip[1] <= 127)) return false; // CGNAT
-    if (ip[0] >= 224 and ip[0] <= 239) return false; // multicast
-    if (ip[0] >= 240) return false; // reserved
-    if (ip[0] == 255 and ip[1] == 255 and ip[2] == 255 and ip[3] == 255) return false; // broadcast
-    return true;
 }
 
 fn parseIpv4(s: []const u8) ?[4]u8 {
@@ -199,7 +254,7 @@ fn appendTag(
 // Tests
 // ===========================================================================
 
-test "build + parse round trip" {
+test "build + parse ipv4 round trip" {
     const allocator = std.testing.allocator;
 
     var sk: secp.SecretKey = undefined;
@@ -216,8 +271,30 @@ test "build + parse round trip" {
 
     const ann = try parse(ev);
     try std.testing.expectEqualSlices(u8, &info_hash, &ann.info_hash);
-    try std.testing.expectEqualSlices(u8, &[_]u8{ 203, 0, 113, 7 }, &ann.ip);
-    try std.testing.expectEqual(@as(u16, 6881), ann.port);
+    try std.testing.expect(ann.endpoint == .ipv4);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 203, 0, 113, 7 }, &ann.endpoint.ipv4.ip);
+    try std.testing.expectEqual(@as(u16, 6881), ann.endpoint.ipv4.port);
+}
+
+test "build + parse onion round trip" {
+    const allocator = std.testing.allocator;
+    var label: [56]u8 = undefined;
+    @memset(&label, 'a');
+    var host_buf: [v3_onion_host_len]u8 = undefined;
+    const onion = std.fmt.bufPrint(&host_buf, "{s}.onion", .{&label}) catch unreachable;
+
+    var sk: secp.SecretKey = undefined;
+    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try secp.publicKeyFromSecret(sk);
+
+    const info_hash: [20]u8 = .{0xAB} ** 20;
+    var ev = try buildOnion(allocator, sk, pk, info_hash, onion, 80);
+    defer ev.deinit(allocator);
+
+    const ann = try parse(ev);
+    try std.testing.expect(ann.endpoint == .onion);
+    try std.testing.expectEqualStrings(onion, ann.endpoint.onion.host);
+    try std.testing.expectEqual(@as(u16, 80), ann.endpoint.onion.port);
 }
 
 test "parse rejects private IP" {
@@ -235,37 +312,13 @@ test "parse rejects private IP" {
     try std.testing.expectError(error.UnsafeIp, parse(ev));
 }
 
-test "parse rejects loopback" {
+test "parse rejects bad onion host" {
     const allocator = std.testing.allocator;
     var sk: secp.SecretKey = undefined;
     try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
     const pk = try secp.publicKeyFromSecret(sk);
     const info_hash: [20]u8 = .{0} ** 20;
-    var ev = try build(allocator, sk, pk, info_hash, .{ 127, 0, 0, 1 }, 6881);
-    defer ev.deinit(allocator);
-    try std.testing.expectError(error.UnsafeIp, parse(ev));
-}
-
-test "parse rejects link-local" {
-    const allocator = std.testing.allocator;
-    var sk: secp.SecretKey = undefined;
-    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
-    const pk = try secp.publicKeyFromSecret(sk);
-    const info_hash: [20]u8 = .{0} ** 20;
-    var ev = try build(allocator, sk, pk, info_hash, .{ 169, 254, 1, 1 }, 6881);
-    defer ev.deinit(allocator);
-    try std.testing.expectError(error.UnsafeIp, parse(ev));
-}
-
-test "parse rejects multicast" {
-    const allocator = std.testing.allocator;
-    var sk: secp.SecretKey = undefined;
-    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
-    const pk = try secp.publicKeyFromSecret(sk);
-    const info_hash: [20]u8 = .{0} ** 20;
-    var ev = try build(allocator, sk, pk, info_hash, .{ 239, 1, 2, 3 }, 6881);
-    defer ev.deinit(allocator);
-    try std.testing.expectError(error.UnsafeIp, parse(ev));
+    try std.testing.expectError(error.BadHost, buildOnion(allocator, sk, pk, info_hash, "not-an-onion", 80));
 }
 
 test "parse rejects wrong kind" {
@@ -283,14 +336,15 @@ test "parse rejects wrong kind" {
 
 test "isRoutable spot checks" {
     try std.testing.expect(isRoutable(.{ 8, 8, 8, 8 }));
-    try std.testing.expect(isRoutable(.{ 1, 1, 1, 1 }));
-    try std.testing.expect(isRoutable(.{ 203, 0, 113, 5 }));
-    try std.testing.expect(!isRoutable(.{ 0, 0, 0, 0 }));
     try std.testing.expect(!isRoutable(.{ 127, 0, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 10, 0, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 172, 20, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 192, 168, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 169, 254, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 100, 64, 0, 1 }));
-    try std.testing.expect(!isRoutable(.{ 255, 255, 255, 255 }));
+}
+
+test "isValidV3OnionHost" {
+    var label: [56]u8 = undefined;
+    @memset(&label, 'a');
+    var host_buf: [v3_onion_host_len]u8 = undefined;
+    const ok = std.fmt.bufPrint(&host_buf, "{s}.onion", .{&label}) catch unreachable;
+    try std.testing.expect(isValidV3OnionHost(ok));
+    try std.testing.expect(!isValidV3OnionHost("short.onion"));
+    try std.testing.expect(!isValidV3OnionHost("aaaa.com"));
 }

--- a/src/peer_announce.zig
+++ b/src/peer_announce.zig
@@ -119,23 +119,26 @@ pub fn parse(event: nostr.Event) Error!PeerAnnounce {
     const port = std.fmt.parseUnsigned(u16, port_str, 10) catch return error.BadPort;
     if (port == 0) return error.BadPort;
 
-    if (event.firstTagValue("ip")) |ip_str| {
-        const ip = parseIpv4(ip_str) orelse return error.BadIp;
-        if (!isRoutable(ip)) return error.UnsafeIp;
-        return .{
-            .info_hash = info_hash,
-            .endpoint = .{ .ipv4 = .{ .ip = ip, .port = port } },
-            .pubkey = event.pubkey,
-            .created_at = event.created_at,
-        };
+    // Prefer a valid `host` (.onion) over `ip` when both are present so a signed
+    // event cannot smuggle a clearnet endpoint alongside an onion hostname.
+    if (event.firstTagValue("host")) |host| {
+        if (isValidV3OnionHost(host)) {
+            return .{
+                .info_hash = info_hash,
+                .endpoint = .{ .onion = .{ .host = host, .port = port } },
+                .pubkey = event.pubkey,
+                .created_at = event.created_at,
+            };
+        }
+        return error.BadHost;
     }
 
-    const host = event.firstTagValue("host") orelse return error.BadHost;
-    if (!isValidV3OnionHost(host)) return error.BadHost;
-
+    const ip_str = event.firstTagValue("ip") orelse return error.BadIp;
+    const ip = parseIpv4(ip_str) orelse return error.BadIp;
+    if (!isRoutable(ip)) return error.UnsafeIp;
     return .{
         .info_hash = info_hash,
-        .endpoint = .{ .onion = .{ .host = host, .port = port } },
+        .endpoint = .{ .ipv4 = .{ .ip = ip, .port = port } },
         .pubkey = event.pubkey,
         .created_at = event.created_at,
     };

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ws = @import("ws.zig");
+const proxy_mod = @import("proxy.zig");
 const nostr = @import("nostr.zig");
 
 const log = std.log.scoped(.relay);
@@ -27,8 +28,8 @@ pub const Relay = struct {
     url: []const u8, // borrowed
     conn: ws.Conn,
 
-    pub fn connect(allocator: Allocator, url: []const u8) Error!Relay {
-        const conn = ws.Conn.connect(allocator, url) catch |err| {
+    pub fn connect(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Relay {
+        const conn = ws.Conn.connect(allocator, url, .{ .proxy = proxy }) catch |err| {
             log.warn("relay connect to {s} failed: {}", .{ url, err });
             return error.ConnectFailed;
         };

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -29,7 +29,13 @@ pub const Relay = struct {
     conn: ws.Conn,
 
     pub fn connect(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Relay {
-        const conn = ws.Conn.connect(allocator, url, .{ .proxy = proxy }) catch |err| {
+        // `wss://` over SOCKS is not implemented yet; use clearnet for relays while
+        // `--proxy` still tunnels BitTorrent peer TCP (including `.onion` hosts).
+        const relay_proxy = effectiveRelayProxy(url, proxy);
+        if (proxy != null and relay_proxy == null) {
+            log.debug("relay {s}: clearnet wss (peer traffic still uses --proxy)", .{url});
+        }
+        const conn = ws.Conn.connect(allocator, url, .{ .proxy = relay_proxy }) catch |err| {
             log.warn("relay connect to {s} failed: {}", .{ url, err });
             return error.ConnectFailed;
         };
@@ -244,6 +250,14 @@ pub const default_relays: []const []const u8 = &.{
     "wss://relay.nostr.band",
 };
 
+/// Nostr relays are `wss://`; proxied WebSocket TLS is not supported yet.
+fn effectiveRelayProxy(url: []const u8, proxy: ?proxy_mod.Proxy) ?proxy_mod.Proxy {
+    if (proxy == null) return null;
+    if (std.mem.startsWith(u8, url, "wss://") or std.mem.startsWith(u8, url, "ws://"))
+        return null;
+    return proxy;
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
@@ -254,6 +268,12 @@ pub const default_relays: []const []const u8 = &.{
 test "default_relays is non-empty and all wss://" {
     try std.testing.expect(default_relays.len >= 1);
     for (default_relays) |r| try std.testing.expect(std.mem.startsWith(u8, r, "wss://"));
+}
+
+test "effectiveRelayProxy strips wss proxy" {
+    const px = proxy_mod.Proxy{ .scheme = .socks5h, .host = "127.0.0.1", .port = 9050 };
+    try std.testing.expect(effectiveRelayProxy("wss://nos.lol", px) == null);
+    try std.testing.expect(effectiveRelayProxy("http://tracker", px) != null);
 }
 
 test "SearchOptions defaults are sensible" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -33,6 +33,8 @@ fn sigintHandler(_: i32) callconv(.c) void {
 
 pub const Mode = enum { download, seed };
 
+pub const ListenBind = enum { any, loopback };
+
 pub const Session = struct {
     allocator: Allocator,
     meta: metainfo.Metainfo,
@@ -87,6 +89,11 @@ pub const Session = struct {
     // listener are disabled to avoid leaking the real IP.
     proxy: ?proxy_mod.Proxy,
 
+    /// Where the inbound listener binds when active.
+    listen_bind: ListenBind,
+    /// Tor hidden-service seed: no tracker/DHT (would leak or bypass Tor).
+    tor_hidden: bool,
+
     // Progress tracking
     start_time: i64,
     last_progress_time: i64,
@@ -99,6 +106,8 @@ pub const Session = struct {
         mode: Mode,
         listen_port: u16,
         proxy: ?proxy_mod.Proxy,
+        listen_bind: ListenBind,
+        tor_hidden: bool,
     ) !Session {
         const total_length = piece_mod.totalLength(meta.files);
         const num_pieces = piece_mod.numPieces(total_length, meta.piece_length);
@@ -144,7 +153,11 @@ pub const Session = struct {
         // peers would reveal the real IP to whoever connects.
         var listener: ?std.net.Server = null;
         if (proxy == null and (mode == .seed or our_bitfield.count() > 0)) {
-            const addr = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, listen_port);
+            const bind_ip: [4]u8 = switch (listen_bind) {
+                .any => .{ 0, 0, 0, 0 },
+                .loopback => .{ 127, 0, 0, 1 },
+            };
+            const addr = std.net.Address.initIp4(bind_ip, listen_port);
             listener = addr.listen(.{ .reuse_address = true }) catch null;
         }
 
@@ -181,6 +194,8 @@ pub const Session = struct {
             .dht_instance = null,
             .dht_failed = false,
             .proxy = proxy,
+            .listen_bind = listen_bind,
+            .tor_hidden = tor_hidden,
             .start_time = now,
             .last_progress_time = now,
             .last_progress_bytes = 0,
@@ -238,14 +253,18 @@ pub const Session = struct {
 
         // Multi-tracker announce (BEP 12) / DHT peer discovery
         const has_trackers = (self.meta.announce.len > 0) or (self.meta.announce_list != null);
-        if (has_trackers) {
-            stderr.print("announcing to tracker...\n", .{}) catch {};
-        }
-        self.doMultiTrackerAnnounce(.started) catch |err| {
+        if (!self.tor_hidden) {
             if (has_trackers) {
-                stderr.print("all trackers failed: {}\n", .{err}) catch {};
+                stderr.print("announcing to tracker...\n", .{}) catch {};
             }
-        };
+            self.doMultiTrackerAnnounce(.started) catch |err| {
+                if (has_trackers) {
+                    stderr.print("all trackers failed: {}\n", .{err}) catch {};
+                }
+            };
+        } else {
+            log.info("tor hidden-service mode: tracker and DHT announces disabled", .{});
+        }
 
         stdout.print("session started: {d} pieces, {d} bytes\n", .{ self.num_pieces, self.total_length }) catch {};
 
@@ -255,7 +274,11 @@ pub const Session = struct {
                 self.doMultiTrackerAnnounce(.completed) catch {};
                 // Don't open an inbound listener when proxied (would leak our IP).
                 if (self.listener == null and self.proxy == null) {
-                    const addr = std.net.Address.initIp4(.{ 0, 0, 0, 0 }, self.listen_port);
+                    const bind_ip: [4]u8 = switch (self.listen_bind) {
+                        .any => .{ 0, 0, 0, 0 },
+                        .loopback => .{ 127, 0, 0, 1 },
+                    };
+                    const addr = std.net.Address.initIp4(bind_ip, self.listen_port);
                     self.listener = addr.listen(.{ .reuse_address = true }) catch null;
                 }
                 self.mode = .seed;
@@ -290,8 +313,10 @@ pub const Session = struct {
         if (shutdown_requested.load(.acquire)) {
             stderr.print("\nshutting down gracefully...\n", .{}) catch {};
         }
-        self.doMultiTrackerAnnounce(.stopped) catch {};
-        stderr.print("sent stopped announce to tracker\n", .{}) catch {};
+        if (!self.tor_hidden) {
+            self.doMultiTrackerAnnounce(.stopped) catch {};
+            stderr.print("sent stopped announce to tracker\n", .{}) catch {};
+        }
     }
 
     fn buildPollFds(self: *Session, fds: *[max_peers + 1]std.posix.pollfd) usize {
@@ -1003,15 +1028,17 @@ pub const Session = struct {
         // Run choking algorithm
         self.runChokingAlgorithm();
 
-        // Re-announce to trackers at the tracker-provided interval
-        const interval_secs = std.math.cast(i64, self.tracker_interval) orelse 1800;
-        if (now - self.last_announce_time > interval_secs) {
-            self.doMultiTrackerAnnounce(.none) catch {};
-        }
+        if (!self.tor_hidden) {
+            // Re-announce to trackers at the tracker-provided interval
+            const interval_secs = std.math.cast(i64, self.tracker_interval) orelse 1800;
+            if (now - self.last_announce_time > interval_secs) {
+                self.doMultiTrackerAnnounce(.none) catch {};
+            }
 
-        // DHT: retry more aggressively when we have zero peers
-        if (self.peers.items.len == 0 and now - self.last_announce_time > 30) {
-            self.tryDhtPeerDiscovery() catch {};
+            // DHT: retry more aggressively when we have zero peers
+            if (self.peers.items.len == 0 and now - self.last_announce_time > 30) {
+                self.tryDhtPeerDiscovery() catch {};
+            }
         }
     }
 
@@ -1172,6 +1199,23 @@ pub const Session = struct {
         p.* = peer_mod.PeerConnection.init(self.allocator, addr);
         p.proxy = self.proxy;
 
+        try self.finishPeerConnect(p);
+    }
+
+    /// Connect to a Tor hidden service (or other hostname) via the session proxy.
+    pub fn connectOnionPeer(self: *Session, host: []const u8, port: u16) !void {
+        if (self.peers.items.len >= max_peers) return;
+        const px = self.proxy orelse return error.ConnectionFailed;
+
+        const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(p);
+        p.* = try peer_mod.PeerConnection.initOnion(self.allocator, host, port);
+        errdefer p.deinit();
+        p.proxy = px;
+        try self.finishPeerConnect(p);
+    }
+
+    fn finishPeerConnect(self: *Session, p: *peer_mod.PeerConnection) !void {
         p.connect() catch {
             p.deinit();
             self.allocator.destroy(p);

--- a/src/tor_control.zig
+++ b/src/tor_control.zig
@@ -111,6 +111,11 @@ fn connectControl(allocator: Allocator, addr_str: []const u8) !std.net.Stream {
     const host = addr_str[0..colon];
     const port = std.fmt.parseUnsigned(u16, addr_str[colon + 1 ..], 10) catch return error.ConnectFailed;
 
+    if (!isLoopbackControlHost(host)) {
+        log.err("refusing non-loopback Tor control host '{s}' (use 127.0.0.1 or localhost)", .{host});
+        return error.ConnectFailed;
+    }
+
     const list = std.net.getAddressList(allocator, host, port) catch return error.ConnectFailed;
     defer list.deinit();
 
@@ -131,9 +136,10 @@ fn authenticate(allocator: Allocator, stream: std.net.Stream, cookie_path: []con
         hex_buf.writer(allocator).print("{x:0>2}", .{b}) catch return error.AuthFailed;
     }
 
-    var cmd_buf: [512]u8 = undefined;
-    const cmd = std.fmt.bufPrint(&cmd_buf, "AUTHENTICATE {s}\r\n", .{hex_buf.items}) catch return error.AuthFailed;
-    sendCommand(stream, cmd) catch return error.AuthFailed;
+    var cmd_list: std.ArrayList(u8) = .empty;
+    defer cmd_list.deinit(allocator);
+    cmd_list.writer(allocator).print("AUTHENTICATE {s}\r\n", .{hex_buf.items}) catch return error.AuthFailed;
+    sendCommand(stream, cmd_list.items) catch return error.AuthFailed;
     const reply = readReply(stream) catch return error.AuthFailed;
     if (!std.mem.startsWith(u8, reply, "250")) return error.AuthFailed;
 }
@@ -183,11 +189,34 @@ pub fn parseServiceId(allocator: Allocator, reply: []const u8) Error![]u8 {
         const prefix = "250-ServiceID=";
         if (std.mem.startsWith(u8, line, prefix)) {
             const id = line[prefix.len..];
-            if (id.len == 0) return error.InvalidResponse;
+            if (!isValidServiceId(id)) return error.InvalidResponse;
             return try allocator.dupe(u8, id);
         }
     }
     return error.InvalidResponse;
+}
+
+/// Tor v3 hidden-service service id: 56-char base32 (same alphabet as onion label).
+fn isValidServiceId(id: []const u8) bool {
+    if (id.len != 56) return false;
+    for (id) |c| {
+        const ok = (c >= 'a' and c <= 'z') or (c >= '2' and c <= '7');
+        if (!ok) return false;
+    }
+    return true;
+}
+
+fn isLoopbackControlHost(host: []const u8) bool {
+    if (std.mem.eql(u8, host, "localhost")) return true;
+    if (std.net.Ip4Address.parse(host, 0)) |addr| {
+        const o = std.mem.asBytes(&addr.sa.addr);
+        return o[0] == 127;
+    } else |_| {}
+    if (std.net.Ip6Address.parse(host, 0)) |addr| {
+        const o = std.mem.asBytes(&addr.sa.addr);
+        return std.mem.eql(u8, o, &[_]u8{0} ** 15 ++ .{1});
+    } else |_| {}
+    return false;
 }
 
 fn isValidV3OnionHost(host: []const u8) bool {

--- a/src/tor_control.zig
+++ b/src/tor_control.zig
@@ -1,0 +1,207 @@
+//! Minimal Tor ControlPort client for creating ephemeral v3 hidden services.
+//!
+//! Carl uses `ADD_ONION NEW:ED25519-V3` to obtain a `.onion` hostname and
+//! tears it down with `DEL_ONION` on shutdown. Authentication uses the
+//! cookie file from a local `tor` instance.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const posix = std.posix;
+
+const log = std.log.scoped(.tor);
+
+pub const Error = error{
+    ConnectFailed,
+    AuthFailed,
+    CommandFailed,
+    InvalidResponse,
+    BadOnionHost,
+    OutOfMemory,
+};
+
+pub const HiddenService = struct {
+    allocator: Allocator,
+    stream: std.net.Stream,
+    service_id: []const u8,
+    onion_host: []const u8,
+    onion_port: u16,
+
+    pub fn deinit(self: *HiddenService) void {
+        self.delOnion() catch |err| {
+            log.warn("DEL_ONION failed: {}", .{err});
+        };
+        self.allocator.free(self.service_id);
+        self.allocator.free(self.onion_host);
+        self.stream.close();
+    }
+
+    fn delOnion(self: *HiddenService) !void {
+        var cmd_buf: [128]u8 = undefined;
+        const cmd = std.fmt.bufPrint(&cmd_buf, "DEL_ONION {s}\r\n", .{self.service_id}) catch return;
+        sendCommand(self.stream, cmd) catch return;
+        _ = readReply(self.stream) catch return;
+    }
+};
+
+pub const Options = struct {
+    /// `host:port` for the ControlPort (default `127.0.0.1:9051`).
+    control_addr: []const u8 = "127.0.0.1:9051",
+    /// Path to the control cookie file (default `~/.tor/control_auth_cookie`).
+    cookie_path: ?[]const u8 = null,
+    /// Local BitTorrent listen port (HiddenServicePort target).
+    local_port: u16,
+    /// Virtual port exposed on the onion (default 80).
+    onion_port: u16 = 80,
+};
+
+/// Create a v3 hidden service forwarding `onion_port` → `127.0.0.1:local_port`.
+pub fn addOnion(allocator: Allocator, opts: Options) Error!HiddenService {
+    const stream = connectControl(allocator, opts.control_addr) catch return error.ConnectFailed;
+    errdefer stream.close();
+
+    const cookie_path = opts.cookie_path orelse defaultCookiePath(allocator) catch return error.AuthFailed;
+    defer if (opts.cookie_path == null) allocator.free(cookie_path);
+
+    authenticate(allocator, stream, cookie_path) catch return error.AuthFailed;
+
+    var cmd_buf: [256]u8 = undefined;
+    const cmd = std.fmt.bufPrint(
+        &cmd_buf,
+        "ADD_ONION NEW:ED25519-V3 Port={d},127.0.0.1:{d}\r\n",
+        .{ opts.onion_port, opts.local_port },
+    ) catch return error.CommandFailed;
+    sendCommand(stream, cmd) catch return error.CommandFailed;
+
+    const reply = readReplyAlloc(allocator, stream) catch return error.InvalidResponse;
+    defer allocator.free(reply);
+
+    const service_id = parseServiceId(allocator, reply) catch return error.InvalidResponse;
+    errdefer allocator.free(service_id);
+
+    const onion_host = std.fmt.allocPrint(allocator, "{s}.onion", .{service_id}) catch return error.OutOfMemory;
+    errdefer allocator.free(onion_host);
+
+    if (!isValidV3OnionHost(onion_host)) {
+        allocator.free(service_id);
+        allocator.free(onion_host);
+        return error.BadOnionHost;
+    }
+
+    log.info("tor hidden service {s}:{d} -> 127.0.0.1:{d}", .{
+        onion_host, opts.onion_port, opts.local_port,
+    });
+
+    return .{
+        .allocator = allocator,
+        .stream = stream,
+        .service_id = service_id,
+        .onion_host = onion_host,
+        .onion_port = opts.onion_port,
+    };
+}
+
+fn defaultCookiePath(allocator: Allocator) ![]const u8 {
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return error.OutOfMemory;
+    defer allocator.free(home);
+    return std.fmt.allocPrint(allocator, "{s}/.tor/control_auth_cookie", .{home});
+}
+
+fn connectControl(allocator: Allocator, addr_str: []const u8) !std.net.Stream {
+    const colon = std.mem.lastIndexOfScalar(u8, addr_str, ':') orelse return error.ConnectFailed;
+    const host = addr_str[0..colon];
+    const port = std.fmt.parseUnsigned(u16, addr_str[colon + 1 ..], 10) catch return error.ConnectFailed;
+
+    const list = std.net.getAddressList(allocator, host, port) catch return error.ConnectFailed;
+    defer list.deinit();
+
+    for (list.addrs) |a| {
+        if (std.net.tcpConnectToAddress(a)) |s| return s else |_| {}
+    }
+    return error.ConnectFailed;
+}
+
+fn authenticate(allocator: Allocator, stream: std.net.Stream, cookie_path: []const u8) !void {
+    const cookie = std.fs.cwd().readFileAlloc(allocator, cookie_path, 256) catch return error.AuthFailed;
+    defer allocator.free(cookie);
+    if (cookie.len == 0) return error.AuthFailed;
+
+    var hex_buf: std.ArrayList(u8) = .empty;
+    defer hex_buf.deinit(allocator);
+    for (cookie) |b| {
+        hex_buf.writer(allocator).print("{x:0>2}", .{b}) catch return error.AuthFailed;
+    }
+
+    var cmd_buf: [512]u8 = undefined;
+    const cmd = std.fmt.bufPrint(&cmd_buf, "AUTHENTICATE {s}\r\n", .{hex_buf.items}) catch return error.AuthFailed;
+    sendCommand(stream, cmd) catch return error.AuthFailed;
+    const reply = readReply(stream) catch return error.AuthFailed;
+    if (!std.mem.startsWith(u8, reply, "250")) return error.AuthFailed;
+}
+
+fn sendCommand(stream: std.net.Stream, cmd: []const u8) !void {
+    try stream.writeAll(cmd);
+}
+
+fn readReplyAlloc(allocator: Allocator, stream: std.net.Stream) ![]u8 {
+    var buf: [4096]u8 = undefined;
+    var len: usize = 0;
+    while (len < buf.len) {
+        const n = stream.read(buf[len..]) catch return error.InvalidResponse;
+        if (n == 0) break;
+        len += n;
+        if (std.mem.endsWith(u8, buf[0..len], "\r\n250 OK\r\n") or
+            std.mem.endsWith(u8, buf[0..len], "250 OK\r\n"))
+        {
+            break;
+        }
+    }
+    if (len == 0) return error.InvalidResponse;
+    return try allocator.dupe(u8, buf[0..len]);
+}
+
+fn readReply(stream: std.net.Stream) ![]const u8 {
+    var buf: [4096]u8 = undefined;
+    var len: usize = 0;
+    while (len < buf.len) {
+        const n = stream.read(buf[len..]) catch return error.InvalidResponse;
+        if (n == 0) break;
+        len += n;
+        if (std.mem.endsWith(u8, buf[0..len], "\r\n250 OK\r\n") or
+            std.mem.endsWith(u8, buf[0..len], "250 OK\r\n"))
+        {
+            break;
+        }
+    }
+    if (len == 0) return error.InvalidResponse;
+    return buf[0..len];
+}
+
+/// Extract ServiceID from a multi-line `ADD_ONION` reply.
+pub fn parseServiceId(allocator: Allocator, reply: []const u8) Error![]u8 {
+    var lines = std.mem.tokenizeAny(u8, reply, "\r\n");
+    while (lines.next()) |line| {
+        const prefix = "250-ServiceID=";
+        if (std.mem.startsWith(u8, line, prefix)) {
+            const id = line[prefix.len..];
+            if (id.len == 0) return error.InvalidResponse;
+            return try allocator.dupe(u8, id);
+        }
+    }
+    return error.InvalidResponse;
+}
+
+fn isValidV3OnionHost(host: []const u8) bool {
+    return @import("peer_announce.zig").isValidV3OnionHost(host);
+}
+
+test "parseServiceId" {
+    const allocator = std.testing.allocator;
+    var label: [56]u8 = undefined;
+    @memset(&label, 'a');
+    var reply_buf: [128]u8 = undefined;
+    const reply = try std.fmt.bufPrint(&reply_buf, "250-ServiceID={s}\r\n250 OK\r\n", .{&label});
+    const id = try parseServiceId(allocator, reply);
+    defer allocator.free(id);
+    try std.testing.expectEqual(@as(usize, 56), id.len);
+    try std.testing.expectEqualStrings(&label, id);
+}

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -16,8 +16,15 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
+const tls = std.crypto.tls;
+const proxy_mod = @import("proxy.zig");
 
 const log = std.log.scoped(.ws);
+
+pub const ConnectOptions = struct {
+    /// When set, `wss://` connects through SOCKS5/HTTP (e.g. Tor at 127.0.0.1:9050).
+    proxy: ?proxy_mod.Proxy = null,
+};
 
 pub const Error = error{
     InvalidUrl,
@@ -102,6 +109,8 @@ pub const Conn = struct {
     stream: std.net.Stream,
     /// Non-null for `wss://`; owns the TLS session used for reads/writes.
     http: ?HttpIo = null,
+    /// Non-null for `wss://` over a proxy tunnel (TLS on top of SOCKS).
+    tls_proxy: ?*TlsProxyIo = null,
 
     /// Buffer used to accumulate the payload of an in-progress message when
     /// the relay fragments. Owned by the Conn.
@@ -113,10 +122,31 @@ pub const Conn = struct {
         connection: *std.http.Client.Connection,
     };
 
-    pub fn connect(allocator: Allocator, url_input: []const u8) Error!Conn {
+    const TlsProxyIo = struct {
+        stream: std.net.Stream,
+        tls: tls.Client,
+        socket_read_buf: []u8,
+        socket_write_buf: []u8,
+        tls_read_buf: []u8,
+        tls_write_buf: []u8,
+
+        fn deinit(self: *TlsProxyIo, allocator: Allocator) void {
+            allocator.free(self.socket_read_buf);
+            allocator.free(self.socket_write_buf);
+            allocator.free(self.tls_read_buf);
+            allocator.free(self.tls_write_buf);
+            self.stream.close();
+            allocator.destroy(self);
+        }
+    };
+
+    pub fn connect(allocator: Allocator, url_input: []const u8, options: ConnectOptions) Error!Conn {
         const url = try parseUrl(url_input);
 
         if (url.secure) {
+            if (options.proxy) |px| {
+                return connectWssProxied(allocator, url, px);
+            }
             const client = try allocator.create(std.http.Client);
             client.* = .{ .allocator = allocator };
 
@@ -181,6 +211,8 @@ pub const Conn = struct {
             h.client.connection_pool.release(h.connection);
             h.client.deinit();
             self.allocator.destroy(h.client);
+        } else if (self.tls_proxy) |t| {
+            t.deinit(self.allocator);
         } else {
             self.stream.close();
         }
@@ -291,6 +323,57 @@ pub const Conn = struct {
     fn performHandshake(self: *Conn, url: Url) Error!void {
         if (self.http) |h| return performHandshakeHttps(self, url, h);
         return performHandshakePlain(self, url);
+    }
+
+    fn connectWssProxied(allocator: Allocator, url: Url, px: proxy_mod.Proxy) Error!Conn {
+        const stream = proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch {
+            log.warn("proxy connect to {s}:{d} failed", .{ url.host, url.port });
+            return error.ConnectFailed;
+        };
+        errdefer stream.close();
+
+        const min = tls.Client.min_buffer_len;
+        const tp = try allocator.create(TlsProxyIo);
+        errdefer allocator.destroy(tp);
+
+        tp.socket_read_buf = try allocator.alloc(u8, min);
+        errdefer allocator.free(tp.socket_read_buf);
+        tp.socket_write_buf = try allocator.alloc(u8, min);
+        errdefer allocator.free(tp.socket_write_buf);
+        tp.tls_read_buf = try allocator.alloc(u8, min);
+        errdefer allocator.free(tp.tls_read_buf);
+        tp.tls_write_buf = try allocator.alloc(u8, min);
+        errdefer allocator.free(tp.tls_write_buf);
+
+        tp.stream = stream;
+        var sr = stream.reader(tp.socket_read_buf);
+        var sw = stream.writer(tp.socket_write_buf);
+
+        var ca_bundle: std.crypto.Certificate.Bundle = .{};
+        ca_bundle.rescan(allocator) catch return error.TlsInitFailed;
+        defer ca_bundle.deinit(allocator);
+
+        tp.tls = tls.Client.init(sr.interface(), &sw.interface, .{
+            .host = .{ .explicit = url.host },
+            .ca = .{ .bundle = ca_bundle },
+            .read_buffer = tp.tls_read_buf,
+            .write_buffer = tp.tls_write_buf,
+            .allow_truncation_attacks = true,
+        }) catch return error.TlsInitFailed;
+
+        var conn = Conn{
+            .allocator = allocator,
+            .stream = stream,
+            .http = null,
+            .tls_proxy = tp,
+            .fragment_buf = .empty,
+            .fragment_opcode = null,
+        };
+        errdefer conn.deinit();
+
+        try conn.performHandshake(url);
+        setRecvTimeout(conn.stream, 30);
+        return conn;
     }
 
     /// `wss://` upgrade via `std.http.Client` — the same stack as HTTPS
@@ -510,6 +593,11 @@ pub const Conn = struct {
             const w = h.connection.writer();
             w.writeAll(buf) catch return error.SendFailed;
             h.connection.flush() catch return error.SendFailed;
+        } else if (self.tls_proxy) |t| {
+            t.tls.writer.writeAll(buf) catch return error.SendFailed;
+            t.tls.writer.flush() catch return error.SendFailed;
+            var sw = t.stream.writer(t.socket_write_buf);
+            sw.interface.flush() catch return error.SendFailed;
         } else {
             var off: usize = 0;
             while (off < buf.len) {
@@ -524,6 +612,9 @@ pub const Conn = struct {
         if (self.http) |h| {
             const r = h.connection.reader();
             return r.readSliceShort(buf) catch return error.RecvFailed;
+        }
+        if (self.tls_proxy) |t| {
+            return t.tls.reader.readSliceShort(buf) catch return error.RecvFailed;
         }
         const n = posix.recv(self.stream.handle, buf, 0) catch |err| switch (err) {
             error.WouldBlock => return error.Timeout,

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -122,19 +122,21 @@ pub const Conn = struct {
         connection: *std.http.Client.Connection,
     };
 
+    const tls_io_buf_len = tls.max_ciphertext_record_len;
+
     const TlsProxyIo = struct {
         stream: std.net.Stream,
+        socket_reader: std.net.Stream.Reader,
+        socket_writer: std.net.Stream.Writer,
         tls: tls.Client,
-        socket_read_buf: []u8,
-        socket_write_buf: []u8,
-        tls_read_buf: []u8,
-        tls_write_buf: []u8,
+        ca_bundle: std.crypto.Certificate.Bundle,
+        socket_read_buf: [tls_io_buf_len]u8,
+        socket_write_buf: [tls_io_buf_len]u8,
+        tls_read_buf: [tls_io_buf_len]u8,
+        tls_write_buf: [tls_io_buf_len]u8,
 
         fn deinit(self: *TlsProxyIo, allocator: Allocator) void {
-            allocator.free(self.socket_read_buf);
-            allocator.free(self.socket_write_buf);
-            allocator.free(self.tls_read_buf);
-            allocator.free(self.tls_write_buf);
+            self.ca_bundle.deinit(allocator);
             self.stream.close();
             allocator.destroy(self);
         }
@@ -144,8 +146,9 @@ pub const Conn = struct {
         const url = try parseUrl(url_input);
 
         if (url.secure) {
-            if (options.proxy) |px| {
-                return connectWssProxied(allocator, url, px);
+            if (options.proxy != null) {
+                log.warn("wss over proxy is not supported; use relay.connect or clearnet", .{});
+                return error.ConnectFailed;
             }
             const client = try allocator.create(std.http.Client);
             client.* = .{ .allocator = allocator };
@@ -323,57 +326,6 @@ pub const Conn = struct {
     fn performHandshake(self: *Conn, url: Url) Error!void {
         if (self.http) |h| return performHandshakeHttps(self, url, h);
         return performHandshakePlain(self, url);
-    }
-
-    fn connectWssProxied(allocator: Allocator, url: Url, px: proxy_mod.Proxy) Error!Conn {
-        const stream = proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch {
-            log.warn("proxy connect to {s}:{d} failed", .{ url.host, url.port });
-            return error.ConnectFailed;
-        };
-        errdefer stream.close();
-
-        const min = tls.Client.min_buffer_len;
-        const tp = try allocator.create(TlsProxyIo);
-        errdefer allocator.destroy(tp);
-
-        tp.socket_read_buf = try allocator.alloc(u8, min);
-        errdefer allocator.free(tp.socket_read_buf);
-        tp.socket_write_buf = try allocator.alloc(u8, min);
-        errdefer allocator.free(tp.socket_write_buf);
-        tp.tls_read_buf = try allocator.alloc(u8, min);
-        errdefer allocator.free(tp.tls_read_buf);
-        tp.tls_write_buf = try allocator.alloc(u8, min);
-        errdefer allocator.free(tp.tls_write_buf);
-
-        tp.stream = stream;
-        var sr = stream.reader(tp.socket_read_buf);
-        var sw = stream.writer(tp.socket_write_buf);
-
-        var ca_bundle: std.crypto.Certificate.Bundle = .{};
-        ca_bundle.rescan(allocator) catch return error.TlsInitFailed;
-        defer ca_bundle.deinit(allocator);
-
-        tp.tls = tls.Client.init(sr.interface(), &sw.interface, .{
-            .host = .{ .explicit = url.host },
-            .ca = .{ .bundle = ca_bundle },
-            .read_buffer = tp.tls_read_buf,
-            .write_buffer = tp.tls_write_buf,
-            .allow_truncation_attacks = true,
-        }) catch return error.TlsInitFailed;
-
-        var conn = Conn{
-            .allocator = allocator,
-            .stream = stream,
-            .http = null,
-            .tls_proxy = tp,
-            .fragment_buf = .empty,
-            .fragment_opcode = null,
-        };
-        errdefer conn.deinit();
-
-        try conn.performHandshake(url);
-        setRecvTimeout(conn.stream, 30);
-        return conn;
     }
 
     /// `wss://` upgrade via `std.http.Client` — the same stack as HTTPS
@@ -596,8 +548,7 @@ pub const Conn = struct {
         } else if (self.tls_proxy) |t| {
             t.tls.writer.writeAll(buf) catch return error.SendFailed;
             t.tls.writer.flush() catch return error.SendFailed;
-            var sw = t.stream.writer(t.socket_write_buf);
-            sw.interface.flush() catch return error.SendFailed;
+            t.socket_writer.interface.flush() catch return error.SendFailed;
         } else {
             var off: usize = 0;
             while (off < buf.len) {


### PR DESCRIPTION
## Summary

Adds `src/mse.zig`, the first slice of [issue #12](https://github.com/vincenzopalazzo/carl/issues/12) (Vuze MSE/PE). This PR is **crypto + handshake only** — no changes to `peer.zig`, `session.zig`, or the CLI yet.

- 768-bit DH with the standard MSE safe prime
- SHA-1 `HASH('req1'|'keyA'|…)` key derivation
- RC4 with mandatory 1024-byte keystream discard
- Full 5-step initiator/responder handshake over `std.net.Stream`
- Unit tests: DH vectors, RC4 discard, TCP loopback handshake

## Plan

Follow-up PRs are documented in `docs/plans/2026-06-03-mse-pe-protocol-encryption.md`:

1. ✅ This PR — `mse.zig`
2. `peer.zig` — outbound MSE-first + plaintext fallback
3. `session.zig` — inbound detect + responder
4. CLI flags
5. Tracker `supportcrypto` / `crypto_flags`
6. Docs + integration test

## Decision log

| Decision | Rationale |
|----------|-----------|
| Dedicated `mse.zig` module | Keeps crypto testable; `wire.zig` stays unaware of encryption |
| RC4 in-tree | Required for interop; Zig std has no RC4 |
| Step 3 splits plaintext `req1`/SKEY hash from encrypted tail | Matches Vuze spec; encrypting the whole step broke resync |
| `Stream.close()` owns the socket | Handshake copies `stream.*` into `Stream`; callers must not double-close |

## Testing

- `zig build test` (local green)

Part of #12 — does not close the issue until peer/session/tracker integration lands.