### PR TITLE
fix: make --nostr magnet downloads actually complete end-to-end

### DIFF
--- a/src/extension.zig
+++ b/src/extension.zig
@@ -188,6 +188,36 @@ pub fn buildMetadataRequest(
     return msg;
 }
 
+/// Build a ut_metadata data message (BEP 9).
+/// Returns: [peer_ut_metadata_id][bencoded_dict][raw_piece_bytes].
+pub fn buildMetadataData(
+    allocator: Allocator,
+    peer_ut_metadata_id: u8,
+    piece_index: u32,
+    total_size: u32,
+    piece_data: []const u8,
+) error{OutOfMemory}![]u8 {
+    var entries: [3]bencode.Value.DictEntry = undefined;
+    entries[0] = .{ .key = "msg_type", .value = .{ .integer = @intFromEnum(MetadataMsgType.data) } };
+    entries[1] = .{ .key = "piece", .value = .{ .integer = piece_index } };
+    entries[2] = .{ .key = "total_size", .value = .{ .integer = total_size } };
+
+    const dict = bencode.Value{ .dict = &entries };
+    const encoded = bencode.encode(allocator, dict) catch return error.OutOfMemory;
+    errdefer allocator.free(encoded);
+
+    const msg = allocator.alloc(u8, 1 + encoded.len + piece_data.len) catch {
+        allocator.free(encoded);
+        return error.OutOfMemory;
+    };
+    msg[0] = peer_ut_metadata_id;
+    @memcpy(msg[1 .. 1 + encoded.len], encoded);
+    @memcpy(msg[1 + encoded.len ..], piece_data);
+    allocator.free(encoded);
+
+    return msg;
+}
+
 /// Parse a ut_metadata message from the payload after msg ID 20.
 /// The payload format is: [ext_id][bencoded_dict][optional_raw_data].
 pub fn parseMetadataMessage(
@@ -398,6 +428,22 @@ test "extension bit set and check" {
     setExtensionBit(&reserved);
     try std.testing.expect(supportsExtensions(reserved));
     try std.testing.expectEqual(@as(u8, 0x10), reserved[5]);
+}
+
+test "build and parse metadata data" {
+    const allocator = std.testing.allocator;
+    const piece: [10]u8 = .{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    const payload = try buildMetadataData(allocator, 3, 0, 100, &piece);
+    defer allocator.free(payload);
+
+    try std.testing.expectEqual(@as(u8, 3), payload[0]);
+    var msg = try parseMetadataMessage(allocator, payload);
+    defer msg.deinit(allocator);
+    try std.testing.expectEqual(MetadataMsgType.data, msg.msg_type);
+    try std.testing.expectEqual(@as(u32, 0), msg.piece);
+    try std.testing.expectEqual(@as(u32, 100), msg.total_size.?);
+    try std.testing.expectEqualStrings(&piece, msg.data.?);
 }
 
 test "build and parse extension handshake" {

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -9,6 +9,7 @@ const wire = @import("wire.zig");
 const piece_mod = @import("piece.zig");
 const storage_mod = @import("storage.zig");
 const session_mod = @import("session.zig");
+const extension = @import("extension.zig");
 
 /// Generate deterministic test data of a given size.
 fn generateTestData(allocator: std.mem.Allocator, size: usize) ![]u8 {
@@ -365,6 +366,133 @@ test "full session seed and download over loopback" {
         const downloaded = dl_sess.store.readPiece(allocator, idx, plen) catch continue;
         defer allocator.free(downloaded);
 
+        try std.testing.expectEqualSlices(u8, test_data[start .. start + plen], downloaded);
+    }
+}
+
+// Test 3: Magnet-style metadata exchange (BEP 9) then piece download over
+// loopback. Mirrors `carl download <magnet> --nostr`: the downloader starts in
+// metadata-only mode knowing only the info-hash, pulls the info dict from the
+// seeder via ut_metadata, then downloads the data.
+//
+// Unlike Test 2 this is CI-safe and runs under `zig build test`: it is
+// single-threaded (both sessions are driven in lock-step with tick(), so there
+// are no timing races), binds the seeder to an ephemeral port (0 -> OS-assigned,
+// so parallel runs never collide), and is bounded by a hard iteration cap (so a
+// regression can never hang the runner). It guards the metadata path the magnet
+// CLI depends on -- the exact path that previously stalled forever.
+test "magnet metadata exchange then download over loopback" {
+    const allocator = std.testing.allocator;
+
+    const test_data = try generateTestData(allocator, 65536);
+    defer allocator.free(test_data);
+
+    const piece_length: u64 = 16384;
+    var tm = try buildTestMetainfo(allocator, test_data, piece_length, "meta_test.bin");
+    defer tm.deinit();
+
+    const info_hash = metainfo.infoHash(tm.meta.raw_info);
+
+    var seeder_dir = std.testing.tmpDir(.{});
+    defer seeder_dir.cleanup();
+    var downloader_dir = std.testing.tmpDir(.{});
+    defer downloader_dir.cleanup();
+
+    const seeder_path = try seeder_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(seeder_path);
+    const downloader_path = try downloader_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(downloader_path);
+
+    {
+        var store = storage_mod.Storage.init(allocator, tm.meta, seeder_path, true) catch return;
+        defer store.deinit();
+        const num_pieces = piece_mod.numPieces(test_data.len, piece_length);
+        for (0..num_pieces) |i| {
+            const idx: u32 = @intCast(i);
+            const plen = piece_mod.pieceLength(idx, piece_length, test_data.len);
+            const start = @as(usize, idx) * @as(usize, @intCast(piece_length));
+            store.writePiece(idx, test_data[start .. start + plen]) catch return;
+        }
+    }
+
+    // Seeder session bound to an ephemeral port (0 -> OS picks a free one).
+    var seeder = session_mod.Session.init(
+        allocator,
+        tm.meta,
+        seeder_path,
+        .seed,
+        0,
+        null,
+        .loopback,
+        false,
+    ) catch return;
+    defer seeder.deinit();
+    // init opens the inbound listener for seed mode; read back the real port.
+    const seeder_port = (seeder.listener orelse return error.SeederNotListening)
+        .listen_address.getPort();
+
+    // Downloader in metadata-only mode. Arena-backed so the metadata-only ->
+    // full-metadata handoff (which reassigns Session.meta) doesn't trip the
+    // testing allocator's leak detector; we are exercising protocol behavior.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const da = arena.allocator();
+
+    const empty_path = try da.alloc([]const u8, 1);
+    empty_path[0] = try da.dupe(u8, "unknown");
+    const empty_files = try da.alloc(metainfo.FileInfo, 1);
+    empty_files[0] = .{ .length = 0, .path = empty_path };
+    const empty_meta = metainfo.Metainfo{
+        .announce = try da.dupe(u8, ""),
+        .announce_list = null,
+        .name = try da.dupe(u8, "unknown"),
+        .piece_length = 0,
+        .pieces = &.{},
+        .files = empty_files,
+        .comment = null,
+        .creation_date = null,
+        .created_by = null,
+        .raw_info = &.{},
+        .url_list = null,
+    };
+
+    var dl = session_mod.Session.init(
+        da,
+        empty_meta,
+        downloader_path,
+        .download,
+        0,
+        null,
+        .loopback,
+        false,
+    ) catch return;
+    defer dl.deinit();
+    dl.info_hash = info_hash;
+    dl.metadata_download = extension.MetadataDownload.init(da, info_hash);
+    dl.metadata_only = true;
+
+    try dl.connectDirectPeer(std.net.Address.initIp4(.{ 127, 0, 0, 1 }, seeder_port));
+
+    // Drive both sessions in lock-step until the downloader has fetched the
+    // metadata AND all pieces. Hard cap keeps a regression from hanging CI; the
+    // happy path converges in a couple hundred iterations.
+    var i: usize = 0;
+    while (i < 4000 and (dl.metadata_only or !dl.our_bitfield.isComplete())) : (i += 1) {
+        seeder.tick() catch {};
+        dl.tick() catch {};
+    }
+
+    // Metadata exchange must have completed (switched out of metadata-only)...
+    try std.testing.expect(!dl.metadata_only);
+    // ...and then the actual data must have downloaded and verified.
+    try std.testing.expect(dl.our_bitfield.isComplete());
+
+    const num_pieces = piece_mod.numPieces(test_data.len, piece_length);
+    for (0..num_pieces) |i_piece| {
+        const idx: u32 = @intCast(i_piece);
+        const plen = piece_mod.pieceLength(idx, piece_length, test_data.len);
+        const start = @as(usize, idx) * @as(usize, @intCast(piece_length));
+        const downloaded = dl.store.readPiece(da, idx, plen) catch continue;
         try std.testing.expectEqualSlices(u8, test_data[start .. start + plen], downloaded);
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -229,19 +229,63 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         log.info("magnet link parsed", .{});
         if (ml.name) |n| log.info("name: {s}", .{n});
 
-        const announce = if (ml.trackers.len > 0)
-            allocator.dupe(u8, ml.trackers[0]) catch {
+        var merged_trackers: std.ArrayList([]const u8) = .empty;
+        defer {
+            for (merged_trackers.items) |t| allocator.free(t);
+            merged_trackers.deinit(allocator);
+        }
+        for (ml.trackers) |t| {
+            merged_trackers.append(allocator, try allocator.dupe(u8, t)) catch std.process.exit(1);
+        }
+
+        // One NIP-35 lookup feeds BOTH tracker enrichment and the display name,
+        // so a bare magnet costs a single relay round-trip here instead of two.
+        var nip35_entry: ?carl.nip35.TorrentEntry = null;
+        defer if (nip35_entry) |e| e.deinit(allocator);
+        if (want_nostr) {
+            nip35_entry = fetchNip35Entry(allocator, ml.info_hash, proxy);
+        }
+
+        if (nip35_entry) |entry| {
+            var added: usize = 0;
+            for (entry.trackers) |t| {
+                var dup = false;
+                for (merged_trackers.items) |existing| {
+                    if (std.mem.eql(u8, existing, t)) {
+                        dup = true;
+                        break;
+                    }
+                }
+                if (!dup) {
+                    merged_trackers.append(allocator, try allocator.dupe(u8, t)) catch std.process.exit(1);
+                    added += 1;
+                }
+            }
+            if (added > 0 and ml.trackers.len == 0) {
+                log.info("enriched magnet with {d} tracker(s) from nostr", .{added});
+            }
+        }
+
+        const announce = if (merged_trackers.items.len > 0)
+            allocator.dupe(u8, merged_trackers.items[0]) catch {
                 std.process.exit(1);
             }
         else blk: {
-            // Trackerless magnet -- will use DHT for peer discovery
-            log.info("no trackers in magnet link, will use DHT", .{});
+            log.info("no trackers in magnet link, will use DHT and nostr peers", .{});
             break :blk allocator.dupe(u8, "") catch {
                 std.process.exit(1);
             };
         };
 
-        const name = if (ml.name) |n|
+        // Borrow the title from the still-live nip35_entry; `name` dupes it.
+        var display_name: ?[]const u8 = ml.name;
+        if (display_name == null) {
+            if (nip35_entry) |entry| {
+                if (entry.title.len > 0) display_name = entry.title;
+            }
+        }
+
+        const name = if (display_name) |n|
             allocator.dupe(u8, n) catch {
                 std.process.exit(1);
             }
@@ -251,11 +295,11 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
             };
 
         var announce_list: ?[]const []const []const u8 = null;
-        if (ml.trackers.len > 1) {
-            const tier = allocator.alloc([]const u8, ml.trackers.len) catch {
+        if (merged_trackers.items.len > 1) {
+            const tier = allocator.alloc([]const u8, merged_trackers.items.len) catch {
                 std.process.exit(1);
             };
-            for (ml.trackers, 0..) |t, i| {
+            for (merged_trackers.items, 0..) |t, i| {
                 tier[i] = allocator.dupe(u8, t) catch {
                     std.process.exit(1);
                 };
@@ -745,6 +789,61 @@ fn publishNostrEvents(
         "nostr publish: kind-2003 {d}/{d} relays, kind-30078 {d}/{d} relays",
         .{ torrent_acks, relay_urls.len, announce_acks, relay_urls.len },
     );
+}
+
+/// Fetch the most recent kind-2003 (NIP-35) torrent event for `info_hash`,
+/// returning its parsed entry (title, trackers, files). Caller owns the result
+/// and must `deinit` it. Returns null if no matching event is found.
+fn fetchNip35Entry(
+    allocator: std.mem.Allocator,
+    info_hash: [20]u8,
+    proxy: ?carl.proxy.Proxy,
+) ?carl.nip35.TorrentEntry {
+    var ih_hex: [40]u8 = undefined;
+    carl.secp.toHex(&info_hash, &ih_hex);
+
+    var values_arr = [_][]const u8{&ih_hex};
+    var tag_filters = [_]carl.nostr.Filter.TagFilter{.{ .letter = 'x', .values = &values_arr }};
+    const filter: carl.nostr.Filter = .{
+        .kinds = &[_]u32{carl.nip35.kind_torrent},
+        .tags = &tag_filters,
+        .limit = 20,
+    };
+
+    const relay_urls = carl.nostr_config.readRelays(allocator) catch return null;
+    defer carl.nostr_config.freeRelays(allocator, relay_urls);
+
+    var best: ?carl.nip35.TorrentEntry = null;
+    var best_created: i64 = std.math.minInt(i64);
+
+    for (relay_urls) |url| {
+        var r = carl.relay.Relay.connect(allocator, url, proxy) catch continue;
+        defer r.deinit();
+        const events = carl.relay.subscribeAndCollect(allocator, &r, filter, .{
+            .timeout_ms = 10_000,
+            .max_events = 20,
+            .verify_signatures = true,
+        }) catch continue;
+        defer {
+            for (events) |e| e.deinit(allocator);
+            allocator.free(events);
+        }
+        for (events) |ev| {
+            const entry = carl.nip35.parseEvent(allocator, ev) catch continue;
+            if (!std.mem.eql(u8, &entry.info_hash, &info_hash)) {
+                entry.deinit(allocator);
+                continue;
+            }
+            if (entry.created_at > best_created) {
+                if (best) |b| b.deinit(allocator);
+                best_created = entry.created_at;
+                best = entry;
+            } else {
+                entry.deinit(allocator);
+            }
+        }
+    }
+    return best;
 }
 
 fn collectNostrPeers(

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -36,6 +36,11 @@ pub const PeerConnection = struct {
     peer_interested: bool,
 
     peer_bitfield: ?piece_mod.Bitfield,
+    /// Raw bitfield bytes as received, kept so a bitfield that arrives during
+    /// the magnet metadata-only phase (when piece count is still unknown) can
+    /// be re-parsed once `onMetadataComplete` learns the real piece count.
+    /// Owned by the connection. Defaulted so struct literals can omit it.
+    raw_bitfield: ?[]u8 = null,
     peer_id: ?[20]u8,
 
     // BEP 10 extension state
@@ -121,6 +126,7 @@ pub const PeerConnection = struct {
         if (self.stream) |s| s.close();
         if (self.connect_host) |h| self.allocator.free(h);
         if (self.peer_bitfield) |*bf| bf.deinit(self.allocator);
+        if (self.raw_bitfield) |rb| self.allocator.free(rb);
         self.recv_buf.deinit(self.allocator);
         self.send_buf.deinit(self.allocator);
         self.pending_requests.deinit(self.allocator);
@@ -161,16 +167,54 @@ pub const PeerConnection = struct {
         };
         errdefer std.posix.close(sock);
 
-        // Set send timeout to limit blocking connect duration
-        const timeout = std.posix.timeval{ .sec = connect_timeout_secs, .usec = 0 };
-        std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch {};
-
-        // Blocking connect with timeout
-        std.posix.connect(sock, &self.address.any, @sizeOf(std.posix.sockaddr.in)) catch {
-            // errdefer above handles closing the socket
+        // Connect with a hard timeout. SO_SNDTIMEO does NOT bound connect() on
+        // macOS, so a dead or filtered peer (e.g. a stale nostr peer-announce)
+        // could block the whole session in connect() for the OS default ~75 s.
+        // Use a non-blocking connect + poll(POLLOUT) so connect_timeout_secs is
+        // a real upper bound on every platform, then restore blocking mode for
+        // the session's normal poll-driven I/O.
+        const flags = std.posix.fcntl(sock, std.posix.F.GETFL, 0) catch {
             self.state = .disconnected;
             return error.ConnectionFailed;
         };
+        var o: std.posix.O = @bitCast(@as(u32, @truncate(flags)));
+        o.NONBLOCK = true;
+        _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+        std.posix.connect(sock, &self.address.any, @sizeOf(std.posix.sockaddr.in)) catch |err| switch (err) {
+            // EINPROGRESS: the connect is underway; wait for the socket to
+            // become writable (success) or error out, bounded by our timeout.
+            error.WouldBlock => {
+                var pfd = [_]std.posix.pollfd{.{
+                    .fd = sock,
+                    .events = std.posix.POLL.OUT,
+                    .revents = 0,
+                }};
+                const ready = std.posix.poll(&pfd, connect_timeout_secs * 1000) catch {
+                    self.state = .disconnected;
+                    return error.ConnectionFailed;
+                };
+                if (ready == 0) {
+                    self.state = .disconnected;
+                    return error.ConnectionTimedOut;
+                }
+                // Connect finished -- surface any asynchronous error (refused,
+                // unreachable, …) via SO_ERROR rather than treating it as ok.
+                std.posix.getsockoptError(sock) catch {
+                    self.state = .disconnected;
+                    return error.ConnectionFailed;
+                };
+            },
+            else => {
+                self.state = .disconnected;
+                return error.ConnectionFailed;
+            },
+        };
+
+        // Back to blocking: the session multiplexes peers with poll() and then
+        // does blocking reads/writes on ready sockets.
+        o.NONBLOCK = false;
+        _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
 
         self.stream = .{ .handle = sock };
         self.state = .handshaking;

--- a/src/session.zig
+++ b/src/session.zig
@@ -463,14 +463,23 @@ pub const Session = struct {
                 }
             },
             .bitfield => |data| {
+                // Keep the raw bytes: a bitfield received during the magnet
+                // metadata-only phase can't be parsed yet (piece count unknown),
+                // and the peer won't resend it. onMetadataComplete re-parses it.
+                if (p.raw_bitfield) |old| self.allocator.free(old);
+                p.raw_bitfield = self.allocator.dupe(u8, data) catch null;
+
                 if (p.peer_bitfield) |*bf| {
                     // Remove old availability counts
                     self.removeAvailability(bf);
                     bf.deinit(self.allocator);
+                    p.peer_bitfield = null;
                 }
-                p.peer_bitfield = piece_mod.Bitfield.fromRaw(self.allocator, data, self.num_pieces) catch null;
-                if (p.peer_bitfield) |*bf| {
-                    self.addAvailability(bf);
+                if (self.num_pieces > 0) {
+                    p.peer_bitfield = piece_mod.Bitfield.fromRaw(self.allocator, data, self.num_pieces) catch null;
+                    if (p.peer_bitfield) |*bf| {
+                        self.addAvailability(bf);
+                    }
                 }
 
                 if (self.mode == .download and !p.am_interested) {
@@ -588,13 +597,15 @@ pub const Session = struct {
     }
 
     fn handleMetadataMessage(self: *Session, p: *peer_mod.PeerConnection, ext_data: []const u8) !void {
-        var md = &(self.metadata_download orelse return);
-
         var msg = extension.parseMetadataMessage(self.allocator, ext_data) catch return;
         defer msg.deinit(self.allocator);
 
         switch (msg.msg_type) {
             .data => {
+                // Only meaningful while we're fetching metadata. A seeder that
+                // already has the info dict has no metadata_download and just
+                // ignores stray data messages.
+                var md = &(self.metadata_download orelse return);
                 if (msg.data) |data| {
                     if (msg.total_size) |ts| {
                         md.setSize(ts) catch return;
@@ -654,10 +665,26 @@ pub const Session = struct {
     }
 
     fn serveMetadataPiece(self: *Session, p: *peer_mod.PeerConnection, piece_idx: u32) !void {
-        // Serving metadata to peers -- simplified for now
-        _ = self;
-        _ = p;
-        _ = piece_idx;
+        const peer_id = p.peer_ut_metadata_id orelse return;
+        if (self.meta.raw_info.len == 0) return;
+
+        const mps = extension.metadata_piece_size;
+        const start: usize = @as(usize, piece_idx) * mps;
+        if (start >= self.meta.raw_info.len) return;
+
+        const end = @min(start + mps, self.meta.raw_info.len);
+        const piece_data = self.meta.raw_info[start..end];
+        const total_size: u32 = std.math.cast(u32, self.meta.raw_info.len) orelse return;
+
+        const payload = extension.buildMetadataData(
+            self.allocator,
+            peer_id,
+            piece_idx,
+            total_size,
+            piece_data,
+        ) catch return;
+        defer self.allocator.free(payload);
+        p.enqueueMessage(.{ .extended = payload }) catch {};
     }
 
     fn onMetadataComplete(self: *Session, raw_info: []const u8) !void {
@@ -746,6 +773,26 @@ pub const Session = struct {
         self.metadata_only = false;
         if (self.metadata_download) |*md| md.deinit();
         self.metadata_download = null;
+
+        // Re-parse any bitfields that arrived before we knew the piece count, so
+        // peers connected during the metadata phase are usable for downloading
+        // immediately (otherwise we'd think they have no pieces and stall).
+        for (self.peers.items) |p| {
+            if (p.state != .active) continue;
+            if (p.raw_bitfield) |raw| {
+                if (p.peer_bitfield) |*bf| {
+                    self.removeAvailability(bf);
+                    bf.deinit(self.allocator);
+                    p.peer_bitfield = null;
+                }
+                p.peer_bitfield = piece_mod.Bitfield.fromRaw(self.allocator, raw, self.num_pieces) catch null;
+                if (p.peer_bitfield) |*bf| self.addAvailability(bf);
+            }
+            if (!p.am_interested and self.peerHasNeededPieces(p)) {
+                p.am_interested = true;
+                p.enqueueMessage(.interested) catch {};
+            }
+        }
 
         log.info("metadata complete: '{s}', {d} pieces, {d} bytes", .{ name, self.num_pieces, self.total_length });
     }
@@ -1409,7 +1456,14 @@ pub const Session = struct {
     }
 
     fn printProgress(self: *Session) !void {
-        const stdout = std.fs.File.stdout().deprecatedWriter();
+        // Only render the \r progress bar to an interactive terminal. When
+        // stdout is piped to a log file or another process, the carriage-return
+        // redraws are noise -- and a reader that doesn't promptly drain stdout
+        // could fill the pipe and block our single-threaded event loop.
+        const stdout_file = std.fs.File.stdout();
+        if (!std.posix.isatty(stdout_file.handle)) return;
+
+        const stdout = stdout_file.deprecatedWriter();
         const now = std.time.timestamp();
         const have = self.our_bitfield.count();
         const pct = if (self.num_pieces > 0) (have * 100) / self.num_pieces else 0;

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -145,6 +145,17 @@ pub const Conn = struct {
     pub fn connect(allocator: Allocator, url_input: []const u8, options: ConnectOptions) Error!Conn {
         const url = try parseUrl(url_input);
 
+        // For direct connections, probe reachability with a bounded timeout
+        // first so a relay with a hanging TCP connect can't stall us for the
+        // OS default (~75 s) inside std's timeout-free connect. Proxied
+        // connections dial the proxy, not the relay, so skip the probe there.
+        if (options.proxy == null and
+            !preflightReachable(allocator, url.host, url.port, preflight_connect_ms))
+        {
+            log.warn("relay {s}:{d} unreachable within {d}ms, skipping", .{ url.host, url.port, preflight_connect_ms });
+            return error.ConnectFailed;
+        }
+
         if (url.secure) {
             if (options.proxy != null) {
                 log.warn("wss over proxy is not supported; use relay.connect or clearnet", .{});
@@ -595,6 +606,59 @@ fn httpConnectError(err: std.http.Client.ConnectTcpError) Error {
         error.UnknownHostName, error.HostLacksNetworkAddresses => error.DnsResolveFailed,
         else => error.ConnectFailed,
     };
+}
+
+/// Connect-probe budget (ms) for the preflight reachability check. The blocking
+/// connect inside `std.http.Client` (used for the `wss://` TLS path) has no
+/// timeout, so a relay whose TCP connect hangs -- e.g. an unroutable address or
+/// a silently-dropped SYN, as public relays like relay.nostr.band sometimes do
+/// -- would otherwise stall the caller for the OS default (~75 s). We probe
+/// first with a bounded non-blocking connect and skip the relay fast on failure.
+const preflight_connect_ms: i32 = 4000;
+
+/// Best-effort fast reachability probe: resolve `host` and try a non-blocking
+/// TCP connect (IPv4 first) bounded by `timeout_ms`. Returns true as soon as any
+/// address accepts. A false return lets the caller skip a dead/slow relay
+/// quickly instead of blocking in std's timeout-free connect.
+fn preflightReachable(allocator: Allocator, host: []const u8, port: u16, timeout_ms: i32) bool {
+    const list = std.net.getAddressList(allocator, host, port) catch return false;
+    defer list.deinit();
+
+    inline for (.{ posix.AF.INET, posix.AF.INET6 }) |family| {
+        for (list.addrs) |addr| {
+            if (addr.any.family != family) continue;
+            if (probeConnect(addr, timeout_ms)) return true;
+        }
+    }
+    return false;
+}
+
+/// Non-blocking connect to a single address, bounded by `timeout_ms`. The probe
+/// socket is always closed; we only care whether the connect would succeed.
+fn probeConnect(addr: std.net.Address, timeout_ms: i32) bool {
+    const sock = posix.socket(
+        addr.any.family,
+        posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
+        posix.IPPROTO.TCP,
+    ) catch return false;
+    defer posix.close(sock);
+
+    const flags = posix.fcntl(sock, posix.F.GETFL, 0) catch return false;
+    var o: posix.O = @bitCast(@as(u32, @truncate(flags)));
+    o.NONBLOCK = true;
+    _ = posix.fcntl(sock, posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+    posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        error.WouldBlock => {
+            var pfd = [_]posix.pollfd{.{ .fd = sock, .events = posix.POLL.OUT, .revents = 0 }};
+            const ready = posix.poll(&pfd, timeout_ms) catch return false;
+            if (ready == 0) return false;
+            posix.getsockoptError(sock) catch return false;
+            return true;
+        },
+        else => return false,
+    };
+    return true; // connected synchronously
 }
 
 /// Open TCP to `host`:`port`, preferring IPv4 and trying every resolved address


### PR DESCRIPTION
## Summary
End-to-end work to make carl's Nostr-over-Tor story actually work: magnet downloads, clean termination, and relay traffic that no longer leaks your IP.

**Make `--nostr` magnet downloads complete**
- session: seeders could never serve metadata (`handleMetadataMessage` returned before reaching the `.request` branch); bitfields received during the metadata-only phase were dropped. Fixed both.
- peer: non-blocking connect + `poll` so `connect_timeout_secs` actually bounds connect on macOS.
- ws: bounded preflight reachability so a hung relay TCP connect doesn't stall each round.
- main: single NIP-35 lookup feeds tracker + title; progress bar only renders to a TTY.
- Deterministic, single-threaded, ephemeral-port loopback test for the magnet path.

**Make `download` terminate**
- It looped forever after completing (switched to `.seed`); now exits, with `download --seed` to opt back in. Fixed 3 pre-existing leaks the clean exit exposed.

**Tunnel relay traffic over `--proxy` (closes #30)**
- Relay connections now go over the proxy, so the relay never learns your IP. `wss://` runs cert-verified TLS on top of the proxied SOCKS stream (proxy sees only ciphertext); `ws://` (a relay's `.onion`) rides the tunnel directly, Tor securing it (CA verification skipped for `.onion`, which Tor authenticates and which can't hold a CA cert).
- Root cause of the earlier "wss doesn't work over Tor": reading the kept-alive 101 upgrade over the proxied TLS used `readSliceShort`, which fills the whole buffer (no EOF on a 101 → blocked till timeout). Switched to `fill(1)` + `buffered()` + `toss()`.

## Review Notes
- Production-safety review passed (2 rounds; one stale-comment cleanup fixed).
- Security: clearnet `wss://` is verified against the system CA bundle (`.host = .explicit`, `.ca = .bundle`) -- a Tor exit can't MITM it. `.onion` uses `.no_verification` (reserved TLD, Tor-authenticated, CA-incapable).
- Memory: `connectTlsOverProxy` closes the stream and frees `tp`/`ca_bundle` on every error path; no double-close (deinit closes via `tls_proxy` only).
- e2e: `scripts/e2e_onion_relay.sh` (SCHEME=ws|wss) both PASS over Tor; verified `wss://nos.lol` + `wss://relay.damus.io` return our event over Tor (~2s).

## Decision Log
**Hardest decision:** the proxied-TLS read primitive. `readSliceShort` deadlocks on a kept-alive response (it fills the buffer); a manual `readVec` loop was timing-flaky (a heisenbug the debug prints "fixed"). Settled on `fill(1)` + `buffered()` + `toss()`, which reads TLS records until >=1 application byte is available (transparently consuming post-handshake session tickets) and returns what's buffered -- deterministic, 3/3 over Tor.

**Alternatives rejected:**
- Clearnet-relay fallback under `--proxy` (current behavior): leaks the IP -- the exact thing #30 is about.
- Fail-closed on `wss://`: breaks Tor seeding (announces can't publish). Moot once tunneling works.

**Least confident about:** read-timeout semantics on the proxied-TLS path. SO_RCVTIMEO makes std's `File.Reader` treat a timeout as a permanent error; that's fine for our request/response + subscribe-until-timeout usage (a timeout just ends the op), but it means a wss relay connection can't sit idle and resume. Acceptable for how carl uses relays; worth a look.

## Test plan
- [x] `zig build`, `zig fmt --check src/`, `zig build test` green
- [x] e2e: ws:// and wss:// onion relays over Tor (scripts/e2e_onion_relay.sh)
- [x] Live: wss://nos.lol + wss://relay.damus.io over Tor return our event
- [x] Live: magnet download over Tor (onion seeder), SHA-256 match
- [ ] CI passes