### PR TITLE
feat: finish nostr-over-Tor — clean exit, leak fixes, relay tunneling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,18 @@
 - Build: `zig build`
 - Test: `zig build test`
 - Format: `zig fmt src/`
+
+## Install (always use a fresh binary)
+
+Whenever you test `carl` by hand or run it via `$PATH`, rebuild and reinstall
+first so you are never running a stale binary (a stale `~/.local/bin/carl`
+silently produces wrong results — e.g. a 0-byte `unknown` file). After any code
+change, before manual/e2e testing:
+
+```sh
+zig build -Doptimize=ReleaseSafe
+cp zig-out/bin/carl ~/.local/bin/carl   # the binary `carl` on $PATH resolves to
+```
+
+Prefer invoking the freshly built `./zig-out/bin/carl` directly in scripts, and
+keep the installed `~/.local/bin/carl` in sync after every change.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,29 @@ real IP is not leaked to trackers.
 Full details (proxy split, security, E2E test, troubleshooting):
 [docs/tor-hidden-service.md](docs/tor-hidden-service.md).
 
+#### Keeping relay traffic off clearnet
+
+With `--proxy`, relay connections are tunneled too, so the relay never learns
+your real IP:
+
+- `wss://` relays run cert-verified TLS on top of the proxied stream -- the
+  proxy only ever sees ciphertext. Works with public relays over Tor.
+- `ws://` relays (e.g. a relay's `.onion` address) ride the SOCKS tunnel
+  directly; Tor secures the plaintext WebSocket. CA verification is skipped for
+  `.onion` hosts since Tor authenticates the address.
+
+```sh
+# Public wss relay, fully over Tor:
+carl search "ubuntu" --relay wss://nos.lol --proxy socks5h://127.0.0.1:9050
+
+# Onion relay (clearnet never touched at all):
+carl search "ubuntu" --relay ws://<relay-v3-address>.onion \
+    --proxy socks5h://127.0.0.1:9050
+```
+
+Relays default to `~/.config/carl/relays` (one URL per line) when not passed
+explicitly. See [issue #30](https://github.com/vincenzopalazzo/carl/issues/30).
+
 ### Download using Nostr peer-discovery
 
 ```sh

--- a/scripts/e2e_download.sh
+++ b/scripts/e2e_download.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# End-to-end download test: pull a file from a live carl seeder over nostr and
+# verify the bytes match BOTH the canonical source and the server's copy.
+#
+# It does NOT trust carl's own "download complete!". It independently obtains
+# three hashes and requires all of them to agree:
+#
+#   1. the canonical file freshly downloaded from OFFICIAL_URL (bitcoin.org)
+#   2. the file the server is seeding (hashed over SSH)
+#   3. the file carl downloaded for us
+#
+# All three matching proves we downloaded the GENUINE whitepaper end-to-end --
+# not merely whatever happened to be on the server.
+#
+# Everything is overridable via environment variables so this works for any
+# carl seed:
+#
+#   CARL         path to the carl binary            (default ./zig-out/bin/carl)
+#   MAGNET       magnet link to download            (default the whitepaper)
+#   SERVER       ssh target running `carl seed`     (default vincent@65.108.246.14)
+#   SERVER_FILE  path to the seeded file on SERVER  (default ~/seed/bitcoin/bitcoin.pdf)
+#   FILE_NAME    expected downloaded filename       (default bitcoin.pdf)
+#   OFFICIAL_URL canonical source to verify against (default https://bitcoin.org/bitcoin.pdf;
+#                                                     set empty to skip this check)
+#   PROXY        optional carl --proxy URL          (e.g. socks5h://127.0.0.1:9050 for a Tor seed)
+#   SSH_KEY      optional ssh identity file
+#   TIMEOUT      seconds to allow the download       (default 180)
+#
+# Exit status: 0 on a verified match, non-zero otherwise.
+#
+# Examples:
+#   scripts/e2e_download.sh                                   # clearnet IP seeder
+#   PROXY=socks5h://127.0.0.1:9050 scripts/e2e_download.sh    # Tor onion seeder
+set -euo pipefail
+
+CARL=${CARL:-./zig-out/bin/carl}
+MAGNET=${MAGNET:-'magnet:?xt=urn:btih:08d72b48f0799bbf62a2dc54cb66cb1ed14f9431'}
+SERVER=${SERVER:-vincent@65.108.246.14}
+SERVER_FILE=${SERVER_FILE:-'~/seed/bitcoin/bitcoin.pdf'}
+FILE_NAME=${FILE_NAME:-bitcoin.pdf}
+OFFICIAL_URL=${OFFICIAL_URL-https://bitcoin.org/bitcoin.pdf}
+PROXY=${PROXY:-}
+SSH_KEY=${SSH_KEY:-}
+TIMEOUT=${TIMEOUT:-180}
+
+ssh_opts=(-o ConnectTimeout=10)
+[ -n "$SSH_KEY" ] && ssh_opts+=(-i "$SSH_KEY")
+
+# sha256 <file> -> lowercase hex digest (portable: Linux sha256sum / macOS shasum)
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "error: no sha256sum/shasum available" >&2
+    return 1
+  fi
+}
+
+fail() { echo "E2E FAIL: $*" >&2; exit 1; }
+
+[ -x "$CARL" ] || fail "carl binary not found/executable at '$CARL' (build with 'zig build' or set CARL=...)"
+
+out_dir=$(mktemp -d)
+log=$(mktemp)
+trap 'rm -rf "$out_dir" "$log"' EXIT
+
+# 1. Canonical source -- a fresh download from the authoritative URL.
+official_hash=""
+if [ -n "$OFFICIAL_URL" ]; then
+  echo "==> canonical source ($OFFICIAL_URL)"
+  official_file="$out_dir/.official"
+  curl -fsSL --retry 2 -o "$official_file" "$OFFICIAL_URL" \
+    || fail "could not fetch canonical file from $OFFICIAL_URL"
+  official_hash=$(sha256 "$official_file")
+  echo "    $official_hash  ($(wc -c < "$official_file" | tr -d ' ') bytes)"
+fi
+
+# 2. The file the server is actually seeding (source of truth #2).
+echo "==> server file hash ($SERVER:$SERVER_FILE)"
+remote_hash=$(ssh "${ssh_opts[@]}" "$SERVER" "sha256sum $SERVER_FILE 2>/dev/null | awk '{print \$1}'") \
+  || fail "could not reach server or read seeded file"
+[ -n "$remote_hash" ] || fail "server returned an empty hash (is $SERVER_FILE present?)"
+echo "    $remote_hash"
+
+# If we have a canonical hash, the server must actually be seeding THAT file.
+if [ -n "$official_hash" ] && [ "$official_hash" != "$remote_hash" ]; then
+  fail "server is not seeding the canonical file (server $remote_hash != official $official_hash)"
+fi
+
+# 3. Download through carl and hash what we received.
+proxy_args=()
+[ -n "$PROXY" ] && proxy_args=(--proxy "$PROXY")
+
+echo "==> downloading via carl (timeout ${TIMEOUT}s)${PROXY:+ over $PROXY}"
+if ! timeout "$TIMEOUT" "$CARL" download "$MAGNET" --nostr "${proxy_args[@]}" \
+       --output-dir "$out_dir" >"$log" 2>&1; then
+  rc=$?
+  sed 's/^/    | /' "$log" >&2
+  [ "$rc" = 124 ] && fail "download did not finish within ${TIMEOUT}s (carl should exit on completion)"
+  fail "carl exited non-zero ($rc)"
+fi
+
+# carl must terminate on its own and leave a clean run (no leaks / panics).
+if grep -qiE 'leaked|error\(gpa\)|panic|segmentation' "$log"; then
+  sed 's/^/    | /' "$log" >&2
+  fail "carl reported a leak/panic on exit"
+fi
+
+local_file="$out_dir/$FILE_NAME"
+[ -f "$local_file" ] || fail "expected downloaded file '$FILE_NAME' not found in output dir"
+
+echo "==> downloaded file hash ($local_file)"
+local_hash=$(sha256 "$local_file")
+echo "    $local_hash"
+
+# Final gate: the downloaded bytes must equal the server's (and, if checked, the
+# canonical source's -- already asserted equal to the server's above).
+if [ "$local_hash" != "$remote_hash" ]; then
+  fail "hash mismatch -- downloaded file differs from the server's copy"
+fi
+
+bytes=$(wc -c < "$local_file" | tr -d ' ')
+if [ -n "$official_hash" ]; then
+  echo "E2E PASS: canonical == server == downloaded ($FILE_NAME, $bytes bytes, sha256 $local_hash)"
+else
+  echo "E2E PASS: downloaded $FILE_NAME ($bytes bytes) matches the server (sha256 $local_hash)"
+fi

--- a/scripts/e2e_onion_relay.sh
+++ b/scripts/e2e_onion_relay.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for ws:// onion relay tunneling (issue #30).
+#
+# Proves that carl reaches a Nostr relay entirely over the proxy with no IP
+# leak: it stands up a mock relay on a remote host, publishes it as a Tor v3
+# onion, and then runs `carl search` against ws://<onion> through the local Tor
+# SOCKS proxy. A hit means the WebSocket rode the Tor circuit end to end -- the
+# relay only ever saw Tor, never our IP.
+#
+# Requires: local Tor SOCKS (default 127.0.0.1:9050), SSH access to a host that
+# runs Tor with a ControlPort + a readable control cookie, and python3 +
+# `websockets` on that host.
+#
+# Env overrides:
+#   CARL         carl binary                 (default ./zig-out/bin/carl)
+#   SERVER       ssh target running Tor      (default vincent@65.108.246.14)
+#   SSH_KEY      ssh identity file
+#   PROXY        local Tor SOCKS for carl     (default socks5h://127.0.0.1:9050)
+#   QUERY        search term                  (default bitcoin)
+#   EXPECT       string the result must contain (default the whitepaper infohash)
+#   ONION_WAIT   seconds to wait for the descriptor to publish (default 35)
+set -euo pipefail
+
+CARL=${CARL:-./zig-out/bin/carl}
+SERVER=${SERVER:-vincent@65.108.246.14}
+SSH_KEY=${SSH_KEY:-}
+PROXY=${PROXY:-socks5h://127.0.0.1:9050}
+QUERY=${QUERY:-bitcoin}
+EXPECT=${EXPECT:-08d72b48f0799bbf62a2dc54cb66cb1ed14f9431}
+ONION_WAIT=${ONION_WAIT:-35}
+# ws (plain, Tor-encrypted) or wss (TLS over the proxied stream).
+SCHEME=${SCHEME:-ws}
+[ "$SCHEME" = "wss" ] && RELAY_TLS=1 || RELAY_TLS=0
+
+here=$(cd "$(dirname "$0")" && pwd)
+mock_local="$here/onion_mock_relay.py"
+mock_remote=/tmp/carl_onion_mock_relay.py
+
+ssh_opts=(-o ConnectTimeout=10)
+scp_opts=(-o ConnectTimeout=10)
+[ -n "$SSH_KEY" ] && { ssh_opts+=(-i "$SSH_KEY"); scp_opts+=(-i "$SSH_KEY"); }
+
+fail() { echo "E2E FAIL: $*" >&2; exit 1; }
+
+[ -x "$CARL" ] || fail "carl binary not found/executable at '$CARL'"
+[ -f "$mock_local" ] || fail "mock relay not found at $mock_local"
+
+# Stop any prior mock (match a unique token, not 'mock_relay', to avoid killing
+# this very ssh command's shell), then launch a fresh one detached.
+cleanup() {
+  ssh "${ssh_opts[@]}" "$SERVER" "pkill -f carl_onion_mock_relay.py" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> deploying mock onion relay to $SERVER"
+scp "${scp_opts[@]}" "$mock_local" "$SERVER:$mock_remote" >/dev/null || fail "scp failed"
+cleanup
+ssh "${ssh_opts[@]}" "$SERVER" "RELAY_TLS=$RELAY_TLS setsid python3 $mock_remote >/tmp/carl_onion_mock.log 2>&1 </dev/null & echo launched" >/dev/null \
+  || fail "could not launch mock relay"
+
+echo "==> waiting for the onion address"
+onion=""
+for _ in $(seq 1 20); do
+  onion=$(ssh "${ssh_opts[@]}" "$SERVER" "grep -m1 '^ONION ' /tmp/carl_onion_mock.log 2>/dev/null | awk '{print \$2}'" || true)
+  [ -n "$onion" ] && break
+  sleep 2
+done
+[ -n "$onion" ] || fail "mock relay never reported an onion (check websockets / Tor cookie on $SERVER)"
+echo "    $onion"
+
+echo "==> waiting ${ONION_WAIT}s for the onion descriptor to publish"
+sleep "$ONION_WAIT"
+
+echo "==> carl search '$QUERY' via $SCHEME://$onion over $PROXY"
+log=$(mktemp); trap 'rm -f "$log"; cleanup' EXIT
+if ! timeout 100 "$CARL" search "$QUERY" --relay "$SCHEME://$onion" --proxy "$PROXY" >"$log" 2>&1; then
+  sed 's/^/    | /' "$log" >&2
+  fail "carl search exited non-zero (could not reach the onion relay)"
+fi
+
+if grep -qi "failed" "$log"; then
+  sed 's/^/    | /' "$log" >&2
+  fail "relay connection reported a failure"
+fi
+if ! grep -q "$EXPECT" "$log"; then
+  sed 's/^/    | /' "$log" >&2
+  fail "expected '$EXPECT' not found in results -- the onion relay roundtrip did not return the event"
+fi
+
+echo "E2E PASS: reached $SCHEME://$onion over Tor and got the signed event (matched '$EXPECT')"

--- a/scripts/onion_mock_relay.py
+++ b/scripts/onion_mock_relay.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Minimal Nostr relay exposed as a Tor onion, for the ws:// onion-relay e2e.
+
+It does three things:
+  1. Pulls one real, signature-valid kind-2003 (NIP-35) event for INFOHASH from a
+     public relay, so it can replay an event carl will accept (carl verifies
+     Schnorr signatures -- a fake event would be rejected).
+  2. Creates an ephemeral v3 onion via the Tor ControlPort (ADD_ONION). For ws://
+     it forwards onion:80 -> 127.0.0.1:WS_PORT; for wss:// (RELAY_TLS=1) it
+     generates a self-signed cert and forwards onion:443.
+  3. Serves a tiny relay on 127.0.0.1:WS_PORT that answers every REQ with the
+     stored EVENT followed by EOSE.
+
+Prints `ONION <addr>.onion` on stdout once ready. Requires the `websockets`
+package and read access to the Tor control cookie. Env overrides:
+  WS_PORT, TOR_CONTROL_HOST, TOR_CONTROL_PORT, TOR_COOKIE, INFOHASH, SEED_RELAY,
+  RELAY_TLS (set to 1 to serve wss instead of ws)
+"""
+import asyncio
+import binascii
+import json
+import os
+import socket
+import ssl
+import subprocess
+
+import websockets
+
+WS_PORT = int(os.environ.get("WS_PORT", "18777"))
+CONTROL = (os.environ.get("TOR_CONTROL_HOST", "127.0.0.1"),
+           int(os.environ.get("TOR_CONTROL_PORT", "9051")))
+COOKIE = os.environ.get("TOR_COOKIE", "/var/lib/tor/control_auth_cookie")
+INFOHASH = os.environ.get("INFOHASH", "08d72b48f0799bbf62a2dc54cb66cb1ed14f9431")
+SEED_RELAY = os.environ.get("SEED_RELAY", "wss://nos.lol")
+RELAY_TLS = os.environ.get("RELAY_TLS", "") not in ("", "0")
+ONION_PORT = 443 if RELAY_TLS else 80
+
+EVENT = None
+
+
+async def fetch_event():
+    async with websockets.connect(SEED_RELAY) as ws:
+        sub = "fetch1"
+        await ws.send(json.dumps(["REQ", sub, {"kinds": [2003], "#x": [INFOHASH], "limit": 1}]))
+        while True:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=20))
+            if msg[0] == "EVENT" and msg[1] == sub:
+                return msg[2]
+            if msg[0] == "EOSE":
+                return None
+
+
+def add_onion(port):
+    with open(COOKIE, "rb") as fh:
+        cookie = binascii.hexlify(fh.read()).decode()
+    s = socket.create_connection(CONTROL)
+    f = s.makefile("rw")
+
+    def cmd(c):
+        f.write(c + "\r\n")
+        f.flush()
+        out = []
+        while True:
+            line = f.readline().rstrip("\r\n")
+            out.append(line)
+            if len(line) >= 4 and line[3] == " ":
+                break
+        return out
+
+    cmd("AUTHENTICATE " + cookie)
+    res = cmd("ADD_ONION NEW:ED25519-V3 Port=%d,127.0.0.1:%d" % (ONION_PORT, port))
+    onion = None
+    for line in res:
+        if "ServiceID=" in line:
+            onion = line.split("ServiceID=")[1].split()[0]
+    # Keep the control socket open: the ephemeral onion lives only as long as
+    # the connection that created it.
+    return onion, s
+
+
+async def handler(ws):
+    async for raw in ws:
+        try:
+            msg = json.loads(raw)
+        except Exception:
+            continue
+        if isinstance(msg, list) and msg and msg[0] == "REQ":
+            sub = msg[1]
+            if EVENT is not None:
+                await ws.send(json.dumps(["EVENT", sub, EVENT]))
+            await ws.send(json.dumps(["EOSE", sub]))
+
+
+def make_tls_context():
+    # carl skips CA verification for .onion hosts (Tor authenticates the
+    # address), so a throwaway self-signed cert is fine here.
+    cert, key = "/tmp/carl_mock_relay_cert.pem", "/tmp/carl_mock_relay_key.pem"
+    subprocess.run(
+        ["openssl", "req", "-x509", "-newkey", "ec",
+         "-pkeyopt", "ec_paramgen_curve:prime256v1", "-nodes",
+         "-keyout", key, "-out", cert, "-days", "2", "-subj", "/CN=carl-mock-relay"],
+        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(cert, key)
+    return ctx
+
+
+async def main():
+    global EVENT
+    EVENT = await fetch_event()
+    print("EVENT_FETCHED %s" % (EVENT is not None), flush=True)
+    onion, _ctrl = add_onion(WS_PORT)
+    print("ONION %s.onion" % onion, flush=True)
+    ctx = make_tls_context() if RELAY_TLS else None
+    async with websockets.serve(handler, "127.0.0.1", WS_PORT, ssl=ctx):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,10 @@ pub fn main() !void {
         // e.g. magnet:?xt=...&dn=... becomes multiple argv entries when unquoted.
         // Note: consumed fragments remain in args[3..] but are harmless —
         // parseFlag only matches "--output-dir" / "--port" which can't collide.
+        // `source` is either a borrowed argv slice (non-magnet) or an owned
+        // reassembled buffer (magnet split on '&' by the shell); only free the
+        // latter.
+        var source_owned = false;
         const source = blk: {
             if (!std.mem.startsWith(u8, args[2], "magnet:")) break :blk args[2];
             var parts: std.ArrayList(u8) = .empty;
@@ -56,12 +60,15 @@ pub fn main() !void {
                 parts.append(allocator, '&') catch @panic("OOM");
                 parts.appendSlice(allocator, a) catch @panic("OOM");
             }
+            source_owned = true;
             break :blk @as([]const u8, allocator.dupe(u8, parts.items) catch @panic("OOM"));
         };
+        defer if (source_owned) allocator.free(source);
         const output_dir = parseFlag(args[3..], "--output-dir") orelse ".";
         const port = parsePort(args[3..]);
         const want_nostr = parseFlagPresent(args[3..], "--nostr");
-        try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr);
+        const want_seed = parseFlagPresent(args[3..], "--seed");
+        try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr, want_seed);
     } else if (std.mem.eql(u8, command, "seed")) {
         if (args.len < 4) {
             log.err("usage: carl seed <file.torrent> <data-dir> [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--description \"...\"]", .{});
@@ -106,9 +113,11 @@ fn printUsage() void {
         \\commands:
         \\  info <file.torrent>                              show torrent metadata
         \\  announce <file.torrent> [--proxy url]            query tracker for peers
-        \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr]
+        \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr] [--seed]
         \\           source: file.torrent, magnet:?..., or http(s):// URL
         \\           --nostr: also subscribe to nostr peer-announce events
+        \\           --seed: keep seeding after the download completes
+        \\                   (default: exit once the download is done)
         \\  seed <file.torrent> <data-dir> [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
         \\           [--tor-seed] [--tor-control host:port] [--tor-cookie path]
         \\           [--tor-onion-port p] [--tor-socks url] [--description "..."]
@@ -217,7 +226,7 @@ fn cmdAnnounce(allocator: std.mem.Allocator, stdout: anytype, path: []const u8, 
     }
 }
 
-fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool) !void {
+fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool, want_seed: bool) !void {
     if (std.mem.startsWith(u8, source, "magnet:")) {
         // Magnet link
         const ml = carl.magnet.parse(allocator, source) catch |err| {
@@ -346,6 +355,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         session.info_hash = ml.info_hash; // Use magnet's hash, not SHA1("")
         session.metadata_download = carl.extension.MetadataDownload.init(allocator, ml.info_hash);
         session.metadata_only = true;
+        session.seed_after_complete = want_seed;
         if (want_nostr) {
             collectNostrPeers(allocator, ml.info_hash, &session);
         }
@@ -367,21 +377,22 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
             std.process.exit(1);
         };
         defer mi.deinit(allocator);
-        startDownload(allocator, mi, output_dir, port, proxy, want_nostr);
+        startDownload(allocator, mi, output_dir, port, proxy, want_nostr, want_seed);
     } else {
         // File path
         const mi = readTorrent(allocator, source);
         defer mi.deinit(allocator);
-        startDownload(allocator, mi, output_dir, port, proxy, want_nostr);
+        startDownload(allocator, mi, output_dir, port, proxy, want_nostr, want_seed);
     }
 }
 
-fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool) void {
+fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool, want_seed: bool) void {
     std.fs.cwd().makePath(output_dir) catch {};
     var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
+    session.seed_after_complete = want_seed;
     defer session.deinit();
     if (want_nostr) {
         const info_hash = carl.metainfo.infoHash(mi.raw_info);

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -29,13 +29,11 @@ pub const Relay = struct {
     conn: ws.Conn,
 
     pub fn connect(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Relay {
-        // `wss://` over SOCKS is not implemented yet; use clearnet for relays while
-        // `--proxy` still tunnels BitTorrent peer TCP (including `.onion` hosts).
-        const relay_proxy = effectiveRelayProxy(url, proxy);
-        if (proxy != null and relay_proxy == null) {
-            log.debug("relay {s}: clearnet wss (peer traffic still uses --proxy)", .{url});
-        }
-        const conn = ws.Conn.connect(allocator, url, .{ .proxy = relay_proxy }) catch |err| {
+        // Relay traffic is tunneled through `--proxy` so the relay never sees our
+        // real IP -- `ws://` rides the SOCKS tunnel directly (e.g. an onion
+        // relay; Tor secures it), `wss://` runs cert-verified TLS on top of the
+        // proxied stream (the proxy only ever sees ciphertext).
+        const conn = ws.Conn.connect(allocator, url, .{ .proxy = proxy }) catch |err| {
             log.warn("relay connect to {s} failed: {}", .{ url, err });
             return error.ConnectFailed;
         };
@@ -250,14 +248,6 @@ pub const default_relays: []const []const u8 = &.{
     "wss://relay.nostr.band",
 };
 
-/// Nostr relays are `wss://`; proxied WebSocket TLS is not supported yet.
-fn effectiveRelayProxy(url: []const u8, proxy: ?proxy_mod.Proxy) ?proxy_mod.Proxy {
-    if (proxy == null) return null;
-    if (std.mem.startsWith(u8, url, "wss://") or std.mem.startsWith(u8, url, "ws://"))
-        return null;
-    return proxy;
-}
-
 // ===========================================================================
 // Tests
 // ===========================================================================
@@ -268,12 +258,6 @@ fn effectiveRelayProxy(url: []const u8, proxy: ?proxy_mod.Proxy) ?proxy_mod.Prox
 test "default_relays is non-empty and all wss://" {
     try std.testing.expect(default_relays.len >= 1);
     for (default_relays) |r| try std.testing.expect(std.mem.startsWith(u8, r, "wss://"));
-}
-
-test "effectiveRelayProxy strips wss proxy" {
-    const px = proxy_mod.Proxy{ .scheme = .socks5h, .host = "127.0.0.1", .port = 9050 };
-    try std.testing.expect(effectiveRelayProxy("wss://nos.lol", px) == null);
-    try std.testing.expect(effectiveRelayProxy("http://tracker", px) != null);
 }
 
 test "SearchOptions defaults are sensible" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -80,6 +80,18 @@ pub const Session = struct {
     metadata_download: ?extension.MetadataDownload,
     metadata_only: bool, // true when started from magnet link
 
+    /// When true, `download` keeps running as a seeder after the download
+    /// completes instead of exiting. Off by default: `download` should finish
+    /// and return; use `carl seed` (or `download --seed`) to keep seeding.
+    /// Defaulted so the init struct literal need not set it.
+    seed_after_complete: bool = false,
+
+    /// True once `onMetadataComplete` has replaced `meta` with a freshly
+    /// allocated, fully-owned Metainfo (magnet path). The original `meta` is
+    /// owned by the caller; this replacement is owned by the session and freed
+    /// in `deinit`. Defaulted so the init struct literal need not set it.
+    meta_owned: bool = false,
+
     // BEP 5 DHT
     dht_instance: ?dht_mod.Dht,
     dht_failed: bool,
@@ -222,6 +234,9 @@ pub const Session = struct {
         if (self.listener) |*l| l.deinit();
         self.our_bitfield.deinit(self.allocator);
         self.store.deinit();
+        // The magnet path replaces `meta` with a session-owned copy; free it.
+        // The original caller-owned `meta` is freed by the caller.
+        if (self.meta_owned) self.meta.deinit(self.allocator);
     }
 
     pub fn run(self: *Session) !void {
@@ -272,6 +287,16 @@ pub const Session = struct {
             if (self.mode == .download and !self.metadata_only and self.num_pieces > 0 and self.our_bitfield.isComplete()) {
                 stdout.print("\ndownload complete!\n", .{}) catch {};
                 self.doMultiTrackerAnnounce(.completed) catch {};
+
+                // By default `download` is done now -- stop the loop and let the
+                // process exit instead of lingering as a seeder forever (which,
+                // when proxied, can't even accept incoming peers). Opt back into
+                // seed-after-download with `--seed`.
+                if (!self.seed_after_complete) {
+                    self.running = false;
+                    break;
+                }
+
                 // Don't open an inbound listener when proxied (would leak our IP).
                 if (self.listener == null and self.proxy == null) {
                     const bind_ip: [4]u8 = switch (self.listen_bind) {
@@ -620,10 +645,11 @@ pub const Session = struct {
                     } else if (complete) {
                         log.info("all metadata pieces received, verifying...", .{});
                         if (md.assemble() catch null) |raw_info| {
+                            // onMetadataComplete dupes what it keeps, so the
+                            // assembled buffer is ours to free either way.
+                            defer self.allocator.free(raw_info);
                             log.info("metadata verified! parsing torrent info...", .{});
-                            self.onMetadataComplete(raw_info) catch {
-                                self.allocator.free(raw_info);
-                            };
+                            self.onMetadataComplete(raw_info) catch {};
                         } else {
                             log.warn("metadata hash mismatch, retrying...", .{});
                             // Reset and try again
@@ -687,6 +713,39 @@ pub const Session = struct {
         p.enqueueMessage(.{ .extended = payload }) catch {};
     }
 
+    /// Deep-copy a BEP-12 announce-list (tiers of tracker URLs). Returns null
+    /// for a null input. On failure, frees everything allocated so far.
+    fn dupeAnnounceList(
+        allocator: std.mem.Allocator,
+        src: ?[]const []const []const u8,
+    ) error{OutOfMemory}!?[]const []const []const u8 {
+        const tiers = src orelse return null;
+        const out = try allocator.alloc([]const []const u8, tiers.len);
+        var done: usize = 0;
+        errdefer {
+            for (out[0..done]) |tier| {
+                for (tier) |url| allocator.free(url);
+                allocator.free(tier);
+            }
+            allocator.free(out);
+        }
+        for (tiers, 0..) |tier, i| {
+            const out_tier = try allocator.alloc([]const u8, tier.len);
+            var filled: usize = 0;
+            errdefer {
+                for (out_tier[0..filled]) |url| allocator.free(url);
+                allocator.free(out_tier);
+            }
+            for (tier, 0..) |url, j| {
+                out_tier[j] = try allocator.dupe(u8, url);
+                filled = j + 1;
+            }
+            out[i] = out_tier;
+            done = i + 1;
+        }
+        return out;
+    }
+
     fn onMetadataComplete(self: *Session, raw_info: []const u8) !void {
         // Parse the info dict to build a Metainfo struct
         const info_val = bencode.decode(self.allocator, raw_info) catch return error.InvalidMetadata;
@@ -737,10 +796,28 @@ pub const Session = struct {
             return error.OutOfMemory;
         };
 
-        // Update session with the new metadata
+        // Dupe announce + announce_list so the replacement Metainfo owns every
+        // field. The original `meta` (and its announce/announce_list) stays
+        // owned by the caller; mixing the two would risk a double free.
+        const announce_dup = self.allocator.dupe(u8, self.meta.announce) catch {
+            self.allocator.free(name);
+            self.allocator.free(pieces);
+            self.allocator.free(raw_info_dup);
+            return error.OutOfMemory;
+        };
+        const announce_list_dup = dupeAnnounceList(self.allocator, self.meta.announce_list) catch {
+            self.allocator.free(name);
+            self.allocator.free(pieces);
+            self.allocator.free(raw_info_dup);
+            self.allocator.free(announce_dup);
+            return error.OutOfMemory;
+        };
+
+        // Update session with the new metadata. From here `meta` is fully owned
+        // by the session and freed in deinit (see `meta_owned`).
         self.meta = .{
-            .announce = self.meta.announce,
-            .announce_list = self.meta.announce_list,
+            .announce = announce_dup,
+            .announce_list = announce_list_dup,
             .name = name,
             .piece_length = piece_length,
             .pieces = pieces,
@@ -751,6 +828,7 @@ pub const Session = struct {
             .raw_info = raw_info_dup,
             .url_list = null,
         };
+        self.meta_owned = true;
 
         // Now initialize storage and piece tracking
         self.total_length = piece_mod.totalLength(self.meta.files);

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -124,6 +124,10 @@ pub const Conn = struct {
 
     const tls_io_buf_len = tls.max_ciphertext_record_len;
 
+    /// SO_RCVTIMEO (seconds) for the proxied-TLS path: bounds the handshake and
+    /// every read so an unresponsive relay fails instead of hanging.
+    const tls_proxy_handshake_secs: u32 = 20;
+
     const TlsProxyIo = struct {
         stream: std.net.Stream,
         socket_reader: std.net.Stream.Reader,
@@ -157,9 +161,30 @@ pub const Conn = struct {
         }
 
         if (url.secure) {
-            if (options.proxy != null) {
-                log.warn("wss over proxy is not supported; use relay.connect or clearnet", .{});
-                return error.ConnectFailed;
+            // wss:// through the proxy: tunnel TCP via SOCKS, then run TLS on top
+            // of the proxied stream so the proxy only sees ciphertext. The relay
+            // never learns our IP -- the whole connection rides the proxy/Tor.
+            if (options.proxy) |px| {
+                const stream = proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
+                    log.warn("wss proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                    return error.ConnectFailed;
+                };
+                var conn = Conn{
+                    .allocator = allocator,
+                    .stream = stream,
+                    .fragment_buf = .empty,
+                    .fragment_opcode = null,
+                };
+                conn.tls_proxy = connectTlsOverProxy(allocator, stream, url.host) catch |err| {
+                    // connectTlsOverProxy already closed `stream` on failure.
+                    conn.fragment_buf.deinit(allocator);
+                    log.warn("tls over proxy to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                    return err;
+                };
+                conn.stream = conn.tls_proxy.?.stream;
+                errdefer conn.deinit();
+                try conn.performHandshake(url);
+                return conn;
             }
             const client = try allocator.create(std.http.Client);
             client.* = .{ .allocator = allocator };
@@ -198,10 +223,20 @@ pub const Conn = struct {
             return conn;
         }
 
-        const stream = tcpConnect(allocator, url.host, url.port) catch |err| {
-            log.warn("tcp connect to {s}:{d} failed: {}", .{ url.host, url.port, err });
-            return error.ConnectFailed;
-        };
+        // `ws://` (no TLS). Through a proxy this is how we reach a relay's
+        // `.onion` address: the SOCKS tunnel (Tor) provides the encryption and
+        // authenticates the address, so the plaintext WebSocket rides safely on
+        // top -- no redundant TLS layer needed.
+        const stream = if (options.proxy) |px|
+            proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
+                log.warn("ws proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                return error.ConnectFailed;
+            }
+        else
+            tcpConnect(allocator, url.host, url.port) catch |err| {
+                log.warn("tcp connect to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                return error.ConnectFailed;
+            };
 
         var conn = Conn{
             .allocator = allocator,
@@ -212,9 +247,55 @@ pub const Conn = struct {
         };
         errdefer conn.deinit();
 
-        try conn.performHandshake(url);
+        // Set the recv timeout before the handshake so a silent onion relay
+        // can't hang us (the proxy dial leaves its own timeout, but be explicit).
         setRecvTimeout(conn.stream, 30);
+        try conn.performHandshake(url);
         return conn;
+    }
+
+    /// Run a TLS client handshake over an already-proxied `stream` and return a
+    /// heap-allocated `TlsProxyIo` that owns it (same TLS-over-a-raw-stream
+    /// mechanism as proxy.httpsExchange; the buffers + reader/writer live inside
+    /// the returned struct, which is heap-stable so TLS's pointers stay valid).
+    /// On any error the stream is closed and nothing leaks.
+    fn connectTlsOverProxy(allocator: Allocator, stream: std.net.Stream, host: []const u8) Error!*TlsProxyIo {
+        var owned = false;
+        defer if (!owned) stream.close();
+
+        const tp = allocator.create(TlsProxyIo) catch return error.OutOfMemory;
+        errdefer allocator.destroy(tp);
+
+        tp.stream = stream;
+        // Disable Nagle: the WS upgrade + REQ are tiny, and Nagle/delayed-ACK
+        // can otherwise hold a small response (the 101) for a long stall.
+        setTcpNoDelay(stream);
+        tp.socket_reader = stream.reader(&tp.socket_read_buf);
+        tp.socket_writer = stream.writer(&tp.socket_write_buf);
+
+        // A `.onion` host is cryptographically authenticated by Tor itself and
+        // cannot hold a CA-issued certificate, so skip CA verification there
+        // (the TLS is only for the channel). A clearnet wss relay is verified
+        // against the system CA bundle as usual.
+        const onion = std.mem.endsWith(u8, host, ".onion");
+        tp.ca_bundle = .{};
+        if (!onion) tp.ca_bundle.rescan(allocator) catch return error.TlsInitFailed;
+        errdefer tp.ca_bundle.deinit(allocator);
+
+        // SO_RCVTIMEO bounds the handshake and every later read so an
+        // unresponsive relay fails instead of hanging. std's File.Reader turns a
+        // read timeout into an error, which for our request/response +
+        // subscribe-until-timeout relay usage simply ends the op -- the intent.
+        setRecvTimeout(stream, tls_proxy_handshake_secs);
+        tp.tls = tls.Client.init(tp.socket_reader.interface(), &tp.socket_writer.interface, .{
+            .host = if (onion) .no_verification else .{ .explicit = host },
+            .ca = if (onion) .no_verification else .{ .bundle = tp.ca_bundle },
+            .write_buffer = &tp.tls_write_buf,
+            .read_buffer = &tp.tls_read_buf,
+        }) catch return error.TlsInitFailed;
+
+        owned = true; // tp now owns `stream`; TlsProxyIo.deinit closes it
+        return tp;
     }
 
     pub fn deinit(self: *Conn) void {
@@ -576,7 +657,21 @@ pub const Conn = struct {
             return r.readSliceShort(buf) catch return error.RecvFailed;
         }
         if (self.tls_proxy) |t| {
-            return t.tls.reader.readSliceShort(buf) catch return error.RecvFailed;
+            // readSliceShort() fills the whole buffer -- it loops until `buf` is
+            // full or EOF -- so it deadlocks reading a kept-alive HTTP/WS
+            // response that never reaches EOF (e.g. the 101 upgrade headers).
+            // fill(1) instead reads TLS records (transparently consuming
+            // post-handshake session tickets) until at least one application
+            // byte is available, then we hand back whatever is buffered.
+            t.tls.reader.fill(1) catch |err| switch (err) {
+                error.EndOfStream => return 0,
+                else => return error.RecvFailed,
+            };
+            const avail = t.tls.reader.buffered();
+            const k = @min(avail.len, buf.len);
+            @memcpy(buf[0..k], avail[0..k]);
+            t.tls.reader.toss(k);
+            return k;
         }
         const n = posix.recv(self.stream.handle, buf, 0) catch |err| switch (err) {
             error.WouldBlock => return error.Timeout,
@@ -594,6 +689,11 @@ pub const Conn = struct {
         }
     }
 };
+
+fn setTcpNoDelay(stream: std.net.Stream) void {
+    const one: c_int = 1;
+    posix.setsockopt(stream.handle, posix.IPPROTO.TCP, posix.TCP.NODELAY, std.mem.asBytes(&one)) catch {};
+}
 
 fn setRecvTimeout(stream: std.net.Stream, sec: u32) void {
     const tv: posix.timeval = .{ .sec = @intCast(sec), .usec = 0 };


### PR DESCRIPTION
Follow-up to #29, which squash-merged only its first commit (the metadata-download fix). The rest of the work was pushed onto that already-merged branch and never landed -- this PR carries it.

## Summary
- **`download` terminates** when complete instead of seeding forever (under `--proxy` it can't even accept inbound peers); `download --seed` opts back into seeding. Fixed three leaks the clean exit exposed: the `ut_metadata` assemble buffer, the replaced `Session.meta` (now tracked via `meta_owned` + freed in deinit), and the reassembled magnet `source`. Progress bar only renders to a TTY.
- **Relay traffic tunnels over `--proxy`** so the relay never learns our IP. `wss://` runs cert-verified TLS on top of the proxied SOCKS stream (proxy sees only ciphertext); `ws://` (a relay's `.onion`) rides the tunnel directly, Tor authenticating the address (CA verification skipped for `.onion`). The proxied-TLS read uses `fill(1)`/`buffered()`/`toss()` -- `readSliceShort` deadlocked on the kept-alive 101 upgrade since it fills the whole buffer and a 101 never reaches EOF.
- **e2e scripts**: `e2e_download.sh` (downloaded file == canonical bitcoin.org == server seed) and `e2e_onion_relay.sh` (`SCHEME=ws|wss`, replays a real signed kind-2003 event over a Tor onion); `onion_mock_relay.py` fixture.

## Review Notes
- Reviewed with `/code-review` (high effort, 7 finder angles + verify). No blocking correctness bugs. Verified-real follow-up items (kept small / deferred to keep this PR scoped):
  - `session.zig onMetadataComplete`: the OOM error-cleanup ladders don't free `files` -- convert to `errdefer` (also fixes that latent OOM-only leak).
  - `ws.zig connectTlsOverProxy`: `ca_bundle.rescan()` runs per relay connect (repeated disk I/O) -- cache it.
  - `peer.zig`/`ws.zig`: duplicated bounded non-blocking connect -- extract a shared helper.
- Refuted: `meta_owned` double-free (disjoint allocations), `.onion` CA-skip as MITM (reserved TLD, proxy-only, Tor-authenticated), SO_RCVTIMEO killing subscriptions (`subscribeAndCollect` overrides it post-connect).

## Decision Log
**Hardest decision:** the proxied-TLS read primitive. `readSliceShort` deadlocks on a kept-alive response; a manual `readVec` loop was timing-flaky. Settled on `fill(1)` + `buffered()` + `toss()` -- reads TLS records until >=1 application byte (transparently consuming post-handshake session tickets), deterministic over Tor (verified 3/3).

**Alternatives rejected:** clearnet-relay fallback under `--proxy` (leaks the IP -- the whole point); fail-closed on `wss://` (breaks Tor seeding; moot once tunneling works).

**Least confident about:** SO_RCVTIMEO makes std's `File.Reader` treat a read timeout as a permanent error -- fine for carl's request/response + subscribe-until-timeout usage (a timeout just ends the op), but a relay connection can't sit idle and resume. Acceptable for how carl uses relays.

## Test plan
- [x] `zig build`, `zig fmt --check src/`, `zig build test` green on top of merged main
- [x] e2e: ws:// and wss:// onion relays over Tor (scripts/e2e_onion_relay.sh)
- [x] Live: wss://nos.lol + wss://relay.damus.io over Tor return our event (~2s)
- [x] Live: magnet download over Tor (onion seeder), SHA-256 match
- [ ] CI passes