### PR TITLE
feat: carl daemon — HTTP+WebSocket backend for the desktop GUI

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -56,6 +56,32 @@ pub fn build(b: *std.Build) void {
     secp.installHeadersDirectory(secp_dep.path("include"), "", .{});
 
     // ----------------------------------------------------------------
+    // SQLite — vendored amalgamation, built as a static C lib. Avoids a
+    // system libsqlite3 dependency so the build is identical everywhere.
+    // ----------------------------------------------------------------
+    const sqlite_dep = b.dependency("sqlite", .{});
+    const sqlite = b.addLibrary(.{
+        .name = "sqlite3",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    sqlite.root_module.addCSourceFile(.{
+        .file = sqlite_dep.path("sqlite3.c"),
+        .flags = &.{
+            "-DSQLITE_THREADSAFE=1",
+            "-DSQLITE_DQS=0",
+            "-DSQLITE_OMIT_LOAD_EXTENSION",
+            "-DSQLITE_DEFAULT_MEMSTATUS=0",
+            "-Wno-unused-function",
+        },
+    });
+    sqlite.root_module.addIncludePath(sqlite_dep.path("."));
+
+    // ----------------------------------------------------------------
     // carl library module
     // ----------------------------------------------------------------
     const lib_mod = b.addModule("carl", .{
@@ -65,6 +91,8 @@ pub fn build(b: *std.Build) void {
     });
     lib_mod.linkLibrary(secp);
     lib_mod.addIncludePath(secp_dep.path("include"));
+    // SQLite for durable daemon-state persistence (vendored static lib).
+    lib_mod.linkLibrary(sqlite);
 
     // ----------------------------------------------------------------
     // CLI executable
@@ -83,6 +111,7 @@ pub fn build(b: *std.Build) void {
     });
     exe.linkLibrary(secp);
     exe.root_module.addIncludePath(secp_dep.path("include"));
+    exe.linkLibrary(sqlite);
 
     b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,12 @@
             .url = "https://github.com/bitcoin-core/secp256k1/archive/refs/tags/v0.6.0.tar.gz",
             .hash = "N-V-__8AADJMTgDEfe07_P0Y5osu_kf-DbxYeyW8DVvtN-wv",
         },
+        // SQLite amalgamation, compiled into a static lib (vendored — no system
+        // dependency, builds the same everywhere) for daemon-state persistence.
+        .sqlite = .{
+            .url = "https://www.sqlite.org/2025/sqlite-amalgamation-3510000.zip",
+            .hash = "N-V-__8AALNYqgDpBBECZ3Jn_VpVGjX4xX7uTSZg00tYjmy3",
+        },
     },
     .paths = .{
         "build.zig",

--- a/docs/brainstorms/2026-06-04-carl-desktop-app.md
+++ b/docs/brainstorms/2026-06-04-carl-desktop-app.md
@@ -1,0 +1,109 @@
+# carl Desktop App — Brainstorm
+
+_2026-06-04_
+
+Turn the `carl` BitTorrent CLI into a cross-platform desktop app that pixel-faithfully
+reproduces the design prototype (Claude Design handoff bundle `cart-tor-ux`), with every
+screen wired to a live `carl` backend.
+
+## Clarified Problem Statement
+
+**Goal:** Build `carl` into a real cross-platform desktop app (macOS-first) that
+pixel-faithfully reproduces the prototype's four screens — Transfers, Discover, Seeding,
+Settings — plus the Add-transfer modal and Tor-seed onion callout, with every screen wired
+to a live `carl` backend.
+
+**Architecture (locked with the user):**
+
+- **Shell:** Tauri (Rust + system webview); `carl` ships as a sidecar.
+- **Backend link:** a new `carl daemon` mode exposing a localhost API; the GUI is a thin client.
+- **Scope:** all screens fully wired — no permanent mock data.
+- **Communication (chosen):** localhost HTTP + WebSocket sidecar (Approach A below).
+
+**The core challenge:** `carl` today is a *one-shot text CLI*
+(`info` / `announce` / `download` / `seed` / `search` / `nostr-keygen`). `session.zig`
+(~60KB) drives a single download or seed to completion and prints human-readable lines. The
+GUI needs the inverse: a **persistent process managing N concurrent torrents + seeds**, that
+exposes structured state and live updates. That refactor is ~70% of the work; the UI port is
+the visible 30%.
+
+### The API surface the screens demand
+
+Grounded in `data.jsx` and the screen `.jsx` files:
+
+- **Live state (stream):** transfers (status / route / sources / pct / size / down / up /
+  eta / peers / seeds / ratio / onion), per-transfer **peers** (addr / port / client / rates /
+  pct / flags / onion-flag), **pieces** heatmap (have / downloading / missing), **files**
+  (name / size / pct / prio), **sources** (tracker / DHT / Nostr with state + interval),
+  **relays** (url / state / net / events), **seeds** (visibility / onion / upTotal /
+  leechers / ratio).
+- **Commands:** add transfer (magnet | .torrent path | HTTP URL) × route × `--nostr`; seed
+  file × visibility (direct / proxy / tor) × announce → returns `.onion`; Nostr NIP-35 search;
+  pause / resume / remove; set route + SOCKS endpoint; edit relay list; keygen / import-nsec
+  → npub; leak-check.
+- **Identity rule:** expose npub only — never the nsec (design stores it in the OS keychain).
+
+**Constraints:**
+
+- Reuse `ws.zig` / `relay.zig` / `proxy.zig` rather than reinventing.
+- Keep the privacy model (3 routes × 3 sources) consistent across every screen.
+- No accounts / social features.
+- Serif (Newsreader) + IBM Plex Sans / Mono type system; self-hosted fonts (matching commit `4abcbb7`).
+
+**Non-goals:** mobile, a hosted/multi-user service, changing the wire/BitTorrent internals,
+auth beyond a local-only token.
+
+**Success criteria:** launch the app → add a real magnet over Tor → watch live piece/peer
+progress → seed a file as a hidden service and copy its `.onion` → search Nostr in Discover →
+all matching the mock visually.
+
+## Chosen Approach — A: Localhost HTTP + WebSocket sidecar
+
+- **Sketch:** `carl daemon` runs an HTTP + WS server on `127.0.0.1:<port>` (reusing `ws.zig`,
+  which already speaks WebSocket for relays). REST/JSON for commands, a WS channel pushing
+  live transfer/peer/relay deltas. Tauri spawns it as a sidecar; React fetches + subscribes
+  directly.
+- **Affected:** new `src/daemon.zig` + `src/api.zig`; refactor `session.zig` →
+  `TorrentManager`; `main.zig` gains a `daemon` command; new `desktop/` (Tauri + Vite/React
+  port of the `.jsx` files).
+- **Tradeoffs:**
+  - Debuggable with `curl` / browser devtools.
+  - The daemon is independently useful (headless, future web UI, reuses the existing `site/`).
+  - Clean language boundary between Zig and the web UI.
+  - Needs a port + a local-only auth token; a second listening socket to secure.
+- **Effort:** L
+
+**Why A over the alternatives:** It's the most debuggable, reuses `ws.zig` directly for the
+live channel, and makes `carl daemon` a first-class headless capability (not just GUI
+plumbing) — which also pays off for the existing `site/`. Secure the port with a random token
+that Tauri passes to both sides; bind to loopback only.
+
+The two rejected alternatives were **B: stdio JSON-RPC through Tauri** (no open socket, but
+harder to debug and all traffic funnels through Rust) and **C: in-process Zig↔Rust FFI** (zero
+IPC, but the riskiest path across a threaded, allocating, async-networking core, and it
+contradicts the daemon decision).
+
+## Sequencing (de-risks the refactor)
+
+Freeze the JSON contract from `data.jsx` first and ship the daemon **serving that mock data**,
+build the entire Tauri + React UI against the frozen contract, *then* replace mock handlers
+with real `TorrentManager` calls one endpoint at a time. UI and backend progress in parallel;
+the UI is never blocked on the Zig refactor.
+
+1. **Contract** — freeze the JSON schema from `data.jsx`; document endpoints + WS message types.
+2. **Mock daemon** — `carl daemon` serves the frozen contract from static fixtures.
+3. **Tauri + React port** — scaffold `desktop/`, port the `.jsx` near-verbatim, wire to the
+   mock daemon. Pixel-parity pass against the screenshots.
+4. **TorrentManager refactor** — turn `session.zig` into a persistent multi-torrent/seed manager.
+5. **Wire endpoints** — replace mock handlers with real manager calls, one screen at a time:
+   Transfers → Discover → Seeding → Settings.
+
+## Open questions (non-blocking — sensible defaults exist)
+
+- **Tauri v2** assumed (current; better sidecar + mobile story). OK?
+- **React port fidelity:** keep React (Vite + TS, port the `.jsx` near-verbatim) vs. rewrite
+  in another framework. Default: keep React — fastest route to pixel-parity.
+- **Daemon lifecycle:** app-managed sidecar (starts/stops with the window) vs. a standalone
+  daemon the app attaches to. Default: app-managed, with attach-if-running.
+- **Tor/keychain:** assume a system Tor at `127.0.0.1:9050` and OS keychain for the nsec
+  (matches the mock). Confirm vs. bundling Tor.

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -38,12 +38,18 @@ carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
 ## Persistence
 
 The daemon persists its transfers, seeds, and editable settings (route +
-download dir) to `<config>/daemon-state.json`, rewritten on every change
-(add/remove/settings) — so a crash or restart loses nothing. On startup it
-replays that state: downloads resume from on-disk pieces (the session
-re-verifies them) and seeds re-hash their file. Relays persist separately via
-the relay config file. Transfers are stored as *specs* (source + route + nostr),
-not live session state, so the saved file is small and human-readable.
+download dir) to a **SQLite** database, `<config>/carl.db`, rewritten in a
+single transaction on every change (add/remove/settings) — so a crash or
+restart loses nothing (verified across `kill -9`). On startup it replays that
+state. Transfers are stored as re-create *specs* (kind + source + route +
+nostr), not live session state.
+
+For true resume, once a magnet's metadata completes the daemon writes the
+resolved `.torrent` next to the data (`<download_dir>/<infohash>.carl.torrent`)
+and repoints that transfer's persisted source at it — so after a restart a
+finished download comes back as a **complete** torrent (the session verifies the
+on-disk pieces) rather than re-fetching metadata. Relays/identity persist
+separately via `nostr_config`.
 
 ## Authentication
 

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -85,6 +85,23 @@ Adds and starts a transfer. Returns `{ "id": "t<N>" }`. `400` on a bad source.
 
 Stops and removes a transfer. `204` on success, `404` if unknown.
 
+### `POST /api/seeds`
+
+Create a torrent from a file and start seeding it. The request **body is the
+raw file content** (so a browser drag-drop or the Tauri shell can upload
+directly); metadata rides in headers:
+
+- `X-Carl-Filename` (required) — the file name (basename only; path components
+  are stripped).
+- `X-Carl-Route` — `direct|proxy|tor` (default `tor`).
+- `X-Carl-Nostr` — `true|false`; when true, publishes a NIP-35 torrent event so
+  it's discoverable.
+
+The daemon writes the file into the download dir, hashes it into a torrent
+in-process (no external tool), and seeds it. Returns `{ "id": "t<N>" }`. Bodies
+are capped at 256 MiB. (The peer-announce for a clearnet/onion endpoint is still
+the CLI's `carl seed` job; this publishes the discoverable torrent metadata.)
+
 ### `POST /api/search`
 
 Body `{ "query": "<text>" }` (or `?q=<text>`). Searches configured Nostr relays

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -1,0 +1,142 @@
+# carl daemon API
+
+`carl daemon` runs a small HTTP + WebSocket server that the desktop GUI (a
+Tauri shell wrapping the design prototype) talks to. It is the backend half of
+the desktop app; the frozen JSON contract below lets the frontend be built and
+the real `session.zig` wiring be filled in independently.
+
+This is the first increment: the **download path** is wired to a real
+`TorrentManager` over `session.zig` (magnet / `.torrent` / HTTP URL, routed
+direct or through a SOCKS proxy), Discover search hits real Nostr relays, and
+identity/relays/settings read the real config. See **Not yet wired** at the end.
+
+## Running
+
+```sh
+carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
+            [--download-dir d] [--token tok]
+```
+
+- Binds **127.0.0.1 only**. Never exposed off the loopback interface.
+- `--port` (default `8088`): the HTTP/WebSocket port.
+- `--bt-port` (default `6881`): the BitTorrent listen port sessions use.
+- `--route` / `--socks`: default route for new transfers and the SOCKS endpoint
+  (`proxy` and `tor` both tunnel through `--socks`; default
+  `socks5h://127.0.0.1:9050`).
+- `--token`: shared secret. If omitted, a random 32-hex token is generated and
+  printed. The startup banner is stable and machine-readable:
+
+  ```
+  carl daemon
+  listen: http://127.0.0.1:8088
+  token: <hex>
+  route: direct
+  ```
+
+  The Tauri sidecar parses the `token:` line and presents it on every request.
+
+## Authentication
+
+Every request must present the token, or the daemon answers `401`:
+
+- REST: header `X-Carl-Token: <token>`.
+- WebSocket: `?token=<token>` query parameter (browsers can't set custom headers
+  on the WebSocket handshake).
+
+`OPTIONS` (CORS preflight) is answered `204` without a token. Responses send
+permissive CORS headers (`Access-Control-Allow-Origin: *`); the token, not CORS,
+is the security boundary, and the daemon is loopback-only.
+
+## REST endpoints
+
+All responses are `application/json` with `Connection: close`.
+
+### `GET /api/state`
+
+The combined initial-load payload (and the per-tick WebSocket push). Object:
+
+```jsonc
+{
+  "transfers": [Transfer],
+  "seeds":     [Seed],
+  "relays":    [Relay],
+  "identity":  Identity,
+  "settings":  Settings
+}
+```
+
+### `GET /api/transfers` → `[Transfer]`
+### `GET /api/seeds` → `[Seed]`
+### `GET /api/relays` → `[Relay]`
+### `GET /api/identity` → `Identity`
+### `GET /api/settings` → `Settings`
+
+### `POST /api/transfers`
+
+Body: `{ "source": "<magnet|.torrent path|http(s) url>", "route": "direct|proxy|tor", "nostr": bool }`.
+Adds and starts a transfer. Returns `{ "id": "t<N>" }`. `400` on a bad source.
+
+### `DELETE /api/transfers/<id>`
+
+Stops and removes a transfer. `204` on success, `404` if unknown.
+
+### `POST /api/search`
+
+Body `{ "query": "<text>" }` (or `?q=<text>`). Searches configured Nostr relays
+for NIP-35 (kind-2003) torrent events, client-side filtered by title/description.
+Returns `[DiscoverResult]`. Routed through the proxy when the route isn't direct.
+
+### `POST /api/settings`
+
+Body may contain `{ "route": "direct|proxy|tor" }`. Updates the default route
+for new transfers; echoes back the full `Settings`. (Other fields are read-only
+in this increment.)
+
+## WebSocket — `GET /ws?token=<token>`
+
+Upgrades to a WebSocket and pushes a `GET /api/state` snapshot as a text frame
+**once per second** — the "live-ish" progress the prototype shows, driven by
+real session counters (download/upload rates are recomputed each tick). The
+daemon does not read client frames; closing the socket ends the push.
+
+## Types
+
+`Transfer`:
+
+```jsonc
+{
+  "id": "t1", "name": "...", "hash": "<40-hex|''>", "magnet": "magnet:?...|''",
+  "status": "downloading|seeding|complete|metadata|stalled",
+  "route": "direct|proxy|tor",
+  "sources": ["tracker"|"dht"|"nostr", ...],
+  "pct": 0-100, "size": <bytes>|null,
+  "down": <bytes/s>, "up": <bytes/s>, "eta": "1m 48s|—|stalled",
+  "peers": <n>, "seeds": <n>, "ratio": <float>|null, "onion": "<addr>"|null
+}
+```
+
+`Peer` (Peers detail tab — see Not yet wired): `{ addr, port, client, down, up, pct, flags, onion }`.
+`FileEntry` (Files tab): `{ name, size, pct, prio }`.
+`Source` (Sources tab): `{ kind, label, state, detail, interval }`.
+`DiscoverResult`: `{ id, title, hash, size, files, trackers, desc, verified, relays:[url], author, age }`.
+`Relay`: `{ url, state: "connected|connecting|unreachable|configured", net: "clearnet|tor", events }`.
+`Seed`: `{ id, name, visibility, onion|null, size, upTotal, up, leechers, ratio, relays }`.
+`Identity`: `{ npub: "<bech32|''>" }` — the nsec is **never** serialized.
+`Settings`: `{ route, socks, relays:[url], downloadDir, listenPort, maxActive, peerLimit, publishNip35 }`.
+
+## Not yet wired (follow-ups)
+
+These are part of the contract but return empty / derived values until later PRs:
+
+- **Per-transfer detail tabs** (`Peer` rows, the piece heatmap, per-file
+  progress, `Source` rows). `session.zig` mutates its `peers`/`active_pieces`
+  collections on its own thread; exposing them safely requires the session to
+  publish a locked snapshot. Until then `GET /api/transfers/<id>/peers` etc. are
+  not served, and snapshots expose transfer-level state only (peer *count*, real
+  `pct` from the bitfield, real rates).
+- **"Seed a file" creation flow** — creating a torrent from a local file and Tor
+  hidden-service generation. `seeds()` currently reflects transfers that have
+  reached the seeding state.
+- **Live relay connection state** — the daemon reports configured relays as
+  `"configured"`; it does not hold persistent relay connections to report
+  connected/unreachable.

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -93,9 +93,17 @@ Returns `[DiscoverResult]`. Routed through the proxy when the route isn't direct
 
 ### `POST /api/settings`
 
-Body may contain `{ "route": "direct|proxy|tor" }`. Updates the default route
-for new transfers; echoes back the full `Settings`. (Other fields are read-only
-in this increment.)
+Body may contain any subset of:
+
+- `"route": "direct|proxy|tor"` — default route for new transfers.
+- `"downloadDir": "<path>"` — where new transfers download (created if needed;
+  existing transfers keep their directory).
+- `"relays": ["wss://…", "ws://…onion"]` — replaces the relay list, persisted to
+  the carl config so search, peer-announce, and the CLI all use it. The
+  background prober picks up the change on its next cycle.
+
+Echoes back the full `Settings`. `listenPort` / `maxActive` / `peerLimit` remain
+read-only in this increment.
 
 ## WebSocket — `GET /ws?token=<token>`
 

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -68,6 +68,11 @@ The combined initial-load payload (and the per-tick WebSocket push). Object:
 ### `GET /api/transfers` → `[Transfer]`
 ### `GET /api/seeds` → `[Seed]`
 ### `GET /api/relays` → `[Relay]`
+
+A background prober refreshes relay reachability every ~30s (open + close a
+connection per relay, through the configured route), so `state` reflects real
+`connected` / `unreachable` status rather than just `configured`. The same
+status rides in `GET /api/state` and the WebSocket push.
 ### `GET /api/identity` → `Identity`
 ### `GET /api/settings` → `Settings`
 
@@ -137,6 +142,6 @@ These are part of the contract but return empty / derived values until later PRs
 - **"Seed a file" creation flow** — creating a torrent from a local file and Tor
   hidden-service generation. `seeds()` currently reflects transfers that have
   reached the seeding state.
-- **Live relay connection state** — the daemon reports configured relays as
-  `"configured"`; it does not hold persistent relay connections to report
-  connected/unreachable.
+- **Per-relay event counts** — relay reachability is now probed live (see
+  `GET /api/relays`), but `events` is still reported as `0`; surfacing real
+  per-relay event throughput is a follow-up.

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -35,6 +35,16 @@ carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
 
   The Tauri sidecar parses the `token:` line and presents it on every request.
 
+## Persistence
+
+The daemon persists its transfers, seeds, and editable settings (route +
+download dir) to `<config>/daemon-state.json`, rewritten on every change
+(add/remove/settings) — so a crash or restart loses nothing. On startup it
+replays that state: downloads resume from on-disk pieces (the session
+re-verifies them) and seeds re-hash their file. Relays persist separately via
+the relay config file. Transfers are stored as *specs* (source + route + nostr),
+not live session state, so the saved file is small and human-readable.
+
 ## Authentication
 
 Every request must present the token, or the daemon answers `401`:

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -14,8 +14,12 @@ identity/relays/settings read the real config. See **Not yet wired** at the end.
 
 ```sh
 carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
-            [--download-dir d] [--token tok]
+            [--download-dir d] [--token tok] [--parent-pid pid]
 ```
+
+- `--parent-pid`: when set (the desktop shell passes its own PID), a watchdog
+  shuts the daemon down if that process dies — so a hard-killed app never leaves
+  an orphaned daemon holding the port.
 
 - Binds **127.0.0.1 only**. Never exposed off the loopback interface.
 - `--port` (default `8088`): the HTTP/WebSocket port.

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,0 +1,651 @@
+//! Daemon API contract: the JSON shapes the desktop GUI consumes.
+//!
+//! These structs mirror the design prototype's data model (the `data.jsx`
+//! fixture in the Claude Design handoff) so the Tauri/React frontend can be
+//! built against a frozen contract. The full contract is documented in
+//! `docs/daemon-api.md`.
+//!
+//! Serialization is hand-rolled with `std.ArrayList(u8)` (the same pattern as
+//! `nostr.zig`'s `encodeEvent`) rather than `std.json.stringify`, so field
+//! names and number formatting are explicit and stable.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// How a transfer's traffic is routed. The single most important privacy axis,
+/// surfaced on every transfer in the UI.
+pub const Route = enum {
+    direct,
+    proxy,
+    tor,
+
+    pub fn jsonName(self: Route) []const u8 {
+        return @tagName(self);
+    }
+
+    pub fn parse(s: []const u8) ?Route {
+        return std.meta.stringToEnum(Route, s);
+    }
+};
+
+/// Lifecycle state of a transfer. Drives the status pill in the UI.
+pub const Status = enum {
+    downloading,
+    seeding,
+    complete,
+    metadata,
+    stalled,
+
+    pub fn jsonName(self: Status) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// A peer-discovery source. Distinct from `Route`: a transfer can use several.
+pub const SourceKind = enum {
+    tracker,
+    dht,
+    nostr,
+
+    pub fn jsonName(self: SourceKind) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// One row in the Transfers list. Lifetimes: all slices are borrowed from the
+/// owner that built the value (the manager snapshot owns its backing buffers
+/// and frees them together), so `Transfer` itself has no `deinit`.
+pub const Transfer = struct {
+    id: []const u8,
+    name: []const u8,
+    /// info-hash, lowercase hex (40 chars), or empty if not yet known.
+    hash: []const u8,
+    magnet: []const u8,
+    status: Status,
+    route: Route,
+    sources: []const SourceKind,
+    /// 0..100 completion percentage.
+    pct: u8,
+    /// Total size in bytes; null until metadata is known (magnet bootstrap).
+    size: ?u64,
+    /// Instantaneous download / upload rate, bytes per second.
+    down: u64,
+    up: u64,
+    /// Human-readable ETA ("1m 48s", "—", "stalled").
+    eta: []const u8,
+    peers: u32,
+    seeds: u32,
+    /// Upload/download ratio; null while still downloading.
+    ratio: ?f64 = null,
+    /// .onion address when seeding as a hidden service; null otherwise.
+    onion: ?[]const u8 = null,
+};
+
+/// One peer in a transfer's Peers detail tab.
+pub const Peer = struct {
+    addr: []const u8,
+    port: u16,
+    client: []const u8,
+    down: u64,
+    up: u64,
+    pct: u8,
+    /// BEP-style flag string ("DUE", "DU", ...).
+    flags: []const u8,
+    onion: bool = false,
+};
+
+/// One file in a transfer's Files detail tab.
+pub const FileEntry = struct {
+    name: []const u8,
+    size: u64,
+    pct: u8,
+    /// "normal" | "high" | "skip"
+    prio: []const u8 = "normal",
+};
+
+/// One peer-discovery source row in the Sources detail tab.
+pub const Source = struct {
+    kind: SourceKind,
+    label: []const u8,
+    state: []const u8,
+    detail: []const u8,
+    interval: []const u8 = "—",
+};
+
+/// A Nostr (NIP-35) search result card in Discover.
+pub const DiscoverResult = struct {
+    id: []const u8,
+    title: []const u8,
+    hash: []const u8,
+    size: u64,
+    files: u32,
+    trackers: u32,
+    desc: []const u8,
+    verified: bool,
+    relays: []const []const u8,
+    author: []const u8,
+    age: []const u8,
+};
+
+/// A configured Nostr relay and its connection state.
+pub const Relay = struct {
+    url: []const u8,
+    /// "connected" | "connecting" | "unreachable" | "configured"
+    state: []const u8,
+    /// "clearnet" | "tor"
+    net: []const u8,
+    events: u64 = 0,
+};
+
+/// A file being seeded.
+pub const Seed = struct {
+    id: []const u8,
+    name: []const u8,
+    /// matches Route names; "tor" implies an onion address.
+    visibility: Route,
+    onion: ?[]const u8 = null,
+    size: u64,
+    up_total: u64,
+    up: u64,
+    leechers: u32,
+    ratio: f64,
+    relays: u32 = 0,
+};
+
+/// Local Nostr identity. The secret key (nsec) is NEVER serialized.
+pub const Identity = struct {
+    /// bech32 npub, or empty if no key is configured.
+    npub: []const u8,
+};
+
+/// User-facing settings. Mirrors the Settings screen.
+pub const Settings = struct {
+    route: Route,
+    socks: []const u8,
+    relays: []const []const u8,
+    download_dir: []const u8,
+    listen_port: u16,
+    max_active: u32,
+    peer_limit: u32,
+    publish_nip35: bool,
+};
+
+// ===========================================================================
+// JSON writer
+// ===========================================================================
+
+/// Minimal JSON writer over an owned `std.ArrayList(u8)`. Tracks whether a
+/// separator is needed between object members / array elements so callers don't
+/// have to thread comma bookkeeping by hand.
+pub const Json = struct {
+    buf: std.ArrayList(u8),
+    allocator: Allocator,
+    /// Stack of "needs a leading comma before the next item" flags, one per
+    /// open object/array. Depth is bounded by the contract's nesting.
+    need_comma: [16]bool = [_]bool{false} ** 16,
+    depth: usize = 0,
+
+    pub fn init(allocator: Allocator) Json {
+        return .{ .buf = .empty, .allocator = allocator };
+    }
+
+    pub fn deinit(self: *Json) void {
+        self.buf.deinit(self.allocator);
+    }
+
+    /// Hand ownership of the serialized bytes to the caller.
+    pub fn toOwnedSlice(self: *Json) Allocator.Error![]u8 {
+        return self.buf.toOwnedSlice(self.allocator);
+    }
+
+    fn sep(self: *Json) Allocator.Error!void {
+        if (self.depth > 0 and self.need_comma[self.depth - 1]) {
+            try self.buf.append(self.allocator, ',');
+        }
+        if (self.depth > 0) self.need_comma[self.depth - 1] = true;
+    }
+
+    fn push(self: *Json) void {
+        if (self.depth < self.need_comma.len) self.need_comma[self.depth] = false;
+        self.depth += 1;
+    }
+
+    fn pop(self: *Json) void {
+        if (self.depth > 0) self.depth -= 1;
+    }
+
+    pub fn beginObject(self: *Json) Allocator.Error!void {
+        try self.sep();
+        try self.buf.append(self.allocator, '{');
+        self.push();
+    }
+
+    pub fn endObject(self: *Json) Allocator.Error!void {
+        try self.buf.append(self.allocator, '}');
+        self.pop();
+    }
+
+    pub fn beginArray(self: *Json) Allocator.Error!void {
+        try self.sep();
+        try self.buf.append(self.allocator, '[');
+        self.push();
+    }
+
+    pub fn endArray(self: *Json) Allocator.Error!void {
+        try self.buf.append(self.allocator, ']');
+        self.pop();
+    }
+
+    /// Write an object key. The next value call supplies its value.
+    pub fn key(self: *Json, name: []const u8) Allocator.Error!void {
+        try self.sep();
+        try self.writeString(name);
+        try self.buf.append(self.allocator, ':');
+        // A key consumes the separator slot; the value that follows must not
+        // emit another comma before itself.
+        if (self.depth > 0) self.need_comma[self.depth - 1] = false;
+    }
+
+    pub fn string(self: *Json, v: []const u8) Allocator.Error!void {
+        try self.sep();
+        try self.writeString(v);
+    }
+
+    pub fn number(self: *Json, v: anytype) Allocator.Error!void {
+        try self.sep();
+        var tmp: [24]u8 = undefined;
+        const s = std.fmt.bufPrint(&tmp, "{d}", .{v}) catch unreachable;
+        try self.buf.appendSlice(self.allocator, s);
+    }
+
+    /// Floats are emitted with two decimals (ratios, rates) to keep the wire
+    /// representation deterministic for the UI.
+    pub fn float(self: *Json, v: f64) Allocator.Error!void {
+        try self.sep();
+        var tmp: [32]u8 = undefined;
+        const s = std.fmt.bufPrint(&tmp, "{d:.2}", .{v}) catch unreachable;
+        try self.buf.appendSlice(self.allocator, s);
+    }
+
+    pub fn boolean(self: *Json, v: bool) Allocator.Error!void {
+        try self.sep();
+        try self.buf.appendSlice(self.allocator, if (v) "true" else "false");
+    }
+
+    pub fn nullValue(self: *Json) Allocator.Error!void {
+        try self.sep();
+        try self.buf.appendSlice(self.allocator, "null");
+    }
+
+    /// Convenience: write `"key": "value"`.
+    pub fn keyString(self: *Json, name: []const u8, v: []const u8) Allocator.Error!void {
+        try self.key(name);
+        try self.string(v);
+    }
+
+    pub fn keyNumber(self: *Json, name: []const u8, v: anytype) Allocator.Error!void {
+        try self.key(name);
+        try self.number(v);
+    }
+
+    pub fn keyBool(self: *Json, name: []const u8, v: bool) Allocator.Error!void {
+        try self.key(name);
+        try self.boolean(v);
+    }
+
+    fn writeString(self: *Json, s: []const u8) Allocator.Error!void {
+        try self.buf.append(self.allocator, '"');
+        for (s) |c| {
+            switch (c) {
+                '"' => try self.buf.appendSlice(self.allocator, "\\\""),
+                '\\' => try self.buf.appendSlice(self.allocator, "\\\\"),
+                '\n' => try self.buf.appendSlice(self.allocator, "\\n"),
+                '\r' => try self.buf.appendSlice(self.allocator, "\\r"),
+                '\t' => try self.buf.appendSlice(self.allocator, "\\t"),
+                0x00...0x08, 0x0b, 0x0c, 0x0e...0x1f => {
+                    var tmp: [8]u8 = undefined;
+                    const esc = std.fmt.bufPrint(&tmp, "\\u{x:0>4}", .{c}) catch unreachable;
+                    try self.buf.appendSlice(self.allocator, esc);
+                },
+                else => try self.buf.append(self.allocator, c),
+            }
+        }
+        try self.buf.append(self.allocator, '"');
+    }
+};
+
+// ===========================================================================
+// Serializers — each appends one value to an open Json writer.
+// ===========================================================================
+
+fn writeSourceArray(j: *Json, sources: []const SourceKind) Allocator.Error!void {
+    try j.beginArray();
+    for (sources) |s| try j.string(s.jsonName());
+    try j.endArray();
+}
+
+fn writeStringArray(j: *Json, items: []const []const u8) Allocator.Error!void {
+    try j.beginArray();
+    for (items) |s| try j.string(s);
+    try j.endArray();
+}
+
+pub fn writeTransfer(j: *Json, t: Transfer) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("id", t.id);
+    try j.keyString("name", t.name);
+    try j.keyString("hash", t.hash);
+    try j.keyString("magnet", t.magnet);
+    try j.keyString("status", t.status.jsonName());
+    try j.keyString("route", t.route.jsonName());
+    try j.key("sources");
+    try writeSourceArray(j, t.sources);
+    try j.keyNumber("pct", t.pct);
+    try j.key("size");
+    if (t.size) |s| try j.number(s) else try j.nullValue();
+    try j.keyNumber("down", t.down);
+    try j.keyNumber("up", t.up);
+    try j.keyString("eta", t.eta);
+    try j.keyNumber("peers", t.peers);
+    try j.keyNumber("seeds", t.seeds);
+    try j.key("ratio");
+    if (t.ratio) |r| try j.float(r) else try j.nullValue();
+    try j.key("onion");
+    if (t.onion) |o| try j.string(o) else try j.nullValue();
+    try j.endObject();
+}
+
+pub fn writePeer(j: *Json, p: Peer) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("addr", p.addr);
+    try j.keyNumber("port", p.port);
+    try j.keyString("client", p.client);
+    try j.keyNumber("down", p.down);
+    try j.keyNumber("up", p.up);
+    try j.keyNumber("pct", p.pct);
+    try j.keyString("flags", p.flags);
+    try j.keyBool("onion", p.onion);
+    try j.endObject();
+}
+
+pub fn writeFileEntry(j: *Json, f: FileEntry) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("name", f.name);
+    try j.keyNumber("size", f.size);
+    try j.keyNumber("pct", f.pct);
+    try j.keyString("prio", f.prio);
+    try j.endObject();
+}
+
+pub fn writeSource(j: *Json, s: Source) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("kind", s.kind.jsonName());
+    try j.keyString("label", s.label);
+    try j.keyString("state", s.state);
+    try j.keyString("detail", s.detail);
+    try j.keyString("interval", s.interval);
+    try j.endObject();
+}
+
+pub fn writeDiscoverResult(j: *Json, d: DiscoverResult) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("id", d.id);
+    try j.keyString("title", d.title);
+    try j.keyString("hash", d.hash);
+    try j.keyNumber("size", d.size);
+    try j.keyNumber("files", d.files);
+    try j.keyNumber("trackers", d.trackers);
+    try j.keyString("desc", d.desc);
+    try j.keyBool("verified", d.verified);
+    try j.key("relays");
+    try writeStringArray(j, d.relays);
+    try j.keyString("author", d.author);
+    try j.keyString("age", d.age);
+    try j.endObject();
+}
+
+pub fn writeRelay(j: *Json, r: Relay) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("url", r.url);
+    try j.keyString("state", r.state);
+    try j.keyString("net", r.net);
+    try j.keyNumber("events", r.events);
+    try j.endObject();
+}
+
+pub fn writeSeed(j: *Json, s: Seed) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("id", s.id);
+    try j.keyString("name", s.name);
+    try j.keyString("visibility", s.visibility.jsonName());
+    try j.key("onion");
+    if (s.onion) |o| try j.string(o) else try j.nullValue();
+    try j.keyNumber("size", s.size);
+    try j.keyNumber("upTotal", s.up_total);
+    try j.keyNumber("up", s.up);
+    try j.keyNumber("leechers", s.leechers);
+    try j.key("ratio");
+    try j.float(s.ratio);
+    try j.keyNumber("relays", s.relays);
+    try j.endObject();
+}
+
+pub fn writeIdentity(j: *Json, id: Identity) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("npub", id.npub);
+    try j.endObject();
+}
+
+pub fn writeSettings(j: *Json, s: Settings) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("route", s.route.jsonName());
+    try j.keyString("socks", s.socks);
+    try j.key("relays");
+    try writeStringArray(j, s.relays);
+    try j.keyString("downloadDir", s.download_dir);
+    try j.keyNumber("listenPort", s.listen_port);
+    try j.keyNumber("maxActive", s.max_active);
+    try j.keyNumber("peerLimit", s.peer_limit);
+    try j.keyBool("publishNip35", s.publish_nip35);
+    try j.endObject();
+}
+
+/// Serialize a list of transfers as a JSON array. Caller owns the result.
+pub fn transfersJson(allocator: Allocator, transfers: []const Transfer) Allocator.Error![]u8 {
+    var j = Json.init(allocator);
+    errdefer j.deinit();
+    try j.beginArray();
+    for (transfers) |t| try writeTransfer(&j, t);
+    try j.endArray();
+    return j.toOwnedSlice();
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+/// Parse `s` as JSON and assert it succeeds, returning the parsed tree so tests
+/// can assert on individual fields. Caller must deinit.
+fn parse(allocator: Allocator, s: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, s, .{});
+}
+
+test "Json: object with separators is valid and re-parses" {
+    const allocator = testing.allocator;
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try j.beginObject();
+    try j.keyString("a", "x");
+    try j.keyNumber("b", 42);
+    try j.keyBool("c", true);
+    try j.endObject();
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    try testing.expectEqualStrings("x", p.value.object.get("a").?.string);
+    try testing.expectEqual(@as(i64, 42), p.value.object.get("b").?.integer);
+    try testing.expectEqual(true, p.value.object.get("c").?.bool);
+}
+
+test "Json: string escaping" {
+    const allocator = testing.allocator;
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try j.beginObject();
+    try j.keyString("k", "a\"b\\c\nd\te");
+    try j.endObject();
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    try testing.expectEqualStrings("a\"b\\c\nd\te", p.value.object.get("k").?.string);
+}
+
+test "writeTransfer: round-trips through std.json" {
+    const allocator = testing.allocator;
+    const sources = [_]SourceKind{ .tracker, .dht, .nostr };
+    const t = Transfer{
+        .id = "t1",
+        .name = "debian-12.5.0-amd64-netinst.iso",
+        .hash = "a1d9f3c2e7b48f10c9a6d2e5f8b3071c4e9a2d6f",
+        .magnet = "magnet:?xt=urn:btih:a1d9f3c2",
+        .status = .downloading,
+        .route = .direct,
+        .sources = &sources,
+        .pct = 64,
+        .size = 658 * 1024 * 1024,
+        .down = 4_404_019,
+        .up = 262_144,
+        .eta = "1m 48s",
+        .peers = 38,
+        .seeds = 64,
+        .ratio = null,
+        .onion = null,
+    };
+
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try writeTransfer(&j, t);
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expectEqualStrings("t1", o.get("id").?.string);
+    try testing.expectEqualStrings("downloading", o.get("status").?.string);
+    try testing.expectEqualStrings("direct", o.get("route").?.string);
+    try testing.expectEqual(@as(i64, 64), o.get("pct").?.integer);
+    try testing.expectEqual(@as(usize, 3), o.get("sources").?.array.items.len);
+    try testing.expectEqualStrings("tracker", o.get("sources").?.array.items[0].string);
+    try testing.expectEqual(std.json.Value.null, o.get("ratio").?);
+    try testing.expectEqual(std.json.Value.null, o.get("onion").?);
+    try testing.expectEqual(@as(i64, 658 * 1024 * 1024), o.get("size").?.integer);
+}
+
+test "writeTransfer: optional ratio + onion emit values" {
+    const allocator = testing.allocator;
+    const sources = [_]SourceKind{.nostr};
+    const t = Transfer{
+        .id = "t2",
+        .name = "archlinux.iso",
+        .hash = "7f2b9c4e",
+        .magnet = "magnet:?xt=urn:btih:7f2b9c4e",
+        .status = .seeding,
+        .route = .tor,
+        .sources = &sources,
+        .pct = 100,
+        .size = 1_202_590_842,
+        .down = 0,
+        .up = 1_887_436,
+        .eta = "—",
+        .peers = 12,
+        .seeds = 0,
+        .ratio = 3.41,
+        .onion = "g7k3xqp4.onion",
+    };
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try writeTransfer(&j, t);
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expectApproxEqAbs(@as(f64, 3.41), o.get("ratio").?.float, 0.001);
+    try testing.expectEqualStrings("g7k3xqp4.onion", o.get("onion").?.string);
+    try testing.expectEqualStrings("tor", o.get("route").?.string);
+}
+
+test "transfersJson: array of transfers" {
+    const allocator = testing.allocator;
+    const sources = [_]SourceKind{.dht};
+    const items = [_]Transfer{
+        .{ .id = "a", .name = "n1", .hash = "h1", .magnet = "m1", .status = .downloading, .route = .proxy, .sources = &sources, .pct = 10, .size = null, .down = 1, .up = 2, .eta = "x", .peers = 1, .seeds = 2 },
+        .{ .id = "b", .name = "n2", .hash = "h2", .magnet = "m2", .status = .complete, .route = .direct, .sources = &sources, .pct = 100, .size = 99, .down = 0, .up = 0, .eta = "—", .peers = 0, .seeds = 0 },
+    };
+    const s = try transfersJson(allocator, &items);
+    defer allocator.free(s);
+
+    var p = try parse(allocator, s);
+    defer p.deinit();
+    try testing.expectEqual(@as(usize, 2), p.value.array.items.len);
+    try testing.expectEqual(std.json.Value.null, p.value.array.items[0].object.get("size").?);
+    try testing.expectEqualStrings("complete", p.value.array.items[1].object.get("status").?.string);
+}
+
+test "writeSettings: relays array + camelCase keys" {
+    const allocator = testing.allocator;
+    const relays = [_][]const u8{ "wss://relay.damus.io", "wss://nos.lol" };
+    const s = Settings{
+        .route = .tor,
+        .socks = "socks5h://127.0.0.1:9050",
+        .relays = &relays,
+        .download_dir = "~/Downloads/carl",
+        .listen_port = 51413,
+        .max_active = 8,
+        .peer_limit = 60,
+        .publish_nip35 = true,
+    };
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try writeSettings(&j, s);
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expectEqual(@as(usize, 2), o.get("relays").?.array.items.len);
+    try testing.expectEqual(@as(i64, 51413), o.get("listenPort").?.integer);
+    try testing.expectEqual(true, o.get("publishNip35").?.bool);
+}
+
+test "writeSeed: upTotal camelCase and float ratio" {
+    const allocator = testing.allocator;
+    const s = Seed{
+        .id = "s1",
+        .name = "arch.iso",
+        .visibility = .tor,
+        .onion = "abc.onion",
+        .size = 100,
+        .up_total = 382,
+        .up = 18,
+        .leechers = 12,
+        .ratio = 3.41,
+        .relays = 4,
+    };
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try writeSeed(&j, s);
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expectEqual(@as(i64, 382), o.get("upTotal").?.integer);
+    try testing.expectApproxEqAbs(@as(f64, 3.41), o.get("ratio").?.float, 0.001);
+    try testing.expectEqualStrings("abc.onion", o.get("onion").?.string);
+}
+
+test "Route.parse round-trips names" {
+    try testing.expectEqual(Route.tor, Route.parse("tor").?);
+    try testing.expectEqual(Route.proxy, Route.parse("proxy").?);
+    try testing.expectEqual(Route.direct, Route.parse("direct").?);
+    try testing.expectEqual(@as(?Route, null), Route.parse("bogus"));
+}

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -39,12 +39,20 @@ const max_conns: u32 = 64;
 /// then stalls (or lies about Content-Length) can't wedge a thread forever.
 const recv_timeout_secs: u32 = 30;
 
+/// How often the background prober refreshes relay reachability. The daemon
+/// holds no persistent relay connections, so without this the UI could only
+/// ever show relays as "configured" (never connected).
+const probe_interval_ns: u64 = 30 * std.time.ns_per_s;
+
 pub const Daemon = struct {
     allocator: Allocator,
     manager: *manager_mod.Manager,
     token: []const u8,
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
     conns: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    /// Last relay-health probe result (owned). Guarded by `health_mutex`.
+    health_mutex: std.Thread.Mutex = .{},
+    health: []api.Relay = &.{},
 
     /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
     pub fn serve(self: *Daemon, port: u16) !void {
@@ -53,6 +61,13 @@ pub const Daemon = struct {
         defer server.deinit();
 
         log.info("daemon listening on http://127.0.0.1:{d}", .{port});
+
+        // Background relay-health prober: refreshes connected/unreachable status
+        // so the UI's relay strip is real, without probing on every state tick.
+        if (std.Thread.spawn(.{}, Daemon.relayHealthLoop, .{self})) |p| {
+            p.detach();
+        } else |_| {}
+
         // Poll the listen socket with a timeout rather than blocking in
         // accept(): Zig's accept() retries on EINTR, so a bare accept would
         // never observe the SIGINT-set `shutdown_requested`. Polling lets the
@@ -91,6 +106,99 @@ pub const Daemon = struct {
 
     pub fn stop(self: *Daemon) void {
         self.running.store(false, .release);
+    }
+
+    /// Free the cached relay health. Call after `serve` returns (and the prober
+    /// has wound down) before the allocator is torn down.
+    pub fn deinit(self: *Daemon) void {
+        self.health_mutex.lock();
+        const h = self.health;
+        self.health = &.{};
+        self.health_mutex.unlock();
+        freeHealth(self.allocator, h);
+    }
+
+    /// Snapshot current relay health into `arena`. Before the first probe lands,
+    /// falls back to the configured list (state "configured").
+    fn healthSnapshot(self: *Daemon, arena: Allocator) ![]api.Relay {
+        self.health_mutex.lock();
+        defer self.health_mutex.unlock();
+        if (self.health.len == 0) {
+            const urls = try nostr_config.readRelays(arena);
+            const out = try arena.alloc(api.Relay, urls.len);
+            for (urls, 0..) |url, i| {
+                out[i] = .{ .url = url, .state = "configured", .net = relayNet(url), .events = 0 };
+            }
+            return out;
+        }
+        const out = try arena.alloc(api.Relay, self.health.len);
+        for (self.health, 0..) |r, i| {
+            // state/net are static strings; only url is owned by the cache.
+            out[i] = .{ .url = try arena.dupe(u8, r.url), .state = r.state, .net = r.net, .events = r.events };
+        }
+        return out;
+    }
+
+    fn relayHealthLoop(self: *Daemon) void {
+        while (self.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
+            self.probeRelays();
+            var slept: u64 = 0;
+            while (slept < probe_interval_ns and
+                self.running.load(.acquire) and
+                !session_mod.shutdown_requested.load(.acquire)) : (slept += 250 * std.time.ns_per_ms)
+            {
+                std.Thread.sleep(250 * std.time.ns_per_ms);
+            }
+        }
+    }
+
+    /// Probe each configured relay once (open + close a connection) and publish
+    /// the connected/unreachable result. Onion relays are only probed when a
+    /// proxy is set (otherwise they're unreachable by definition).
+    fn probeRelays(self: *Daemon) void {
+        const a = self.allocator;
+        const urls = nostr_config.readRelays(a) catch return;
+        defer nostr_config.freeRelays(a, urls);
+
+        var proxy: ?proxy_mod.Proxy = null;
+        if (self.manager.cfg.route != .direct) {
+            proxy = proxy_mod.parseUrl(self.manager.cfg.socks) catch null;
+        }
+
+        var list: std.ArrayList(api.Relay) = .empty;
+        for (urls) |url| {
+            const onion = std.mem.indexOf(u8, url, ".onion") != null;
+            var state: []const u8 = "configured";
+            if (!(onion and proxy == null)) {
+                if (relay_mod.Relay.connect(a, url, proxy)) |r| {
+                    var rc = r;
+                    rc.deinit();
+                    state = "connected";
+                } else |_| {
+                    state = "unreachable";
+                }
+            }
+            const dup = a.dupe(u8, url) catch {
+                freeHealth(a, list.toOwnedSlice(a) catch &.{});
+                return;
+            };
+            list.append(a, .{ .url = dup, .state = state, .net = relayNet(url), .events = 0 }) catch {
+                a.free(dup);
+                freeHealth(a, list.toOwnedSlice(a) catch &.{});
+                return;
+            };
+        }
+        const fresh = list.toOwnedSlice(a) catch {
+            for (list.items) |r| a.free(r.url);
+            list.deinit(a);
+            return;
+        };
+
+        self.health_mutex.lock();
+        const old = self.health;
+        self.health = fresh;
+        self.health_mutex.unlock();
+        freeHealth(a, old);
     }
 };
 
@@ -194,9 +302,9 @@ const Conn = struct {
         var arena = std.heap.ArenaAllocator.init(a);
         defer arena.deinit();
         const aa = arena.allocator();
-        const relay_urls = try nostr_config.readRelays(aa);
+        const relays = try self.daemon.healthSnapshot(aa);
         const npub = try readNpub(aa);
-        const json = try buildStateJson(aa, self.daemon, relay_urls, npub);
+        const json = try buildStateJson(aa, self.daemon, relays, npub);
         try self.sendJson(.ok, json);
     }
 
@@ -228,7 +336,7 @@ const Conn = struct {
         var arena = std.heap.ArenaAllocator.init(a);
         defer arena.deinit();
         const aa = arena.allocator();
-        const relays = try readRelayStates(aa);
+        const relays = try self.daemon.healthSnapshot(aa);
         var j = api.Json.init(aa);
         try j.beginArray();
         for (relays) |r| try api.writeRelay(&j, r);
@@ -345,12 +453,10 @@ const Conn = struct {
             "Sec-WebSocket-Accept: {s}\r\n\r\n", .{accept}) catch return;
         self.sendAll(upgrade) catch return;
 
-        // Read identity + relay config once for the lifetime of the connection
-        // (a connection-scoped arena), so the per-tick push doesn't hit the
-        // filesystem every second. Transfers/seeds are still read live per tick.
+        // Read the npub once for the connection (it's read from the keyfile);
+        // relay health is an in-memory snapshot taken cheaply per tick.
         var conn_arena = std.heap.ArenaAllocator.init(a);
         defer conn_arena.deinit();
-        const relay_urls: []const []const u8 = nostr_config.readRelays(conn_arena.allocator()) catch &.{};
         const npub: []const u8 = readNpub(conn_arena.allocator()) catch "";
 
         // Push a fresh snapshot every interval until the client closes (send
@@ -359,7 +465,8 @@ const Conn = struct {
         // the next send failing.
         while (self.daemon.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
             var arena = std.heap.ArenaAllocator.init(a);
-            const json = buildStateJson(arena.allocator(), self.daemon, relay_urls, npub) catch {
+            const relays: []const api.Relay = self.daemon.healthSnapshot(arena.allocator()) catch &.{};
+            const json = buildStateJson(arena.allocator(), self.daemon, relays, npub) catch {
                 arena.deinit();
                 break;
             };
@@ -415,9 +522,13 @@ const Conn = struct {
 /// rather than read here, so the WebSocket push can read them once per
 /// connection instead of hitting the filesystem on every tick. Transfers and
 /// seeds are always read live from the manager.
-fn buildStateJson(arena: Allocator, daemon: *Daemon, relay_urls: []const []const u8, npub: []const u8) ![]u8 {
+fn buildStateJson(arena: Allocator, daemon: *Daemon, relays: []const api.Relay, npub: []const u8) ![]u8 {
     const transfers = try daemon.manager.snapshot(arena);
     const seeds = try daemon.manager.seeds(arena);
+
+    // Settings echoes the relay URLs; derive them from the probed list.
+    const relay_urls = try arena.alloc([]const u8, relays.len);
+    for (relays, 0..) |r, i| relay_urls[i] = r.url;
 
     var j = api.Json.init(arena);
     try j.beginObject();
@@ -431,7 +542,7 @@ fn buildStateJson(arena: Allocator, daemon: *Daemon, relay_urls: []const []const
     try j.endArray();
     try j.key("relays");
     try j.beginArray();
-    for (relay_urls) |url| try api.writeRelay(&j, .{ .url = url, .state = "configured", .net = relayNet(url), .events = 0 });
+    for (relays) |r| try api.writeRelay(&j, r);
     try j.endArray();
     try j.key("identity");
     try api.writeIdentity(&j, .{ .npub = npub });
@@ -441,16 +552,10 @@ fn buildStateJson(arena: Allocator, daemon: *Daemon, relay_urls: []const []const
     return j.buf.items;
 }
 
-/// Read configured relays into `api.Relay` rows. The daemon doesn't hold
-/// persistent relay connections, so state is reported as "configured"; the
-/// clearnet/tor split is derived from the URL.
-fn readRelayStates(arena: Allocator) ![]api.Relay {
-    const urls = try nostr_config.readRelays(arena);
-    const out = try arena.alloc(api.Relay, urls.len);
-    for (urls, 0..) |url, i| {
-        out[i] = .{ .url = url, .state = "configured", .net = relayNet(url), .events = 0 };
-    }
-    return out;
+/// Free an owned relay-health list (the url strings, then the slice).
+fn freeHealth(a: Allocator, list: []api.Relay) void {
+    for (list) |r| a.free(r.url);
+    if (list.len > 0) a.free(list);
 }
 
 fn relayNet(url: []const u8) []const u8 {
@@ -661,7 +766,10 @@ test "buildStateJson: produces the five top-level keys" {
 
     var arena = std.heap.ArenaAllocator.init(a);
     defer arena.deinit();
-    const relays = [_][]const u8{ "wss://relay.damus.io", "ws://abc.onion" };
+    const relays = [_]api.Relay{
+        .{ .url = "wss://relay.damus.io", .state = "connected", .net = "clearnet", .events = 0 },
+        .{ .url = "ws://abc.onion", .state = "unreachable", .net = "tor", .events = 0 },
+    };
     const json = try buildStateJson(arena.allocator(), &d, &relays, "npub1test");
 
     var p = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json, .{});
@@ -674,6 +782,7 @@ test "buildStateJson: produces the five top-level keys" {
     try testing.expect(o.get("settings").? == .object);
     try testing.expectEqual(@as(usize, 0), o.get("transfers").?.array.items.len);
     try testing.expectEqual(@as(usize, 2), o.get("relays").?.array.items.len);
+    try testing.expectEqualStrings("connected", o.get("relays").?.array.items[0].object.get("state").?.string);
     try testing.expectEqualStrings("tor", o.get("relays").?.array.items[1].object.get("net").?.string);
     try testing.expectEqualStrings("npub1test", o.get("identity").?.object.get("npub").?.string);
 }

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -145,6 +145,9 @@ pub const Daemon = struct {
     fn relayHealthLoop(self: *Daemon) void {
         while (self.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
             self.probeRelays();
+            // Persist any newly-resolved magnet torrents (headless coverage; the
+            // WS push also does this ~1/s when the GUI is connected).
+            self.manager.checkpoint();
             var slept: u64 = 0;
             while (slept < probe_interval_ns and
                 self.running.load(.acquire) and
@@ -529,6 +532,9 @@ const Conn = struct {
         // GUI only needs the push channel — so a closed socket is detected by
         // the next send failing.
         while (self.daemon.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
+            // Cheap when nothing changed; captures a resolved magnet's .torrent
+            // within ~1s so a restart resumes it as a complete torrent.
+            self.daemon.manager.checkpoint();
             var arena = std.heap.ArenaAllocator.init(a);
             const relays: []const api.Relay = self.daemon.healthSnapshot(arena.allocator()) catch &.{};
             const json = buildStateJson(arena.allocator(), self.daemon, relays, npub) catch {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -30,11 +30,21 @@ const log = std.log.scoped(.daemon);
 /// How often the WebSocket pushes a fresh state snapshot.
 const push_interval_ns: u64 = std.time.ns_per_s;
 
+/// Cap on concurrent connections, so a misbehaving client can't spawn unbounded
+/// threads. A single GUI uses ~2 (one REST poll + one WebSocket); the headroom
+/// covers bursts.
+const max_conns: u32 = 64;
+
+/// Recv timeout (seconds) on accepted sockets, so a client that connects and
+/// then stalls (or lies about Content-Length) can't wedge a thread forever.
+const recv_timeout_secs: u32 = 30;
+
 pub const Daemon = struct {
     allocator: Allocator,
     manager: *manager_mod.Manager,
     token: []const u8,
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+    conns: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
     /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
     pub fn serve(self: *Daemon, port: u16) !void {
@@ -54,12 +64,23 @@ pub const Daemon = struct {
             const conn = server.accept() catch {
                 continue;
             };
+
+            // Shed load past the cap rather than spawning unbounded threads.
+            if (self.conns.fetchAdd(1, .monotonic) >= max_conns) {
+                _ = self.conns.fetchSub(1, .monotonic);
+                conn.stream.close();
+                continue;
+            }
+            setRecvTimeout(conn.stream, recv_timeout_secs);
+
             const ctx = self.allocator.create(Conn) catch {
+                _ = self.conns.fetchSub(1, .monotonic);
                 conn.stream.close();
                 continue;
             };
             ctx.* = .{ .daemon = self, .stream = conn.stream };
             const t = std.Thread.spawn(.{}, Conn.run, .{ctx}) catch {
+                _ = self.conns.fetchSub(1, .monotonic);
                 conn.stream.close();
                 self.allocator.destroy(ctx);
                 continue;
@@ -80,6 +101,7 @@ const Conn = struct {
     fn run(self: *Conn) void {
         const a = self.daemon.allocator;
         defer {
+            _ = self.daemon.conns.fetchSub(1, .monotonic);
             self.stream.close();
             a.destroy(self);
         }
@@ -157,10 +179,10 @@ const Conn = struct {
     fn tokenOk(self: *Conn, req: *const http.Request) bool {
         const expected = self.daemon.token;
         if (req.header("x-carl-token")) |h| {
-            if (std.mem.eql(u8, h, expected)) return true;
+            if (constantTimeEql(h, expected)) return true;
         }
         if (req.queryParam("token")) |q| {
-            if (std.mem.eql(u8, q, expected)) return true;
+            if (constantTimeEql(q, expected)) return true;
         }
         return false;
     }
@@ -171,7 +193,10 @@ const Conn = struct {
         const a = self.daemon.allocator;
         var arena = std.heap.ArenaAllocator.init(a);
         defer arena.deinit();
-        const json = try buildStateJson(arena.allocator(), self.daemon);
+        const aa = arena.allocator();
+        const relay_urls = try nostr_config.readRelays(aa);
+        const npub = try readNpub(aa);
+        const json = try buildStateJson(aa, self.daemon, relay_urls, npub);
         try self.sendJson(.ok, json);
     }
 
@@ -286,8 +311,8 @@ const Conn = struct {
         defer arena.deinit();
         const aa = arena.allocator();
 
-        // Query from JSON body {"query": "..."} or ?q= fallback.
-        var query: []const u8 = req.queryParam("q") orelse "";
+        // Query from JSON body {"query": "..."} or ?q= fallback (percent-decoded).
+        var query: []const u8 = if (req.queryParam("q")) |q| (percentDecode(aa, q) catch q) else "";
         if (body.len > 0) {
             if (std.json.parseFromSlice(std.json.Value, aa, body, .{})) |p| {
                 if (p.value == .object) {
@@ -320,13 +345,21 @@ const Conn = struct {
             "Sec-WebSocket-Accept: {s}\r\n\r\n", .{accept}) catch return;
         self.sendAll(upgrade) catch return;
 
+        // Read identity + relay config once for the lifetime of the connection
+        // (a connection-scoped arena), so the per-tick push doesn't hit the
+        // filesystem every second. Transfers/seeds are still read live per tick.
+        var conn_arena = std.heap.ArenaAllocator.init(a);
+        defer conn_arena.deinit();
+        const relay_urls: []const []const u8 = nostr_config.readRelays(conn_arena.allocator()) catch &.{};
+        const npub: []const u8 = readNpub(conn_arena.allocator()) catch "";
+
         // Push a fresh snapshot every interval until the client closes (send
         // fails) or the daemon stops. We don't read client frames — a localhost
         // GUI only needs the push channel — so a closed socket is detected by
         // the next send failing.
         while (self.daemon.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
             var arena = std.heap.ArenaAllocator.init(a);
-            const json = buildStateJson(arena.allocator(), self.daemon) catch {
+            const json = buildStateJson(arena.allocator(), self.daemon, relay_urls, npub) catch {
                 arena.deinit();
                 break;
             };
@@ -377,12 +410,14 @@ const Conn = struct {
 // ===========================================================================
 
 /// The combined initial-load payload and the per-tick WebSocket push.
-fn buildStateJson(arena: Allocator, daemon: *Daemon) ![]u8 {
+///
+/// `relay_urls` and `npub` are passed in (read from config by the caller)
+/// rather than read here, so the WebSocket push can read them once per
+/// connection instead of hitting the filesystem on every tick. Transfers and
+/// seeds are always read live from the manager.
+fn buildStateJson(arena: Allocator, daemon: *Daemon, relay_urls: []const []const u8, npub: []const u8) ![]u8 {
     const transfers = try daemon.manager.snapshot(arena);
     const seeds = try daemon.manager.seeds(arena);
-    const relays = try readRelayStates(arena);
-    const settings_relays = try nostr_config.readRelays(arena);
-    const npub = try readNpub(arena);
 
     var j = api.Json.init(arena);
     try j.beginObject();
@@ -396,12 +431,12 @@ fn buildStateJson(arena: Allocator, daemon: *Daemon) ![]u8 {
     try j.endArray();
     try j.key("relays");
     try j.beginArray();
-    for (relays) |r| try api.writeRelay(&j, r);
+    for (relay_urls) |url| try api.writeRelay(&j, .{ .url = url, .state = "configured", .net = relayNet(url), .events = 0 });
     try j.endArray();
     try j.key("identity");
     try api.writeIdentity(&j, .{ .npub = npub });
     try j.key("settings");
-    try api.writeSettings(&j, daemon.manager.settings(settings_relays));
+    try api.writeSettings(&j, daemon.manager.settings(relay_urls));
     try j.endObject();
     return j.buf.items;
 }
@@ -432,6 +467,54 @@ fn readNpub(arena: Allocator) ![]const u8 {
 fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
     const v = obj.get(name) orelse return null;
     return if (v == .string) v.string else null;
+}
+
+/// Set a recv timeout on an accepted socket so a stalled client can't wedge its
+/// thread forever. Best-effort (a failed setsockopt just leaves the default).
+fn setRecvTimeout(stream: std.net.Stream, secs: u32) void {
+    const tv = posix.timeval{ .sec = @intCast(secs), .usec = 0 };
+    posix.setsockopt(stream.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+}
+
+/// Length-checked, content-constant-time slice equality for the auth token.
+/// (The token length is not secret, so an early length mismatch is fine.)
+fn constantTimeEql(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    var diff: u8 = 0;
+    for (a, b) |x, y| diff |= x ^ y;
+    return diff == 0;
+}
+
+fn hexDigit(c: u8) ?u8 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => null,
+    };
+}
+
+/// Percent-decode a query-string value (`%XX` escapes, `+` → space). Caller
+/// owns the result.
+fn percentDecode(arena: Allocator, s: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(arena);
+    var i: usize = 0;
+    while (i < s.len) {
+        const c = s[i];
+        if (c == '%' and i + 2 < s.len) {
+            if (hexDigit(s[i + 1])) |hi| {
+                if (hexDigit(s[i + 2])) |lo| {
+                    try out.append(arena, (hi << 4) | lo);
+                    i += 3;
+                    continue;
+                }
+            }
+        }
+        try out.append(arena, if (c == '+') ' ' else c);
+        i += 1;
+    }
+    return out.toOwnedSlice(arena);
 }
 
 // ===========================================================================
@@ -578,7 +661,8 @@ test "buildStateJson: produces the five top-level keys" {
 
     var arena = std.heap.ArenaAllocator.init(a);
     defer arena.deinit();
-    const json = try buildStateJson(arena.allocator(), &d);
+    const relays = [_][]const u8{ "wss://relay.damus.io", "ws://abc.onion" };
+    const json = try buildStateJson(arena.allocator(), &d, &relays, "npub1test");
 
     var p = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json, .{});
     defer p.deinit();
@@ -589,4 +673,28 @@ test "buildStateJson: produces the five top-level keys" {
     try testing.expect(o.get("identity").? == .object);
     try testing.expect(o.get("settings").? == .object);
     try testing.expectEqual(@as(usize, 0), o.get("transfers").?.array.items.len);
+    try testing.expectEqual(@as(usize, 2), o.get("relays").?.array.items.len);
+    try testing.expectEqualStrings("tor", o.get("relays").?.array.items[1].object.get("net").?.string);
+    try testing.expectEqualStrings("npub1test", o.get("identity").?.object.get("npub").?.string);
+}
+
+test "constantTimeEql" {
+    try testing.expect(constantTimeEql("abc123", "abc123"));
+    try testing.expect(!constantTimeEql("abc123", "abc124"));
+    try testing.expect(!constantTimeEql("abc", "abcd")); // length mismatch
+    try testing.expect(constantTimeEql("", ""));
+}
+
+test "percentDecode: escapes and plus" {
+    const a = testing.allocator;
+    const r1 = try percentDecode(a, "big%20buck+bunny");
+    defer a.free(r1);
+    try testing.expectEqualStrings("big buck bunny", r1);
+    // Trailing/invalid escapes are passed through literally.
+    const r2 = try percentDecode(a, "100%");
+    defer a.free(r2);
+    try testing.expectEqualStrings("100%", r2);
+    const r3 = try percentDecode(a, "%zz");
+    defer a.free(r3);
+    try testing.expectEqualStrings("%zz", r3);
 }

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -248,6 +248,10 @@ const Conn = struct {
             if (n == 0) break;
             try buf.appendSlice(a, tmp[0..n]);
         }
+        // A short read (recv timeout / peer hangup) leaves a truncated body. Do
+        // not process it: POST /api/seeds would write a partial file and seed a
+        // corrupt torrent.
+        if (buf.items.len < need) return self.sendStatus(.bad_request);
 
         const req = http.parse(buf.items) catch return self.sendStatus(.bad_request);
         const body_end = @min(buf.items.len, req.head_len + req.contentLength());

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -402,8 +402,26 @@ const Conn = struct {
         const parsed = std.json.parseFromSlice(std.json.Value, aa, body, .{}) catch
             return self.sendStatus(.bad_request);
         if (parsed.value == .object) {
-            if (strField(parsed.value.object, "route")) |r| {
+            const obj = parsed.value.object;
+            if (strField(obj, "route")) |r| {
                 if (api.Route.parse(r)) |rt| self.daemon.manager.setRoute(rt);
+            }
+            if (strField(obj, "downloadDir")) |dir| {
+                if (dir.len > 0) self.daemon.manager.setDownloadDir(dir) catch {};
+            }
+            // Relays: a JSON array of strings, persisted to the config file so
+            // the prober, search, and the CLI all pick them up.
+            if (obj.get("relays")) |v| {
+                if (v == .array) {
+                    var list: std.ArrayList([]const u8) = .empty;
+                    for (v.array.items) |item| {
+                        if (item == .string) {
+                            const t = std.mem.trim(u8, item.string, " \t\r\n");
+                            if (t.len > 0) try list.append(aa, t);
+                        }
+                    }
+                    nostr_config.writeRelays(a, list.items) catch {};
+                }
             }
         }
         // Echo the (possibly updated) settings back.
@@ -627,7 +645,9 @@ fn percentDecode(arena: Allocator, s: []const u8) ![]u8 {
 // ===========================================================================
 
 fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
-    const relay_urls = try nostr_config.readRelays(arena);
+    // Use the prober's health view: skip relays already known unreachable so a
+    // dead relay's connect timeout doesn't stall the whole search.
+    const health = daemon.healthSnapshot(arena) catch &.{};
 
     // Match the route the manager is configured for, so search over Tor/proxy
     // doesn't leak the real IP.
@@ -645,12 +665,14 @@ fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
     var seen: std.ArrayList([40]u8) = .empty;
     const now = std.time.timestamp();
 
-    for (relay_urls) |url| {
+    for (health) |relay| {
         if (results.items.len >= 50) break;
+        if (std.mem.eql(u8, relay.state, "unreachable")) continue;
+        const url = relay.url;
         var r = relay_mod.Relay.connect(arena, url, proxy) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(arena, &r, filter, .{
-            .timeout_ms = 12_000,
+            .timeout_ms = 7_000,
             .max_events = 200,
             .verify_signatures = true,
         }) catch continue;

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -1,0 +1,592 @@
+//! Localhost HTTP + WebSocket daemon: the thin backend the desktop GUI talks
+//! to. Binds loopback only and guards every request with a shared token
+//! (`X-Carl-Token`, or `?token=` for the WebSocket handshake the browser can't
+//! set headers on). One thread per connection — fine for a single local GUI.
+//!
+//! REST endpoints serve JSON snapshots from the `TorrentManager` and the real
+//! Nostr subsystems; `GET /ws` upgrades to a WebSocket that pushes a fresh
+//! state snapshot once a second (the "live-ish" tick the prototype shows). The
+//! full contract is in docs/daemon-api.md.
+
+const std = @import("std");
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+
+const http = @import("http.zig");
+const ws_server = @import("ws_server.zig");
+const manager_mod = @import("manager.zig");
+const session_mod = @import("session.zig");
+const api = @import("api.zig");
+const nostr_config = @import("nostr_config.zig");
+const proxy_mod = @import("proxy.zig");
+const relay_mod = @import("relay.zig");
+const nip35 = @import("nip35.zig");
+const nostr_mod = @import("nostr.zig");
+const secp = @import("secp.zig");
+const nip19 = @import("nip19.zig");
+
+const log = std.log.scoped(.daemon);
+
+/// How often the WebSocket pushes a fresh state snapshot.
+const push_interval_ns: u64 = std.time.ns_per_s;
+
+pub const Daemon = struct {
+    allocator: Allocator,
+    manager: *manager_mod.Manager,
+    token: []const u8,
+    running: std.atomic.Value(bool) = std.atomic.Value(bool).init(true),
+
+    /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
+    pub fn serve(self: *Daemon, port: u16) !void {
+        const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port);
+        var server = try addr.listen(.{ .reuse_address = true });
+        defer server.deinit();
+
+        log.info("daemon listening on http://127.0.0.1:{d}", .{port});
+        // Poll the listen socket with a timeout rather than blocking in
+        // accept(): Zig's accept() retries on EINTR, so a bare accept would
+        // never observe the SIGINT-set `shutdown_requested`. Polling lets the
+        // loop re-check the shutdown flags ~twice a second and exit cleanly.
+        var pfd = [_]posix.pollfd{.{ .fd = server.stream.handle, .events = posix.POLL.IN, .revents = 0 }};
+        while (self.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
+            const ready = posix.poll(&pfd, 500) catch 0;
+            if (ready == 0) continue;
+            const conn = server.accept() catch {
+                continue;
+            };
+            const ctx = self.allocator.create(Conn) catch {
+                conn.stream.close();
+                continue;
+            };
+            ctx.* = .{ .daemon = self, .stream = conn.stream };
+            const t = std.Thread.spawn(.{}, Conn.run, .{ctx}) catch {
+                conn.stream.close();
+                self.allocator.destroy(ctx);
+                continue;
+            };
+            t.detach();
+        }
+    }
+
+    pub fn stop(self: *Daemon) void {
+        self.running.store(false, .release);
+    }
+};
+
+const Conn = struct {
+    daemon: *Daemon,
+    stream: std.net.Stream,
+
+    fn run(self: *Conn) void {
+        const a = self.daemon.allocator;
+        defer {
+            self.stream.close();
+            a.destroy(self);
+        }
+        self.handle() catch |err| {
+            log.debug("connection error: {}", .{err});
+        };
+    }
+
+    fn handle(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(a);
+
+        // Read until the header block is complete.
+        var tmp: [4096]u8 = undefined;
+        while (std.mem.indexOf(u8, buf.items, "\r\n\r\n") == null) {
+            const n = posix.recv(self.stream.handle, &tmp, 0) catch return;
+            if (n == 0) return;
+            try buf.appendSlice(a, tmp[0..n]);
+            if (buf.items.len > 256 * 1024) return self.sendStatus(.bad_request);
+        }
+
+        // Probe to learn Content-Length, then read the whole body before the
+        // final parse, so the parsed Request's slices don't dangle on realloc.
+        const probe = http.parse(buf.items) catch return self.sendStatus(.bad_request);
+        const need = probe.head_len + probe.contentLength();
+        while (buf.items.len < need) {
+            const n = posix.recv(self.stream.handle, &tmp, 0) catch break;
+            if (n == 0) break;
+            try buf.appendSlice(a, tmp[0..n]);
+        }
+
+        const req = http.parse(buf.items) catch return self.sendStatus(.bad_request);
+        const body_end = @min(buf.items.len, req.head_len + req.contentLength());
+        const body = buf.items[req.head_len..body_end];
+        try self.route(&req, body);
+    }
+
+    fn route(self: *Conn, req: *const http.Request, body: []const u8) !void {
+        // CORS preflight: answer before the token check so the browser can
+        // proceed to the real, token-bearing request.
+        if (std.mem.eql(u8, req.method, "OPTIONS")) return self.sendStatus(.no_content);
+
+        if (!self.tokenOk(req)) return self.sendStatus(.unauthorized);
+
+        const path = req.path;
+        if (std.mem.eql(u8, path, "/ws")) return self.serveWebSocket(req);
+
+        if (std.mem.eql(u8, req.method, "GET")) {
+            if (std.mem.eql(u8, path, "/api/state")) return self.serveState();
+            if (std.mem.eql(u8, path, "/api/transfers")) return self.serveTransfers();
+            if (std.mem.eql(u8, path, "/api/seeds")) return self.serveSeeds();
+            if (std.mem.eql(u8, path, "/api/relays")) return self.serveRelays();
+            if (std.mem.eql(u8, path, "/api/identity")) return self.serveIdentity();
+            if (std.mem.eql(u8, path, "/api/settings")) return self.serveSettings();
+            return self.sendStatus(.not_found);
+        }
+        if (std.mem.eql(u8, req.method, "POST")) {
+            if (std.mem.eql(u8, path, "/api/transfers")) return self.addTransfer(body);
+            if (std.mem.eql(u8, path, "/api/search")) return self.search(req, body);
+            if (std.mem.eql(u8, path, "/api/settings")) return self.updateSettings(body);
+            return self.sendStatus(.not_found);
+        }
+        if (std.mem.eql(u8, req.method, "DELETE")) {
+            if (std.mem.startsWith(u8, path, "/api/transfers/")) {
+                const id = path["/api/transfers/".len..];
+                const removed = self.daemon.manager.removeTransfer(id) catch false;
+                return self.sendStatus(if (removed) .no_content else .not_found);
+            }
+            return self.sendStatus(.not_found);
+        }
+        return self.sendStatus(.method_not_allowed);
+    }
+
+    fn tokenOk(self: *Conn, req: *const http.Request) bool {
+        const expected = self.daemon.token;
+        if (req.header("x-carl-token")) |h| {
+            if (std.mem.eql(u8, h, expected)) return true;
+        }
+        if (req.queryParam("token")) |q| {
+            if (std.mem.eql(u8, q, expected)) return true;
+        }
+        return false;
+    }
+
+    // ----- GET handlers -----
+
+    fn serveState(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const json = try buildStateJson(arena.allocator(), self.daemon);
+        try self.sendJson(.ok, json);
+    }
+
+    fn serveTransfers(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const transfers = try self.daemon.manager.snapshot(aa);
+        const json = try api.transfersJson(aa, transfers);
+        try self.sendJson(.ok, json);
+    }
+
+    fn serveSeeds(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const seeds = try self.daemon.manager.seeds(aa);
+        var j = api.Json.init(aa);
+        try j.beginArray();
+        for (seeds) |s| try api.writeSeed(&j, s);
+        try j.endArray();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    fn serveRelays(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const relays = try readRelayStates(aa);
+        var j = api.Json.init(aa);
+        try j.beginArray();
+        for (relays) |r| try api.writeRelay(&j, r);
+        try j.endArray();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    fn serveIdentity(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        var j = api.Json.init(aa);
+        try api.writeIdentity(&j, .{ .npub = try readNpub(aa) });
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    fn serveSettings(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const relays = try nostr_config.readRelays(aa);
+        var j = api.Json.init(aa);
+        try api.writeSettings(&j, self.daemon.manager.settings(relays));
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    // ----- POST/DELETE handlers -----
+
+    fn addTransfer(self: *Conn, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const parsed = std.json.parseFromSlice(std.json.Value, aa, body, .{}) catch
+            return self.sendStatus(.bad_request);
+        const obj = if (parsed.value == .object) parsed.value.object else return self.sendStatus(.bad_request);
+        const source = strField(obj, "source") orelse return self.sendStatus(.bad_request);
+        const route_val = api.Route.parse(strField(obj, "route") orelse "direct") orelse .direct;
+        const want_nostr = if (obj.get("nostr")) |v| (v == .bool and v.bool) else false;
+
+        const id = self.daemon.manager.addTransfer(source, route_val, want_nostr) catch |err| {
+            log.warn("addTransfer failed: {}", .{err});
+            return self.sendStatus(.bad_request);
+        };
+        defer a.free(id);
+
+        var j = api.Json.init(aa);
+        try j.beginObject();
+        try j.keyString("id", id);
+        try j.endObject();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    fn updateSettings(self: *Conn, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const parsed = std.json.parseFromSlice(std.json.Value, aa, body, .{}) catch
+            return self.sendStatus(.bad_request);
+        if (parsed.value == .object) {
+            if (strField(parsed.value.object, "route")) |r| {
+                if (api.Route.parse(r)) |rt| self.daemon.manager.setRoute(rt);
+            }
+        }
+        // Echo the (possibly updated) settings back.
+        const relays = try nostr_config.readRelays(aa);
+        var j = api.Json.init(aa);
+        try api.writeSettings(&j, self.daemon.manager.settings(relays));
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    fn search(self: *Conn, req: *const http.Request, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        // Query from JSON body {"query": "..."} or ?q= fallback.
+        var query: []const u8 = req.queryParam("q") orelse "";
+        if (body.len > 0) {
+            if (std.json.parseFromSlice(std.json.Value, aa, body, .{})) |p| {
+                if (p.value == .object) {
+                    if (strField(p.value.object, "query")) |q| query = q;
+                }
+            } else |_| {}
+        }
+
+        const json = runSearch(aa, self.daemon, query) catch |err| {
+            log.warn("search failed: {}", .{err});
+            return self.sendJson(.ok, "[]");
+        };
+        try self.sendJson(.ok, json);
+    }
+
+    // ----- WebSocket -----
+
+    fn serveWebSocket(self: *Conn, req: *const http.Request) !void {
+        if (!req.isWebSocketUpgrade()) return self.sendStatus(.bad_request);
+        const key = req.header("sec-websocket-key") orelse return self.sendStatus(.bad_request);
+
+        var accept: [28]u8 = undefined;
+        ws_server.acceptKey(key, &accept);
+
+        const a = self.daemon.allocator;
+        var hdr: [256]u8 = undefined;
+        const upgrade = std.fmt.bufPrint(&hdr, "HTTP/1.1 101 Switching Protocols\r\n" ++
+            "Upgrade: websocket\r\n" ++
+            "Connection: Upgrade\r\n" ++
+            "Sec-WebSocket-Accept: {s}\r\n\r\n", .{accept}) catch return;
+        self.sendAll(upgrade) catch return;
+
+        // Push a fresh snapshot every interval until the client closes (send
+        // fails) or the daemon stops. We don't read client frames — a localhost
+        // GUI only needs the push channel — so a closed socket is detected by
+        // the next send failing.
+        while (self.daemon.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
+            var arena = std.heap.ArenaAllocator.init(a);
+            const json = buildStateJson(arena.allocator(), self.daemon) catch {
+                arena.deinit();
+                break;
+            };
+            ws_server.sendText(a, self.stream, json) catch {
+                arena.deinit();
+                break;
+            };
+            arena.deinit();
+            // Sleep in small steps so the push thread observes shutdown promptly
+            // (within ~100ms) rather than holding the process open for a full
+            // tick — keeps teardown responsive.
+            var slept: u64 = 0;
+            while (slept < push_interval_ns and
+                self.daemon.running.load(.acquire) and
+                !session_mod.shutdown_requested.load(.acquire)) : (slept += 100 * std.time.ns_per_ms)
+            {
+                std.Thread.sleep(100 * std.time.ns_per_ms);
+            }
+        }
+        ws_server.sendClose(a, self.stream);
+    }
+
+    // ----- response writers -----
+
+    fn sendJson(self: *Conn, status: http.Status, json: []const u8) !void {
+        const resp = try http.jsonResponse(self.daemon.allocator, status, json);
+        defer self.daemon.allocator.free(resp);
+        try self.sendAll(resp);
+    }
+
+    fn sendStatus(self: *Conn, status: http.Status) !void {
+        // A tiny JSON body keeps clients that always parse JSON happy.
+        try self.sendJson(status, "{}");
+    }
+
+    fn sendAll(self: *Conn, buf: []const u8) !void {
+        var off: usize = 0;
+        while (off < buf.len) {
+            const n = posix.send(self.stream.handle, buf[off..], 0) catch return error.SendFailed;
+            if (n == 0) return error.Closed;
+            off += n;
+        }
+    }
+};
+
+// ===========================================================================
+// JSON builders (arena-allocated; caller frees the arena)
+// ===========================================================================
+
+/// The combined initial-load payload and the per-tick WebSocket push.
+fn buildStateJson(arena: Allocator, daemon: *Daemon) ![]u8 {
+    const transfers = try daemon.manager.snapshot(arena);
+    const seeds = try daemon.manager.seeds(arena);
+    const relays = try readRelayStates(arena);
+    const settings_relays = try nostr_config.readRelays(arena);
+    const npub = try readNpub(arena);
+
+    var j = api.Json.init(arena);
+    try j.beginObject();
+    try j.key("transfers");
+    try j.beginArray();
+    for (transfers) |t| try api.writeTransfer(&j, t);
+    try j.endArray();
+    try j.key("seeds");
+    try j.beginArray();
+    for (seeds) |s| try api.writeSeed(&j, s);
+    try j.endArray();
+    try j.key("relays");
+    try j.beginArray();
+    for (relays) |r| try api.writeRelay(&j, r);
+    try j.endArray();
+    try j.key("identity");
+    try api.writeIdentity(&j, .{ .npub = npub });
+    try j.key("settings");
+    try api.writeSettings(&j, daemon.manager.settings(settings_relays));
+    try j.endObject();
+    return j.buf.items;
+}
+
+/// Read configured relays into `api.Relay` rows. The daemon doesn't hold
+/// persistent relay connections, so state is reported as "configured"; the
+/// clearnet/tor split is derived from the URL.
+fn readRelayStates(arena: Allocator) ![]api.Relay {
+    const urls = try nostr_config.readRelays(arena);
+    const out = try arena.alloc(api.Relay, urls.len);
+    for (urls, 0..) |url, i| {
+        out[i] = .{ .url = url, .state = "configured", .net = relayNet(url), .events = 0 };
+    }
+    return out;
+}
+
+fn relayNet(url: []const u8) []const u8 {
+    return if (std.mem.indexOf(u8, url, ".onion") != null) "tor" else "clearnet";
+}
+
+/// The local npub, or "" when no key is configured. The nsec is never exposed.
+fn readNpub(arena: Allocator) ![]const u8 {
+    const sk = nostr_config.readSecretKey(arena) catch return "";
+    const pk = secp.publicKeyFromSecret(sk) catch return "";
+    return nip19.encode32(arena, .npub, pk) catch "";
+}
+
+fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const v = obj.get(name) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+// ===========================================================================
+// Nostr search → DiscoverResult JSON
+// ===========================================================================
+
+fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
+    const relay_urls = try nostr_config.readRelays(arena);
+
+    // Match the route the manager is configured for, so search over Tor/proxy
+    // doesn't leak the real IP.
+    var proxy: ?proxy_mod.Proxy = null;
+    if (daemon.manager.cfg.route != .direct) {
+        proxy = proxy_mod.parseUrl(daemon.manager.cfg.socks) catch null;
+    }
+
+    const filter: nostr_mod.Filter = .{
+        .kinds = &[_]u32{nip35.kind_torrent},
+        .limit = 100,
+    };
+
+    var results: std.ArrayList(api.DiscoverResult) = .empty;
+    var seen: std.ArrayList([40]u8) = .empty;
+    const now = std.time.timestamp();
+
+    for (relay_urls) |url| {
+        if (results.items.len >= 50) break;
+        var r = relay_mod.Relay.connect(arena, url, proxy) catch continue;
+        defer r.deinit();
+        const events = relay_mod.subscribeAndCollect(arena, &r, filter, .{
+            .timeout_ms = 12_000,
+            .max_events = 200,
+            .verify_signatures = true,
+        }) catch continue;
+
+        for (events) |ev| {
+            const entry = nip35.parseEvent(arena, ev) catch continue;
+            if (!textMatches(entry.title, query) and !textMatches(entry.description, query)) continue;
+
+            var ih_hex: [40]u8 = undefined;
+            secp.toHex(&entry.info_hash, &ih_hex);
+            if (containsHash(seen.items, ih_hex)) continue;
+            try seen.append(arena, ih_hex);
+
+            var total: u64 = 0;
+            for (entry.files) |f| total += f.size;
+
+            const author = nip19.encode32(arena, .npub, ev.pubkey) catch "";
+            const found_on = try arena.alloc([]const u8, 1);
+            found_on[0] = url;
+
+            try results.append(arena, .{
+                .id = try arena.dupe(u8, &ih_hex),
+                .title = try arena.dupe(u8, entry.title),
+                .hash = try arena.dupe(u8, &ih_hex),
+                .size = total,
+                .files = @intCast(entry.files.len),
+                .trackers = @intCast(entry.trackers.len),
+                .desc = try arena.dupe(u8, entry.description),
+                .verified = true, // collected with verify_signatures = true
+                .relays = found_on,
+                .author = author,
+                .age = try formatAge(arena, now - ev.created_at),
+            });
+            if (results.items.len >= 50) break;
+        }
+    }
+
+    var j = api.Json.init(arena);
+    try j.beginArray();
+    for (results.items) |d| try api.writeDiscoverResult(&j, d);
+    try j.endArray();
+    return j.buf.items;
+}
+
+fn containsHash(seen: []const [40]u8, h: [40]u8) bool {
+    for (seen) |s| {
+        if (std.mem.eql(u8, &s, &h)) return true;
+    }
+    return false;
+}
+
+/// Case-insensitive ASCII substring match; an empty needle matches everything.
+fn textMatches(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (haystack.len < needle.len) return false;
+    var off: usize = 0;
+    const max_off = haystack.len - needle.len + 1;
+    while (off < max_off) : (off += 1) {
+        var match = true;
+        for (needle, 0..) |n, i| {
+            if (std.ascii.toLower(haystack[off + i]) != std.ascii.toLower(n)) {
+                match = false;
+                break;
+            }
+        }
+        if (match) return true;
+    }
+    return false;
+}
+
+fn formatAge(arena: Allocator, secs_ago: i64) ![]const u8 {
+    const s: u64 = if (secs_ago < 0) 0 else @intCast(secs_ago);
+    if (s < 3600) return std.fmt.allocPrint(arena, "{d}m ago", .{s / 60});
+    if (s < 86400) return std.fmt.allocPrint(arena, "{d}h ago", .{s / 3600});
+    return std.fmt.allocPrint(arena, "{d}d ago", .{s / 86400});
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "relayNet: onion vs clearnet" {
+    try testing.expectEqualStrings("tor", relayNet("ws://abc.onion"));
+    try testing.expectEqualStrings("clearnet", relayNet("wss://relay.damus.io"));
+}
+
+test "textMatches: case-insensitive substring" {
+    try testing.expect(textMatches("Debian 12.5", "debian"));
+    try testing.expect(textMatches("anything", "")); // empty needle
+    try testing.expect(!textMatches("arch", "debian"));
+}
+
+test "formatAge: buckets" {
+    const a = testing.allocator;
+    const m = try formatAge(a, 120);
+    defer a.free(m);
+    try testing.expectEqualStrings("2m ago", m);
+    const h = try formatAge(a, 7200);
+    defer a.free(h);
+    try testing.expectEqualStrings("2h ago", h);
+    const d = try formatAge(a, 172800);
+    defer a.free(d);
+    try testing.expectEqualStrings("2d ago", d);
+}
+
+test "buildStateJson: produces the five top-level keys" {
+    const a = testing.allocator;
+    var mgr = try manager_mod.Manager.init(a, .{});
+    defer mgr.deinit();
+    var d = Daemon{ .allocator = a, .manager = &mgr, .token = "tok" };
+
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const json = try buildStateJson(arena.allocator(), &d);
+
+    var p = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json, .{});
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expect(o.get("transfers").? == .array);
+    try testing.expect(o.get("seeds").? == .array);
+    try testing.expect(o.get("relays").? == .array);
+    try testing.expect(o.get("identity").? == .object);
+    try testing.expect(o.get("settings").? == .object);
+    try testing.expectEqual(@as(usize, 0), o.get("transfers").?.array.items.len);
+}

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -39,6 +39,9 @@ const max_conns: u32 = 64;
 /// then stalls (or lies about Content-Length) can't wedge a thread forever.
 const recv_timeout_secs: u32 = 30;
 
+/// Max request size held in memory (covers the "Seed a file" upload body).
+const max_body: usize = 256 * 1024 * 1024;
+
 /// How often the background prober refreshes relay reachability. The daemon
 /// holds no persistent relay connections, so without this the UI could only
 /// ever show relays as "configured" (never connected).
@@ -236,6 +239,7 @@ const Conn = struct {
         // final parse, so the parsed Request's slices don't dangle on realloc.
         const probe = http.parse(buf.items) catch return self.sendStatus(.bad_request);
         const need = probe.head_len + probe.contentLength();
+        if (need > max_body) return self.sendStatus(.bad_request);
         while (buf.items.len < need) {
             const n = posix.recv(self.stream.handle, &tmp, 0) catch break;
             if (n == 0) break;
@@ -269,6 +273,7 @@ const Conn = struct {
         }
         if (std.mem.eql(u8, req.method, "POST")) {
             if (std.mem.eql(u8, path, "/api/transfers")) return self.addTransfer(body);
+            if (std.mem.eql(u8, path, "/api/seeds")) return self.createSeed(req, body);
             if (std.mem.eql(u8, path, "/api/search")) return self.search(req, body);
             if (std.mem.eql(u8, path, "/api/settings")) return self.updateSettings(body);
             return self.sendStatus(.not_found);
@@ -382,6 +387,48 @@ const Conn = struct {
 
         const id = self.daemon.manager.addTransfer(source, route_val, want_nostr) catch |err| {
             log.warn("addTransfer failed: {}", .{err});
+            return self.sendStatus(.bad_request);
+        };
+        defer a.free(id);
+
+        var j = api.Json.init(aa);
+        try j.beginObject();
+        try j.keyString("id", id);
+        try j.endObject();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
+    /// POST /api/seeds — body is the raw file content (so a browser drag-drop or
+    /// the Tauri shell can upload directly). Headers: X-Carl-Filename (required),
+    /// X-Carl-Route (direct|proxy|tor, default tor), X-Carl-Nostr (true|false).
+    /// Writes the file into the download dir, creates a torrent in-process, and
+    /// starts seeding it; returns { id }.
+    fn createSeed(self: *Conn, req: *const http.Request, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const raw_name = req.header("x-carl-filename") orelse return self.sendStatus(.bad_request);
+        // Sanitize to a bare filename — never let the client write outside the dir.
+        const filename = std.fs.path.basename(raw_name);
+        if (filename.len == 0 or body.len == 0) return self.sendStatus(.bad_request);
+        const route_val = api.Route.parse(req.header("x-carl-route") orelse "tor") orelse .tor;
+        const want_nostr = if (req.header("x-carl-nostr")) |h| std.mem.eql(u8, h, "true") else false;
+
+        const dir = self.daemon.manager.downloadDirDup(aa) catch return self.sendStatus(.internal_error);
+        std.fs.cwd().makePath(dir) catch {};
+        const full = std.fmt.allocPrint(aa, "{s}/{s}", .{ dir, filename }) catch
+            return self.sendStatus(.internal_error);
+        {
+            var f = std.fs.cwd().createFile(full, .{ .truncate = true }) catch
+                return self.sendStatus(.internal_error);
+            defer f.close();
+            f.writeAll(body) catch return self.sendStatus(.internal_error);
+        }
+
+        const id = self.daemon.manager.addSeed(full, route_val, want_nostr) catch |err| {
+            log.warn("addSeed failed: {}", .{err});
             return self.sendStatus(.bad_request);
         };
         defer a.free(id);

--- a/src/http.zig
+++ b/src/http.zig
@@ -173,7 +173,10 @@ pub fn response(allocator: Allocator, status: Status, content_type: []const u8, 
     // without it the browser blocks every non-simple request.
     try buf.appendSlice(allocator, "Access-Control-Allow-Origin: *\r\n");
     try buf.appendSlice(allocator, "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n");
-    try buf.appendSlice(allocator, "Access-Control-Allow-Headers: X-Carl-Token, Content-Type\r\n");
+    // Wildcard so custom headers (X-Carl-Token and the X-Carl-Filename/Route/
+    // Nostr upload headers) all pass the browser preflight. Requests are never
+    // credentialed, so `*` applies; the token is the actual guard.
+    try buf.appendSlice(allocator, "Access-Control-Allow-Headers: *\r\n");
     try buf.appendSlice(allocator, "Connection: close\r\n\r\n");
     try buf.appendSlice(allocator, body);
     return buf.toOwnedSlice(allocator);

--- a/src/http.zig
+++ b/src/http.zig
@@ -168,8 +168,11 @@ pub fn response(allocator: Allocator, status: Status, content_type: []const u8, 
     try buf.appendSlice(allocator, clen_line);
     // The GUI runs in a webview on a different origin (tauri://, file://,
     // http://localhost), so allow cross-origin reads. The token guard, not
-    // CORS, is what protects the daemon.
+    // CORS, is what protects the daemon. `Allow-Methods` is required for the
+    // browser preflight to permit POST/DELETE (and the X-Carl-Token GET) —
+    // without it the browser blocks every non-simple request.
     try buf.appendSlice(allocator, "Access-Control-Allow-Origin: *\r\n");
+    try buf.appendSlice(allocator, "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n");
     try buf.appendSlice(allocator, "Access-Control-Allow-Headers: X-Carl-Token, Content-Type\r\n");
     try buf.appendSlice(allocator, "Connection: close\r\n\r\n");
     try buf.appendSlice(allocator, body);
@@ -232,6 +235,9 @@ test "jsonResponse: well-formed status line, content-length, body" {
     try testing.expect(std.mem.startsWith(u8, resp, "HTTP/1.1 200 OK\r\n"));
     try testing.expect(std.mem.indexOf(u8, resp, "Content-Type: application/json\r\n") != null);
     try testing.expect(std.mem.indexOf(u8, resp, "Content-Length: 11\r\n") != null);
+    // CORS preflight needs Allow-Methods or the browser blocks POST/DELETE.
+    try testing.expect(std.mem.indexOf(u8, resp, "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "Access-Control-Allow-Origin: *\r\n") != null);
     try testing.expect(std.mem.endsWith(u8, resp, body));
 }
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -1,0 +1,243 @@
+//! Minimal HTTP/1.1 request parsing and response building for the daemon.
+//!
+//! The repo has no HTTP server (only `std.http.Client` for outbound tracker /
+//! relay traffic), and `std.http.Server`'s API has churned across Zig
+//! releases, so this is a small hand-rolled subset matching the codebase's
+//! roll-your-own-protocol style. It handles exactly what the localhost GUI
+//! needs: a request line, headers, an optional Content-Length body, and
+//! `Connection`/`Upgrade` lookups for the WebSocket handshake.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+pub const max_headers = 48;
+
+pub const Error = error{
+    /// The buffer does not yet contain a full header block.
+    Incomplete,
+    Malformed,
+    TooManyHeaders,
+};
+
+pub const Header = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// A parsed request head. All slices borrow from the buffer passed to `parse`,
+/// so the buffer must outlive the `Request`.
+pub const Request = struct {
+    method: []const u8,
+    /// Full request target, e.g. "/api/search?q=debian".
+    target: []const u8,
+    /// Path portion of `target` (before '?').
+    path: []const u8,
+    /// Query portion of `target` (after '?'), empty if none.
+    query: []const u8,
+    version: []const u8,
+    headers: [max_headers]Header,
+    header_count: usize,
+    /// Byte length of the head including the terminating CRLFCRLF. The body (if
+    /// any) begins at this offset in the original buffer.
+    head_len: usize,
+
+    /// Case-insensitive header lookup.
+    pub fn header(self: *const Request, name: []const u8) ?[]const u8 {
+        for (self.headers[0..self.header_count]) |h| {
+            if (std.ascii.eqlIgnoreCase(h.name, name)) return h.value;
+        }
+        return null;
+    }
+
+    /// Parse `Content-Length`, defaulting to 0 when absent/invalid.
+    pub fn contentLength(self: *const Request) usize {
+        const v = self.header("content-length") orelse return 0;
+        return std.fmt.parseUnsigned(usize, std.mem.trim(u8, v, " \t"), 10) catch 0;
+    }
+
+    /// True when this request is a WebSocket upgrade.
+    pub fn isWebSocketUpgrade(self: *const Request) bool {
+        const upgrade = self.header("upgrade") orelse return false;
+        if (!std.ascii.eqlIgnoreCase(std.mem.trim(u8, upgrade, " \t"), "websocket")) return false;
+        const conn = self.header("connection") orelse return false;
+        // Connection may be a comma list, e.g. "keep-alive, Upgrade".
+        var it = std.mem.splitScalar(u8, conn, ',');
+        while (it.next()) |part| {
+            if (std.ascii.eqlIgnoreCase(std.mem.trim(u8, part, " \t"), "upgrade")) return true;
+        }
+        return false;
+    }
+
+    /// Look up a query parameter value (no percent-decoding beyond '+'→space is
+    /// performed; the daemon's params are simple). Returns a slice into the
+    /// request buffer, or null.
+    pub fn queryParam(self: *const Request, name: []const u8) ?[]const u8 {
+        var it = std.mem.splitScalar(u8, self.query, '&');
+        while (it.next()) |pair| {
+            const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+            if (std.mem.eql(u8, pair[0..eq], name)) return pair[eq + 1 ..];
+        }
+        return null;
+    }
+};
+
+/// Parse the request head out of `data`. Returns `Incomplete` until the full
+/// header block (ending in CRLFCRLF) is present.
+pub fn parse(data: []const u8) Error!Request {
+    const head_end = std.mem.indexOf(u8, data, "\r\n\r\n") orelse return error.Incomplete;
+    const head = data[0..head_end];
+    var lines = std.mem.splitSequence(u8, head, "\r\n");
+
+    const request_line = lines.next() orelse return error.Malformed;
+    var parts = std.mem.splitScalar(u8, request_line, ' ');
+    const method = parts.next() orelse return error.Malformed;
+    const target = parts.next() orelse return error.Malformed;
+    const version = parts.next() orelse return error.Malformed;
+    if (method.len == 0 or target.len == 0) return error.Malformed;
+
+    const q = std.mem.indexOfScalar(u8, target, '?');
+    const path = if (q) |i| target[0..i] else target;
+    const query = if (q) |i| target[i + 1 ..] else "";
+
+    var req = Request{
+        .method = method,
+        .target = target,
+        .path = path,
+        .query = query,
+        .version = version,
+        .headers = undefined,
+        .header_count = 0,
+        .head_len = head_end + 4,
+    };
+
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse return error.Malformed;
+        if (req.header_count >= max_headers) return error.TooManyHeaders;
+        req.headers[req.header_count] = .{
+            .name = std.mem.trim(u8, line[0..colon], " \t"),
+            .value = std.mem.trim(u8, line[colon + 1 ..], " \t"),
+        };
+        req.header_count += 1;
+    }
+
+    return req;
+}
+
+/// Status codes the daemon emits.
+pub const Status = enum(u16) {
+    ok = 200,
+    no_content = 204,
+    bad_request = 400,
+    unauthorized = 401,
+    not_found = 404,
+    method_not_allowed = 405,
+    internal_error = 500,
+
+    fn reason(self: Status) []const u8 {
+        return switch (self) {
+            .ok => "OK",
+            .no_content => "No Content",
+            .bad_request => "Bad Request",
+            .unauthorized => "Unauthorized",
+            .not_found => "Not Found",
+            .method_not_allowed => "Method Not Allowed",
+            .internal_error => "Internal Server Error",
+        };
+    }
+};
+
+/// Build a complete HTTP/1.1 JSON response. `Connection: close` is always sent
+/// (the daemon uses one request per connection). Caller owns the result.
+pub fn jsonResponse(allocator: Allocator, status: Status, body: []const u8) Allocator.Error![]u8 {
+    return response(allocator, status, "application/json", body);
+}
+
+/// Build a complete response with an arbitrary content type. Caller owns it.
+pub fn response(allocator: Allocator, status: Status, content_type: []const u8, body: []const u8) Allocator.Error![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    var line: [64]u8 = undefined;
+    const status_line = std.fmt.bufPrint(&line, "HTTP/1.1 {d} {s}\r\n", .{ @intFromEnum(status), status.reason() }) catch unreachable;
+    try buf.appendSlice(allocator, status_line);
+    try buf.appendSlice(allocator, "Content-Type: ");
+    try buf.appendSlice(allocator, content_type);
+    try buf.appendSlice(allocator, "\r\n");
+    var clen: [48]u8 = undefined;
+    const clen_line = std.fmt.bufPrint(&clen, "Content-Length: {d}\r\n", .{body.len}) catch unreachable;
+    try buf.appendSlice(allocator, clen_line);
+    // The GUI runs in a webview on a different origin (tauri://, file://,
+    // http://localhost), so allow cross-origin reads. The token guard, not
+    // CORS, is what protects the daemon.
+    try buf.appendSlice(allocator, "Access-Control-Allow-Origin: *\r\n");
+    try buf.appendSlice(allocator, "Access-Control-Allow-Headers: X-Carl-Token, Content-Type\r\n");
+    try buf.appendSlice(allocator, "Connection: close\r\n\r\n");
+    try buf.appendSlice(allocator, body);
+    return buf.toOwnedSlice(allocator);
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "parse: GET with query and headers" {
+    const raw = "GET /api/search?q=debian&limit=10 HTTP/1.1\r\nHost: 127.0.0.1\r\nX-Carl-Token: abc123\r\n\r\n";
+    const req = try parse(raw);
+    try testing.expectEqualStrings("GET", req.method);
+    try testing.expectEqualStrings("/api/search", req.path);
+    try testing.expectEqualStrings("q=debian&limit=10", req.query);
+    try testing.expectEqualStrings("abc123", req.header("x-carl-token").?);
+    try testing.expectEqualStrings("debian", req.queryParam("q").?);
+    try testing.expectEqualStrings("10", req.queryParam("limit").?);
+    try testing.expectEqual(@as(?[]const u8, null), req.queryParam("missing"));
+}
+
+test "parse: Incomplete until CRLFCRLF" {
+    try testing.expectError(error.Incomplete, parse("GET / HTTP/1.1\r\nHost: x\r\n"));
+}
+
+test "parse: POST body offset via head_len + Content-Length" {
+    const raw = "POST /api/transfers HTTP/1.1\r\nContent-Length: 7\r\n\r\nmagnet:";
+    const req = try parse(raw);
+    try testing.expectEqualStrings("POST", req.method);
+    try testing.expectEqual(@as(usize, 7), req.contentLength());
+    try testing.expectEqualStrings("magnet:", raw[req.head_len..]);
+}
+
+test "parse: case-insensitive header lookup" {
+    const raw = "GET / HTTP/1.1\r\nCoNtEnT-tYpE: application/json\r\n\r\n";
+    const req = try parse(raw);
+    try testing.expectEqualStrings("application/json", req.header("content-type").?);
+}
+
+test "isWebSocketUpgrade: detects upgrade with comma-listed Connection" {
+    const raw = "GET /ws HTTP/1.1\r\nUpgrade: websocket\r\nConnection: keep-alive, Upgrade\r\nSec-WebSocket-Key: x\r\n\r\n";
+    const req = try parse(raw);
+    try testing.expect(req.isWebSocketUpgrade());
+}
+
+test "isWebSocketUpgrade: false for plain GET" {
+    const raw = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";
+    const req = try parse(raw);
+    try testing.expect(!req.isWebSocketUpgrade());
+}
+
+test "jsonResponse: well-formed status line, content-length, body" {
+    const allocator = testing.allocator;
+    const body = "{\"ok\":true}";
+    const resp = try jsonResponse(allocator, .ok, body);
+    defer allocator.free(resp);
+    try testing.expect(std.mem.startsWith(u8, resp, "HTTP/1.1 200 OK\r\n"));
+    try testing.expect(std.mem.indexOf(u8, resp, "Content-Type: application/json\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, resp, "Content-Length: 11\r\n") != null);
+    try testing.expect(std.mem.endsWith(u8, resp, body));
+}
+
+test "response: 401 reason phrase" {
+    const allocator = testing.allocator;
+    const resp = try jsonResponse(allocator, .unauthorized, "{}");
+    defer allocator.free(resp);
+    try testing.expect(std.mem.startsWith(u8, resp, "HTTP/1.1 401 Unauthorized\r\n"));
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -25,6 +25,7 @@ pub const ws_server = @import("ws_server.zig");
 pub const http = @import("http.zig");
 pub const manager = @import("manager.zig");
 pub const daemon = @import("daemon.zig");
+pub const state = @import("state.zig");
 
 test {
     _ = bencode;
@@ -53,5 +54,6 @@ test {
     _ = http;
     _ = manager;
     _ = daemon;
+    _ = state;
     _ = @import("integration_test.zig");
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -20,6 +20,11 @@ pub const peer_announce = @import("peer_announce.zig");
 pub const tor_control = @import("tor_control.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
+pub const api = @import("api.zig");
+pub const ws_server = @import("ws_server.zig");
+pub const http = @import("http.zig");
+pub const manager = @import("manager.zig");
+pub const daemon = @import("daemon.zig");
 
 test {
     _ = bencode;
@@ -43,5 +48,10 @@ test {
     _ = tor_control;
     _ = relay;
     _ = nostr_config;
+    _ = api;
+    _ = ws_server;
+    _ = http;
+    _ = manager;
+    _ = daemon;
     _ = @import("integration_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -130,7 +130,7 @@ fn printUsage() void {
         \\           search nostr relays for kind-2003 torrent events
         \\  nostr-keygen                                     generate a fresh nostr key
         \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url]
-        \\         [--download-dir d] [--token tok]
+        \\         [--download-dir d] [--token tok] [--parent-pid pid]
         \\           run a localhost HTTP+WebSocket API for the desktop GUI.
         \\           binds 127.0.0.1 only; every request needs the printed token
         \\           (X-Carl-Token header, or ?token= for the /ws upgrade).
@@ -732,6 +732,23 @@ fn daemonSigintHandler(_: i32) callconv(.c) void {
     carl.session.shutdown_requested.store(true, .release);
 }
 
+/// Watch the spawning parent (the desktop shell). If it dies — including a hard
+/// SIGKILL/crash that bypasses the shell's own cleanup — request shutdown so we
+/// never linger as an orphan holding the port. `kill(pid, 0)` probes existence:
+/// ProcessNotFound means the parent is gone; PermissionDenied means it's alive.
+fn parentWatchdog(parent_pid: std.posix.pid_t) void {
+    while (!carl.session.shutdown_requested.load(.acquire)) {
+        std.Thread.sleep(std.time.ns_per_s);
+        std.posix.kill(parent_pid, 0) catch |err| switch (err) {
+            error.ProcessNotFound => {
+                carl.session.shutdown_requested.store(true, .release);
+                return;
+            },
+            else => {}, // alive (e.g. PermissionDenied) — keep watching
+        };
+    }
+}
+
 fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u8) !void {
     const port = parsePortFlag(extra, "--port", 8088);
     const bt_port = parsePortFlag(extra, "--bt-port", 6881);
@@ -776,6 +793,16 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         .flags = 0,
     };
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
+
+    // Optional parent-death watchdog: the desktop shell passes --parent-pid so a
+    // hard-killed app doesn't leave the daemon orphaned on the port.
+    if (parseFlag(extra, "--parent-pid")) |pid_str| {
+        if (std.fmt.parseInt(std.posix.pid_t, pid_str, 10)) |pid| {
+            if (std.Thread.spawn(.{}, parentWatchdog, .{pid})) |t| {
+                t.detach();
+            } else |e| log.warn("parent watchdog failed to start: {}", .{e});
+        } else |_| log.warn("invalid --parent-pid '{s}', ignoring", .{pid_str});
+    }
 
     // Restore persisted transfers/seeds + settings so a restart loses nothing.
     mgr.restore();

--- a/src/main.zig
+++ b/src/main.zig
@@ -777,6 +777,9 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     };
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
 
+    // Restore persisted transfers/seeds + settings so a restart loses nothing.
+    mgr.restore();
+
     // The token line is machine-readable (the GUI parses it); keep the format
     // stable: "token: <hex>".
     try stdout.print("carl daemon\n", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -99,6 +99,8 @@ pub fn main() !void {
         try cmdSearch(allocator, stdout, args[2], limit, single_relay, parseProxy(args[3..]));
     } else if (std.mem.eql(u8, command, "nostr-keygen")) {
         try cmdNostrKeygen(allocator, stdout);
+    } else if (std.mem.eql(u8, command, "daemon")) {
+        try cmdDaemon(allocator, stdout, args[2..]);
     } else {
         log.err("unknown command: {s}", .{command});
         std.process.exit(1);
@@ -127,6 +129,11 @@ fn printUsage() void {
         \\  search <query> [--limit n] [--relay <wss://...>]
         \\           search nostr relays for kind-2003 torrent events
         \\  nostr-keygen                                     generate a fresh nostr key
+        \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url]
+        \\         [--download-dir d] [--token tok]
+        \\           run a localhost HTTP+WebSocket API for the desktop GUI.
+        \\           binds 127.0.0.1 only; every request needs the printed token
+        \\           (X-Carl-Token header, or ?token= for the /ws upgrade).
         \\
         \\  --proxy url   route peers and HTTP trackers through a proxy. Forms:
         \\                socks5h://[user:pass@]host:port  (remote DNS, no leak)
@@ -712,6 +719,81 @@ fn cmdNostrKeygen(allocator: std.mem.Allocator, stdout: anytype) !void {
     try stdout.print("wrote nsec (secret key) to your config dir\n", .{});
     try stdout.print("npub: {s}\n", .{npub});
     try stdout.print("\nkeep your nsec private. anyone with it can publish as you.\n", .{});
+}
+
+// -------------------------------------------------------------------------
+// `carl daemon` — localhost HTTP+WebSocket API for the desktop GUI
+// -------------------------------------------------------------------------
+
+/// SIGINT handler for the daemon. Reuses the session shutdown flag so any
+/// running transfer threads stop too; the blocking accept() returns EINTR and
+/// the serve loop then exits.
+fn daemonSigintHandler(_: i32) callconv(.c) void {
+    carl.session.shutdown_requested.store(true, .release);
+}
+
+fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u8) !void {
+    const port = parsePortFlag(extra, "--port", 8088);
+    const bt_port = parsePortFlag(extra, "--bt-port", 6881);
+    const route_str = parseFlag(extra, "--route") orelse "direct";
+    const route = carl.api.Route.parse(route_str) orelse {
+        log.err("invalid --route '{s}' (expected direct|proxy|tor)", .{route_str});
+        std.process.exit(1);
+    };
+    const socks = parseFlag(extra, "--socks") orelse "";
+    const download_dir = parseFlag(extra, "--download-dir") orelse "";
+
+    // Token: use --token if given, else generate a random 32-hex secret. The
+    // Tauri sidecar reads it off stdout and presents it on every request.
+    var token_buf: [32]u8 = undefined;
+    const token: []const u8 = if (parseFlag(extra, "--token")) |t| t else blk: {
+        var raw: [16]u8 = undefined;
+        std.crypto.random.bytes(&raw);
+        const hex = "0123456789abcdef";
+        for (raw, 0..) |b, i| {
+            token_buf[i * 2] = hex[b >> 4];
+            token_buf[i * 2 + 1] = hex[b & 0x0f];
+        }
+        break :blk token_buf[0..];
+    };
+
+    var mgr = carl.manager.Manager.init(allocator, .{
+        .route = route,
+        .socks = socks,
+        .download_dir = download_dir,
+        .listen_port = bt_port,
+    }) catch |err| {
+        log.err("failed to init manager: {}", .{err});
+        std.process.exit(1);
+    };
+    defer mgr.deinit();
+
+    var daemon = carl.daemon.Daemon{ .allocator = allocator, .manager = &mgr, .token = token };
+
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = daemonSigintHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.INT, &act, null);
+
+    // The token line is machine-readable (the GUI parses it); keep the format
+    // stable: "token: <hex>".
+    try stdout.print("carl daemon\n", .{});
+    try stdout.print("listen: http://127.0.0.1:{d}\n", .{port});
+    try stdout.print("token: {s}\n", .{token});
+    try stdout.print("route: {s}\n", .{route_str});
+
+    daemon.serve(port) catch |err| {
+        log.err("daemon error: {}", .{err});
+        std.process.exit(1);
+    };
+
+    // Connection/WebSocket threads are detached; give them a brief window to
+    // observe the shutdown flag and finish touching the allocator before
+    // `mgr.deinit()` and the GPA teardown run. (A full join of connection
+    // threads is a follow-up; see docs/daemon-api.md.)
+    std.Thread.sleep(300 * std.time.ns_per_ms);
 }
 
 // -------------------------------------------------------------------------

--- a/src/main.zig
+++ b/src/main.zig
@@ -789,11 +789,13 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         std.process.exit(1);
     };
 
-    // Connection/WebSocket threads are detached; give them a brief window to
-    // observe the shutdown flag and finish touching the allocator before
-    // `mgr.deinit()` and the GPA teardown run. (A full join of connection
-    // threads is a follow-up; see docs/daemon-api.md.)
-    std.Thread.sleep(300 * std.time.ns_per_ms);
+    // Connection/WebSocket threads and the relay prober are detached; give them
+    // a brief window to observe the shutdown flag and finish touching the
+    // allocator before `daemon.deinit()`, `mgr.deinit()`, and the GPA teardown
+    // run. (A full join of background threads is a follow-up; see
+    // docs/daemon-api.md.)
+    std.Thread.sleep(400 * std.time.ns_per_ms);
+    daemon.deinit();
 }
 
 // -------------------------------------------------------------------------

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -360,6 +360,9 @@ pub const Manager = struct {
     }
 
     fn fromMetainfo(self: *Manager, mi: metainfo.Metainfo, proxy: ?proxy_mod.Proxy) Error!Built {
+        // On a failed Session.init the metainfo is ours to free (it only becomes
+        // the session's on success); mirrors the magnet path's errdefer.
+        errdefer mi.deinit(self.allocator);
         const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer self.allocator.destroy(session);
         session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -91,6 +91,9 @@ const ManagedTransfer = struct {
     last_ms: i64 = 0,
     rate_down: u64 = 0,
     rate_up: u64 = 0,
+    /// True once a resolved magnet's .torrent has been written and `source`
+    /// repointed at it, so the checkpoint doesn't redo it.
+    resolved: bool = false,
 
     fn stop(self: *ManagedTransfer) void {
         // Signal the session loop to exit; it re-checks `running` every poll
@@ -507,6 +510,46 @@ pub const Manager = struct {
         self.restoring = false;
         self.persist();
         if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
+    }
+
+    /// Capture any download whose (magnet) metadata has resolved: write the real
+    /// `.torrent` next to the data, repoint the persisted source at it, and
+    /// re-persist. A subsequent restart then resumes the torrent fully —
+    /// verifying on-disk pieces — instead of re-bootstrapping the magnet. Called
+    /// periodically by the daemon; idempotent (the `resolved` flag).
+    pub fn checkpoint(self: *Manager) void {
+        var changed = false;
+        self.mutex.lock();
+        for (self.transfers.items) |mt| {
+            if (mt.is_seed or mt.resolved) continue;
+            const blob = mt.session.copyTorrent(self.allocator) orelse continue;
+            defer self.allocator.free(blob);
+            // Name the file by info-hash (safe; the display name may contain /).
+            const path = std.fmt.allocPrint(self.allocator, "{s}/{s}.carl.torrent", .{ self.cfg.download_dir, &mt.hash_hex }) catch continue;
+            var wrote = true;
+            {
+                var f = std.fs.cwd().createFile(path, .{ .truncate = true }) catch {
+                    self.allocator.free(path);
+                    continue;
+                };
+                defer f.close();
+                f.writeAll(blob) catch {
+                    wrote = false;
+                };
+            }
+            if (!wrote) {
+                self.allocator.free(path);
+                continue;
+            }
+            // Repoint the persisted recipe at the resolved .torrent (ownership of
+            // `path` moves to mt.source).
+            self.allocator.free(mt.source);
+            mt.source = path;
+            mt.resolved = true;
+            changed = true;
+        }
+        self.mutex.unlock();
+        if (changed) self.persist();
     }
 
     // -----------------------------------------------------------------------

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -25,6 +25,7 @@ const magnet_mod = @import("magnet.zig");
 const proxy_mod = @import("proxy.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
+const nip35 = @import("nip35.zig");
 const peer_announce = @import("peer_announce.zig");
 const nostr_config = @import("nostr_config.zig");
 const nostr_mod = @import("nostr.zig");
@@ -65,6 +66,8 @@ const ManagedTransfer = struct {
     info_hash: [20]u8,
     route: api.Route,
     want_nostr: bool,
+    /// True for torrents we created and seed (vs. ones we download).
+    is_seed: bool,
     /// Tracker availability captured at add time (from the initial metainfo), so
     /// snapshots needn't read the session's `meta` across threads — which the
     /// magnet path replaces on metadata completion.
@@ -164,14 +167,80 @@ pub const Manager = struct {
 
         std.fs.cwd().makePath(self.cfg.download_dir) catch {};
 
-        var built = self.buildSession(source, resolved_proxy) catch |err| {
+        const built = self.buildSession(source, resolved_proxy) catch |err| {
             if (socks_owned) |s| self.allocator.free(s);
             return err;
         };
+        const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
+        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, false, magnet);
+    }
 
-        // Once `mt` owns session/meta/socks/strings, all later errors must clean
-        // up through `mt.destroy()` only — never the pre-ownership errdefers, or
-        // we'd double-free. `mt_owned` gates exactly that handoff.
+    /// Create a torrent from a local file (or archive) and start seeding it. The
+    /// file is hashed in-process — carl needs no external torrent tool. With
+    /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
+    pub fn addSeed(self: *Manager, path: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
+        var socks_owned: ?[]u8 = null;
+        var resolved_proxy: ?proxy_mod.Proxy = null;
+        if (route != .direct) {
+            const dup = try self.allocator.dupe(u8, self.cfg.socks);
+            socks_owned = dup;
+            resolved_proxy = proxy_mod.parseUrl(dup) catch {
+                self.allocator.free(dup);
+                return error.BadProxy;
+            };
+        }
+
+        const mi = metainfo.createSingleFile(self.allocator, path, metainfo.default_piece_length) catch |e| {
+            if (socks_owned) |s| self.allocator.free(s);
+            return switch (e) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.InvalidTorrent,
+            };
+        };
+        // Seed from the file's own directory so storage resolves it by name.
+        const data_dir = std.fs.path.dirname(path) orelse ".";
+        const session = self.allocator.create(session_mod.Session) catch {
+            if (socks_owned) |s| self.allocator.free(s);
+            mi.deinit(self.allocator);
+            return error.OutOfMemory;
+        };
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, self.cfg.listen_port, resolved_proxy, .any, false) catch {
+            if (socks_owned) |s| self.allocator.free(s);
+            self.allocator.destroy(session);
+            mi.deinit(self.allocator);
+            return error.SessionInitFailed;
+        };
+        const built = Built{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
+
+        var hex: [40]u8 = undefined;
+        secp.toHex(&session.info_hash, &hex);
+        const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch {
+            if (socks_owned) |s| self.allocator.free(s);
+            session.deinit();
+            self.allocator.destroy(session);
+            mi.deinit(self.allocator);
+            return error.OutOfMemory;
+        };
+        defer self.allocator.free(magnet);
+
+        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, true, magnet);
+    }
+
+    /// Register a built session as a managed transfer and spawn its thread.
+    /// Shared by addTransfer (download) and addSeed (seed). On success takes
+    /// ownership of `built.session`, `built.meta`, and `socks_owned`; on any
+    /// error it frees them (the `mt_owned` flag gates that handoff so we never
+    /// double-free once `mt` owns everything).
+    fn register(
+        self: *Manager,
+        built: Built,
+        route: api.Route,
+        resolved_proxy: ?proxy_mod.Proxy,
+        socks_owned: ?[]u8,
+        want_nostr: bool,
+        is_seed: bool,
+        magnet_src: []const u8,
+    ) Error![]u8 {
         var mt_owned = false;
         errdefer if (!mt_owned) {
             built.session.deinit();
@@ -192,7 +261,7 @@ pub const Manager = struct {
         errdefer if (!mt_owned) self.allocator.free(id);
         const name = try self.allocator.dupe(u8, built.name);
         errdefer if (!mt_owned) self.allocator.free(name);
-        const magnet = try self.allocator.dupe(u8, if (std.mem.startsWith(u8, source, "magnet:")) source else "");
+        const magnet = try self.allocator.dupe(u8, magnet_src);
         errdefer if (!mt_owned) self.allocator.free(magnet);
 
         mt.* = .{
@@ -204,6 +273,7 @@ pub const Manager = struct {
             .info_hash = built.info_hash,
             .route = route,
             .want_nostr = want_nostr,
+            .is_seed = is_seed,
             .has_tracker = built.meta.announce.len > 0 or built.meta.announce_list != null,
             .has_http_tracker = std.mem.startsWith(u8, built.meta.announce, "http"),
             .socks_owned = socks_owned,
@@ -325,6 +395,14 @@ pub const Manager = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
         self.cfg.route = route;
+    }
+
+    /// A locked copy of the current download dir (for callers that need to build
+    /// a path without racing `setDownloadDir`).
+    pub fn downloadDirDup(self: *Manager, a: Allocator) Allocator.Error![]u8 {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return a.dupe(u8, self.cfg.download_dir);
     }
 
     /// Change the directory new transfers download into. Existing transfers keep
@@ -603,10 +681,36 @@ pub fn formatEta(buf: []u8, status: api.Status, remaining_bytes: u64, rate_bps: 
 // ---------------------------------------------------------------------------
 
 fn runThread(mt: *ManagedTransfer) void {
-    if (mt.want_nostr) collectNostrPeers(mt);
+    if (mt.want_nostr) {
+        if (mt.is_seed) publishSeedNostr(mt) else collectNostrPeers(mt);
+    }
     mt.session.run() catch |err| {
         log.err("transfer {s}: session error: {}", .{ mt.id, err });
     };
+}
+
+/// Publish a NIP-35 (kind-2003) torrent event for a seed so it's discoverable
+/// in Discover. Best-effort. The peer-announce (which needs a routable endpoint
+/// or an onion) is left to the CLI's `carl seed` for now; the torrent metadata
+/// event needs no reachable address and is enough to surface the torrent.
+fn publishSeedNostr(mt: *ManagedTransfer) void {
+    const a = mt.allocator;
+    const sk = nostr_config.readSecretKey(a) catch return; // no key → skip
+    const pk = secp.publicKeyFromSecret(sk) catch return;
+    var ev = nip35.buildFromMetainfo(a, sk, pk, mt.meta, mt.info_hash, "") catch return;
+    defer ev.deinit(a);
+
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var acks: usize = 0;
+    for (relay_urls) |url| {
+        if (!mt.session.running) return;
+        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
+        defer r.deinit();
+        if (relay_mod.publishAndWait(a, &r, ev, 5_000)) acks += 1;
+    }
+    if (acks > 0) log.info("seed {s}: published NIP-35 torrent event to {d} relay(s)", .{ mt.id, acks });
 }
 
 /// Pull peer-announce (kind-30078) endpoints for this info-hash off the

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1,0 +1,757 @@
+//! TorrentManager: a long-lived owner of many concurrent `Session`s, the piece
+//! the daemon hangs off of.
+//!
+//! `Session` is single-threaded with a blocking `run()` loop, so each transfer
+//! runs on its own OS thread. The manager itself only touches the list of
+//! transfers (under a mutex); snapshots read each session's *race-safe* state —
+//! scalar counters and the fixed-size `our_bitfield` (allocated once, never
+//! reallocated). It deliberately does NOT iterate a session's live `peers`
+//! ArrayList or `active_pieces` map across threads: those are mutated by the
+//! session thread and reading them concurrently is unsound. Exposing full
+//! per-peer rows requires the session to publish a locked snapshot — tracked as
+//! a follow-up; see docs/daemon-api.md.
+//!
+//! Scope of this first cut: the download path (magnet / .torrent / HTTP URL),
+//! routed direct or through a SOCKS proxy (proxy/tor). Creating a torrent from
+//! a local file ("Seed a file") and Tor hidden-service generation are follow-up
+//! work; `seeds()` therefore reflects transfers that are currently seeding.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const session_mod = @import("session.zig");
+const metainfo = @import("metainfo.zig");
+const magnet_mod = @import("magnet.zig");
+const proxy_mod = @import("proxy.zig");
+const extension = @import("extension.zig");
+const relay_mod = @import("relay.zig");
+const peer_announce = @import("peer_announce.zig");
+const nostr_config = @import("nostr_config.zig");
+const nostr_mod = @import("nostr.zig");
+const secp = @import("secp.zig");
+const api = @import("api.zig");
+
+const log = std.log.scoped(.manager);
+
+pub const Error = error{
+    InvalidMagnet,
+    InvalidTorrent,
+    HttpFailed,
+    BadProxy,
+    SessionInitFailed,
+    NotFound,
+} || Allocator.Error;
+
+/// Daemon-level configuration mirrored to the Settings screen. String fields
+/// are owned; setters free and re-dup.
+pub const Config = struct {
+    route: api.Route = .direct,
+    socks: []const u8 = "",
+    download_dir: []const u8 = "",
+    listen_port: u16 = 6881,
+    max_active: u32 = 8,
+    peer_limit: u32 = 60,
+    publish_nip35: bool = true,
+};
+
+/// One running transfer: its session, the thread driving it, and the metadata
+/// the manager owns for the session's lifetime.
+const ManagedTransfer = struct {
+    allocator: Allocator,
+    id: []u8,
+    name: []u8,
+    magnet: []u8,
+    hash_hex: [40]u8,
+    info_hash: [20]u8,
+    route: api.Route,
+    want_nostr: bool,
+    /// Tracker availability captured at add time (from the initial metainfo), so
+    /// snapshots needn't read the session's `meta` across threads — which the
+    /// magnet path replaces on metadata completion.
+    has_tracker: bool,
+    has_http_tracker: bool,
+    /// Owned copy of the socks URL the proxy slices borrow from.
+    socks_owned: ?[]u8,
+    proxy: ?proxy_mod.Proxy,
+    session: *session_mod.Session,
+    meta: metainfo.Metainfo,
+    thread: ?std.Thread,
+    added_ms: i64,
+
+    // Rate sampling (guarded by Manager.mutex).
+    last_down: u64 = 0,
+    last_up: u64 = 0,
+    last_ms: i64 = 0,
+    rate_down: u64 = 0,
+    rate_up: u64 = 0,
+
+    fn stop(self: *ManagedTransfer) void {
+        // Signal the session loop to exit; it re-checks `running` every poll
+        // tick (~1s). Joining waits for the final stopped-announce.
+        self.session.running = false;
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
+        }
+    }
+
+    fn destroy(self: *ManagedTransfer) void {
+        // Order matters: stop+join the thread, deinit the session, THEN free the
+        // metadata the session borrowed (the magnet path frees its own replaced
+        // copy; the original placeholder is ours).
+        self.stop();
+        self.session.deinit();
+        self.allocator.destroy(self.session);
+        self.meta.deinit(self.allocator);
+        if (self.socks_owned) |s| self.allocator.free(s);
+        self.allocator.free(self.id);
+        self.allocator.free(self.name);
+        self.allocator.free(self.magnet);
+        self.allocator.destroy(self);
+    }
+};
+
+pub const Manager = struct {
+    allocator: Allocator,
+    mutex: std.Thread.Mutex = .{},
+    transfers: std.ArrayList(*ManagedTransfer) = .empty,
+    next_id: usize = 1,
+    cfg: Config,
+
+    pub fn init(allocator: Allocator, cfg: Config) Allocator.Error!Manager {
+        return .{
+            .allocator = allocator,
+            .cfg = .{
+                .route = cfg.route,
+                .socks = try allocator.dupe(u8, if (cfg.socks.len > 0) cfg.socks else "socks5h://127.0.0.1:9050"),
+                .download_dir = try allocator.dupe(u8, if (cfg.download_dir.len > 0) cfg.download_dir else "."),
+                .listen_port = cfg.listen_port,
+                .max_active = cfg.max_active,
+                .peer_limit = cfg.peer_limit,
+                .publish_nip35 = cfg.publish_nip35,
+            },
+        };
+    }
+
+    pub fn deinit(self: *Manager) void {
+        // No lock: deinit happens after the server loop has stopped.
+        for (self.transfers.items) |mt| mt.destroy();
+        self.transfers.deinit(self.allocator);
+        self.allocator.free(self.cfg.socks);
+        self.allocator.free(self.cfg.download_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutations
+    // -----------------------------------------------------------------------
+
+    /// Add a transfer from a magnet URI, .torrent path, or HTTP(S) URL on the
+    /// given route. Spawns the session thread. Returns the new transfer id
+    /// (owned by the caller).
+    pub fn addTransfer(self: *Manager, source: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
+        // Each transfer owns the socks URL its Proxy slices borrow from, so a
+        // later `setRoute`/config change can't dangle a running transfer.
+        var socks_owned: ?[]u8 = null;
+        var resolved_proxy: ?proxy_mod.Proxy = null;
+        if (route != .direct) {
+            const dup = try self.allocator.dupe(u8, self.cfg.socks);
+            socks_owned = dup;
+            resolved_proxy = proxy_mod.parseUrl(dup) catch {
+                self.allocator.free(dup);
+                return error.BadProxy;
+            };
+        }
+
+        std.fs.cwd().makePath(self.cfg.download_dir) catch {};
+
+        var built = self.buildSession(source, resolved_proxy) catch |err| {
+            if (socks_owned) |s| self.allocator.free(s);
+            return err;
+        };
+
+        // Once `mt` owns session/meta/socks/strings, all later errors must clean
+        // up through `mt.destroy()` only — never the pre-ownership errdefers, or
+        // we'd double-free. `mt_owned` gates exactly that handoff.
+        var mt_owned = false;
+        errdefer if (!mt_owned) {
+            built.session.deinit();
+            self.allocator.destroy(built.session);
+            built.meta.deinit(self.allocator);
+            if (socks_owned) |s| self.allocator.free(s);
+        };
+
+        const mt = try self.allocator.create(ManagedTransfer);
+        errdefer if (!mt_owned) self.allocator.destroy(mt);
+
+        self.mutex.lock();
+        const id_num = self.next_id;
+        self.next_id += 1;
+        self.mutex.unlock();
+
+        const id = try std.fmt.allocPrint(self.allocator, "t{d}", .{id_num});
+        errdefer if (!mt_owned) self.allocator.free(id);
+        const name = try self.allocator.dupe(u8, built.name);
+        errdefer if (!mt_owned) self.allocator.free(name);
+        const magnet = try self.allocator.dupe(u8, if (std.mem.startsWith(u8, source, "magnet:")) source else "");
+        errdefer if (!mt_owned) self.allocator.free(magnet);
+
+        mt.* = .{
+            .allocator = self.allocator,
+            .id = id,
+            .name = name,
+            .magnet = magnet,
+            .hash_hex = undefined,
+            .info_hash = built.info_hash,
+            .route = route,
+            .want_nostr = want_nostr,
+            .has_tracker = built.meta.announce.len > 0 or built.meta.announce_list != null,
+            .has_http_tracker = std.mem.startsWith(u8, built.meta.announce, "http"),
+            .socks_owned = socks_owned,
+            .proxy = resolved_proxy,
+            .session = built.session,
+            .meta = built.meta,
+            .thread = null,
+            .added_ms = std.time.milliTimestamp(),
+        };
+        secp.toHex(&built.info_hash, &mt.hash_hex);
+        mt_owned = true; // mt now owns session, meta, socks, id, name, magnet
+
+        self.mutex.lock();
+        self.transfers.append(self.allocator, mt) catch |err| {
+            self.mutex.unlock();
+            mt.destroy();
+            return err;
+        };
+        self.mutex.unlock();
+
+        // Spawn after publishing so a snapshot taken mid-spawn sees the row.
+        mt.thread = std.Thread.spawn(.{}, runThread, .{mt}) catch {
+            // Roll back: remove from the list and destroy (frees `id` too, so we
+            // must not touch it afterward on this path).
+            _ = self.removeTransfer(id) catch {};
+            return error.SessionInitFailed;
+        };
+
+        return self.allocator.dupe(u8, id);
+    }
+
+    /// Stop and remove the transfer with `id`. Returns true if found.
+    pub fn removeTransfer(self: *Manager, id: []const u8) Error!bool {
+        self.mutex.lock();
+        var found: ?*ManagedTransfer = null;
+        var idx: usize = 0;
+        for (self.transfers.items, 0..) |mt, i| {
+            if (std.mem.eql(u8, mt.id, id)) {
+                found = mt;
+                idx = i;
+                break;
+            }
+        }
+        if (found) |_| _ = self.transfers.orderedRemove(idx);
+        self.mutex.unlock();
+
+        if (found) |mt| {
+            mt.destroy(); // joins the thread outside the lock
+            return true;
+        }
+        return false;
+    }
+
+    // -----------------------------------------------------------------------
+    // Snapshots
+    // -----------------------------------------------------------------------
+
+    /// Build a snapshot of all transfers into `arena`. Caller owns nothing
+    /// individually — freeing the arena frees everything.
+    pub fn snapshot(self: *Manager, arena: Allocator) Allocator.Error![]api.Transfer {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const now = std.time.milliTimestamp();
+        var out = try arena.alloc(api.Transfer, self.transfers.items.len);
+        for (self.transfers.items, 0..) |mt, i| {
+            out[i] = try snapshotTransfer(mt, arena, now);
+        }
+        return out;
+    }
+
+    /// Seeds = transfers currently in the seeding state.
+    pub fn seeds(self: *Manager, arena: Allocator) Allocator.Error![]api.Seed {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var list: std.ArrayList(api.Seed) = .empty;
+        for (self.transfers.items) |mt| {
+            const p = mt.session.progressSnapshot();
+            const complete = p.num_pieces > 0 and p.have >= p.num_pieces;
+            const is_seeding = p.mode == .seed or complete;
+            if (!is_seeding) continue;
+            const ratio: f64 = if (p.downloaded > 0)
+                @as(f64, @floatFromInt(p.uploaded)) / @as(f64, @floatFromInt(p.downloaded))
+            else
+                0;
+            try list.append(arena, .{
+                .id = mt.id,
+                .name = mt.name,
+                .visibility = mt.route,
+                .onion = null,
+                .size = p.total_length,
+                .up_total = p.uploaded,
+                .up = mt.rate_up,
+                .leechers = 0,
+                .ratio = ratio,
+                .relays = 0,
+            });
+        }
+        return list.toOwnedSlice(arena);
+    }
+
+    pub fn settings(self: *Manager, relays: []const []const u8) api.Settings {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return .{
+            .route = self.cfg.route,
+            .socks = self.cfg.socks,
+            .relays = relays,
+            .download_dir = self.cfg.download_dir,
+            .listen_port = self.cfg.listen_port,
+            .max_active = self.cfg.max_active,
+            .peer_limit = self.cfg.peer_limit,
+            .publish_nip35 = self.cfg.publish_nip35,
+        };
+    }
+
+    pub fn setRoute(self: *Manager, route: api.Route) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.cfg.route = route;
+    }
+
+    // -----------------------------------------------------------------------
+    // Session construction
+    // -----------------------------------------------------------------------
+
+    const Built = struct {
+        session: *session_mod.Session,
+        meta: metainfo.Metainfo,
+        info_hash: [20]u8,
+        name: []const u8, // borrows from meta
+    };
+
+    fn buildSession(self: *Manager, source: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+        if (std.mem.startsWith(u8, source, "magnet:")) return self.buildMagnet(source, proxy);
+        if (std.mem.startsWith(u8, source, "http://") or std.mem.startsWith(u8, source, "https://"))
+            return self.buildHttp(source, proxy);
+        return self.buildFile(source, proxy);
+    }
+
+    fn buildFile(self: *Manager, path: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+        const data = std.fs.cwd().readFileAlloc(self.allocator, path, 10 * 1024 * 1024) catch return error.InvalidTorrent;
+        defer self.allocator.free(data);
+        const mi = metainfo.parse(self.allocator, data) catch return error.InvalidTorrent;
+        return self.fromMetainfo(mi, proxy);
+    }
+
+    fn buildHttp(self: *Manager, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+        const data = fetchUrl(self.allocator, url, proxy) catch return error.HttpFailed;
+        defer self.allocator.free(data);
+        const mi = metainfo.parse(self.allocator, data) catch return error.InvalidTorrent;
+        return self.fromMetainfo(mi, proxy);
+    }
+
+    fn fromMetainfo(self: *Manager, mi: metainfo.Metainfo, proxy: ?proxy_mod.Proxy) Error!Built {
+        const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(session);
+        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {
+            return error.SessionInitFailed;
+        };
+        return .{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
+    }
+
+    /// Build a metadata-only session from a magnet link (BEP 9 bootstrap),
+    /// mirroring the CLI's magnet path minus the optional NIP-35 enrichment.
+    fn buildMagnet(self: *Manager, uri: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+        const ml = magnet_mod.parse(self.allocator, uri) catch return error.InvalidMagnet;
+        defer ml.deinit(self.allocator);
+        const a = self.allocator;
+
+        const mi = try buildMagnetMetainfo(a, ml);
+        errdefer mi.deinit(a);
+
+        const session = a.create(session_mod.Session) catch return error.OutOfMemory;
+        errdefer a.destroy(session);
+        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {
+            return error.SessionInitFailed;
+        };
+        session.info_hash = ml.info_hash; // use the magnet's hash, not SHA1("")
+        session.metadata_download = extension.MetadataDownload.init(a, ml.info_hash);
+        session.metadata_only = true;
+        return .{ .session = session, .meta = mi, .info_hash = ml.info_hash, .name = session.meta.name };
+    }
+};
+
+/// Construct a fully-owned placeholder `Metainfo` from a magnet link. On any
+/// failure all partial allocations are freed; on success ownership transfers to
+/// the returned value (free it via `Metainfo.deinit`). Kept free-standing so
+/// its errdefers never overlap a caller's `mi.deinit` (which would double-free).
+fn buildMagnetMetainfo(a: Allocator, ml: magnet_mod.MagnetLink) Allocator.Error!metainfo.Metainfo {
+    const name = try a.dupe(u8, ml.name orelse "unknown");
+    errdefer a.free(name);
+
+    const path0 = try a.alloc([]const u8, 1);
+    errdefer a.free(path0);
+    path0[0] = try a.dupe(u8, name);
+    errdefer a.free(path0[0]);
+
+    const files = try a.alloc(metainfo.FileInfo, 1);
+    errdefer a.free(files);
+    files[0] = .{ .length = 0, .path = path0 };
+
+    var announce_list: ?[]const []const []const u8 = null;
+    errdefer if (announce_list) |tiers| {
+        for (tiers) |tier| {
+            for (tier) |t| a.free(t);
+            a.free(tier);
+        }
+        a.free(tiers);
+    };
+    if (ml.trackers.len > 0) {
+        const tier = try a.alloc([]const u8, ml.trackers.len);
+        // Scoped to this block: covers the window before `announce_list` (and
+        // its function-scope errdefer) takes ownership.
+        var filled: usize = 0;
+        errdefer {
+            for (tier[0..filled]) |t| a.free(t);
+            a.free(tier);
+        }
+        while (filled < ml.trackers.len) : (filled += 1) {
+            tier[filled] = try a.dupe(u8, ml.trackers[filled]);
+        }
+        const tiers = try a.alloc([]const []const u8, 1);
+        tiers[0] = tier;
+        announce_list = tiers;
+    }
+
+    const announce = try a.dupe(u8, if (ml.trackers.len > 0) ml.trackers[0] else "");
+    errdefer a.free(announce);
+
+    return metainfo.Metainfo{
+        .announce = announce,
+        .announce_list = announce_list,
+        .name = name,
+        .piece_length = 0,
+        .pieces = &.{},
+        .files = files,
+        .comment = null,
+        .creation_date = null,
+        .created_by = null,
+        .raw_info = &.{},
+        .url_list = null,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Per-transfer snapshot (called with Manager.mutex held)
+// ---------------------------------------------------------------------------
+
+// Build one transfer's snapshot from race-safe session state. Called with
+// Manager.mutex held.
+fn snapshotTransfer(mt: *ManagedTransfer, arena: Allocator, now: i64) Allocator.Error!api.Transfer {
+    const p = mt.session.progressSnapshot();
+
+    // Rate sampling: bytes since the last snapshot over elapsed milliseconds.
+    const dt = now - mt.last_ms;
+    if (mt.last_ms != 0 and dt > 0) {
+        const dd = p.downloaded -| mt.last_down;
+        const du = p.uploaded -| mt.last_up;
+        const dt_ms: u64 = @intCast(dt);
+        mt.rate_down = @intCast(@as(u128, dd) * 1000 / dt_ms);
+        mt.rate_up = @intCast(@as(u128, du) * 1000 / dt_ms);
+    }
+    mt.last_down = p.downloaded;
+    mt.last_up = p.uploaded;
+    mt.last_ms = now;
+
+    const made_progress = mt.rate_down > 0;
+    const status = deriveStatus(p.metadata_only, p.num_pieces, p.have, p.mode == .seed, made_progress);
+    const pct = pctFromCounts(p.have, p.num_pieces);
+
+    var src_buf: [3]api.SourceKind = undefined;
+    const src = deriveSources(&src_buf, mt.route, mt.has_tracker, mt.has_http_tracker, mt.want_nostr);
+    const sources = try arena.dupe(api.SourceKind, src);
+
+    var eta_buf: [24]u8 = undefined;
+    const remaining: u64 = if (p.total_length > 0 and pct < 100)
+        p.total_length - (p.total_length * pct / 100)
+    else
+        0;
+    const eta = try arena.dupe(u8, formatEta(&eta_buf, status, remaining, mt.rate_down));
+
+    const ratio: ?f64 = if (p.downloaded > 0)
+        @as(f64, @floatFromInt(p.uploaded)) / @as(f64, @floatFromInt(p.downloaded))
+    else
+        null;
+
+    return .{
+        .id = try arena.dupe(u8, mt.id),
+        .name = try arena.dupe(u8, mt.name),
+        .hash = try arena.dupe(u8, &mt.hash_hex),
+        .magnet = try arena.dupe(u8, mt.magnet),
+        .status = status,
+        .route = mt.route,
+        .sources = sources,
+        .pct = pct,
+        .size = if (p.total_length > 0) p.total_length else null,
+        .down = mt.rate_down,
+        .up = mt.rate_up,
+        .eta = eta,
+        .peers = p.peers,
+        .seeds = 0,
+        .ratio = if (status == .seeding or status == .complete) ratio else null,
+        .onion = null,
+    };
+}
+
+// ===========================================================================
+// Pure derivation helpers (unit-tested)
+// ===========================================================================
+
+pub fn pctFromCounts(have: u32, num_pieces: u32) u8 {
+    if (num_pieces == 0) return 0;
+    const p = @as(u64, have) * 100 / num_pieces;
+    return @intCast(@min(p, 100));
+}
+
+pub fn deriveStatus(metadata_only: bool, num_pieces: u32, have: u32, mode_is_seed: bool, made_progress: bool) api.Status {
+    if (metadata_only and num_pieces == 0) return .metadata;
+    const complete = num_pieces > 0 and have >= num_pieces;
+    if (mode_is_seed) return .seeding;
+    if (complete) return .complete;
+    if (!made_progress) return .stalled;
+    return .downloading;
+}
+
+/// Fill `out` with the sources for a route and return the used slice.
+pub fn deriveSources(
+    out: *[3]api.SourceKind,
+    route: api.Route,
+    has_tracker: bool,
+    has_http_tracker: bool,
+    want_nostr: bool,
+) []api.SourceKind {
+    var n: usize = 0;
+    switch (route) {
+        .direct => {
+            if (has_tracker) {
+                out[n] = .tracker;
+                n += 1;
+            }
+            out[n] = .dht; // DHT only available on the clear net
+            n += 1;
+            if (want_nostr) {
+                out[n] = .nostr;
+                n += 1;
+            }
+        },
+        .proxy, .tor => {
+            // Proxied: DHT and UDP trackers are disabled to avoid IP leaks.
+            if (has_http_tracker) {
+                out[n] = .tracker;
+                n += 1;
+            }
+            if (want_nostr or n == 0) {
+                out[n] = .nostr;
+                n += 1;
+            }
+        },
+    }
+    return out[0..n];
+}
+
+/// Format a human ETA into `buf`. Returns "—" when stalled/idle/complete.
+pub fn formatEta(buf: []u8, status: api.Status, remaining_bytes: u64, rate_bps: u64) []const u8 {
+    if (status == .stalled) return "stalled";
+    if (status == .complete or status == .seeding) return "—";
+    if (rate_bps == 0 or remaining_bytes == 0) return "—";
+    const secs = remaining_bytes / rate_bps;
+    if (secs >= 3600) {
+        const h = secs / 3600;
+        const m = (secs % 3600) / 60;
+        return std.fmt.bufPrint(buf, "{d}h {d}m", .{ h, m }) catch "—";
+    } else if (secs >= 60) {
+        return std.fmt.bufPrint(buf, "{d}m {d}s", .{ secs / 60, secs % 60 }) catch "—";
+    }
+    return std.fmt.bufPrint(buf, "{d}s", .{secs}) catch "—";
+}
+
+// ---------------------------------------------------------------------------
+// Transfer thread + nostr peer discovery
+// ---------------------------------------------------------------------------
+
+fn runThread(mt: *ManagedTransfer) void {
+    if (mt.want_nostr) collectNostrPeers(mt);
+    mt.session.run() catch |err| {
+        log.err("transfer {s}: session error: {}", .{ mt.id, err });
+    };
+}
+
+/// Pull peer-announce (kind-30078) endpoints for this info-hash off the
+/// configured relays and feed them to the session. Mirrors the CLI's
+/// collectNostrPeers, trimmed. Best-effort: failures are logged, not fatal.
+fn collectNostrPeers(mt: *ManagedTransfer) void {
+    const a = mt.allocator;
+    var ih_hex: [40]u8 = undefined;
+    secp.toHex(&mt.info_hash, &ih_hex);
+
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var values = [_][]const u8{&ih_hex};
+    var tag_filters = [_]nostr_mod.Filter.TagFilter{.{ .letter = 'd', .values = &values }};
+    const filter: nostr_mod.Filter = .{
+        .kinds = &[_]u32{peer_announce.kind_peer_announce},
+        .tags = &tag_filters,
+        .limit = 200,
+    };
+
+    var added: usize = 0;
+    for (relay_urls) |url| {
+        if (!mt.session.running) return;
+        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
+        defer r.deinit();
+        const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
+            .timeout_ms = 10_000,
+            .max_events = 200,
+            .verify_signatures = true,
+        }) catch continue;
+        defer {
+            for (events) |e| e.deinit(a);
+            a.free(events);
+        }
+        for (events) |ev| {
+            const ann = peer_announce.parse(ev) catch continue;
+            if (!std.mem.eql(u8, &ann.info_hash, &mt.info_hash)) continue;
+            if (added >= 50) break;
+            switch (ann.endpoint) {
+                .ipv4 => |ep| {
+                    const addr = std.net.Address.initIp4(ep.ip, ep.port);
+                    mt.session.connectDirectPeer(addr) catch continue;
+                    added += 1;
+                },
+                .onion => |ep| {
+                    if (mt.session.proxy == null) continue;
+                    mt.session.connectOnionPeer(ep.host, ep.port) catch continue;
+                    added += 1;
+                },
+            }
+        }
+    }
+    if (added > 0) log.info("transfer {s}: added {d} peers from nostr", .{ mt.id, added });
+}
+
+// fetchUrl: download a .torrent over HTTP(S), optionally via proxy. Ported from
+// the CLI so the manager doesn't depend on main.zig.
+fn fetchUrl(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy) ![]u8 {
+    if (proxy) |px| {
+        return proxy_mod.httpGet(allocator, px, url, null) catch return error.HttpFailed;
+    }
+    var client: std.http.Client = .{ .allocator = allocator };
+    defer client.deinit();
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(allocator);
+    var adapt_buf: [4096]u8 = undefined;
+    const dw = body.writer(allocator);
+    var adapter = dw.adaptToNewApi(&adapt_buf);
+    const result = client.fetch(.{
+        .location = .{ .url = url },
+        .response_writer = &adapter.new_interface,
+    }) catch return error.HttpFailed;
+    const buffered = adapter.new_interface.buffered();
+    if (buffered.len > 0) body.appendSlice(allocator, buffered) catch return error.HttpFailed;
+    if (result.status != .ok or body.items.len == 0) return error.HttpFailed;
+    return body.toOwnedSlice(allocator);
+}
+
+// ===========================================================================
+// Tests (pure helpers only — the threaded session path is exercised at runtime)
+// ===========================================================================
+
+const testing = std.testing;
+
+test "pctFromCounts" {
+    try testing.expectEqual(@as(u8, 0), pctFromCounts(0, 0));
+    try testing.expectEqual(@as(u8, 0), pctFromCounts(0, 100));
+    try testing.expectEqual(@as(u8, 50), pctFromCounts(50, 100));
+    try testing.expectEqual(@as(u8, 100), pctFromCounts(100, 100));
+    try testing.expectEqual(@as(u8, 63), pctFromCounts(230, 360)); // truncates (63.8)
+    try testing.expectEqual(@as(u8, 100), pctFromCounts(400, 360)); // clamps over-count
+}
+
+test "deriveStatus" {
+    try testing.expectEqual(api.Status.metadata, deriveStatus(true, 0, 0, false, false));
+    try testing.expectEqual(api.Status.complete, deriveStatus(false, 100, 100, false, false));
+    try testing.expectEqual(api.Status.seeding, deriveStatus(false, 100, 100, true, false));
+    try testing.expectEqual(api.Status.seeding, deriveStatus(false, 100, 40, true, false));
+    try testing.expectEqual(api.Status.downloading, deriveStatus(false, 100, 40, false, true));
+    try testing.expectEqual(api.Status.stalled, deriveStatus(false, 100, 40, false, false));
+}
+
+test "deriveSources: direct uses tracker+dht+nostr" {
+    var buf: [3]api.SourceKind = undefined;
+    const s = deriveSources(&buf, .direct, true, true, true);
+    try testing.expectEqual(@as(usize, 3), s.len);
+    try testing.expectEqual(api.SourceKind.tracker, s[0]);
+    try testing.expectEqual(api.SourceKind.dht, s[1]);
+    try testing.expectEqual(api.SourceKind.nostr, s[2]);
+}
+
+test "deriveSources: direct without tracker drops tracker" {
+    var buf: [3]api.SourceKind = undefined;
+    const s = deriveSources(&buf, .direct, false, false, false);
+    try testing.expectEqual(@as(usize, 1), s.len);
+    try testing.expectEqual(api.SourceKind.dht, s[0]);
+}
+
+test "deriveSources: tor falls back to nostr only" {
+    var buf: [3]api.SourceKind = undefined;
+    const s = deriveSources(&buf, .tor, true, false, false);
+    // http tracker absent + want_nostr false => nostr fallback (n==0 branch)
+    try testing.expectEqual(@as(usize, 1), s.len);
+    try testing.expectEqual(api.SourceKind.nostr, s[0]);
+}
+
+test "deriveSources: proxy with http tracker keeps tracker + nostr" {
+    var buf: [3]api.SourceKind = undefined;
+    const s = deriveSources(&buf, .proxy, true, true, true);
+    try testing.expectEqual(@as(usize, 2), s.len);
+    try testing.expectEqual(api.SourceKind.tracker, s[0]);
+    try testing.expectEqual(api.SourceKind.nostr, s[1]);
+}
+
+test "formatEta" {
+    var buf: [24]u8 = undefined;
+    try testing.expectEqualStrings("stalled", formatEta(&buf, .stalled, 100, 0));
+    try testing.expectEqualStrings("—", formatEta(&buf, .complete, 0, 0));
+    try testing.expectEqualStrings("—", formatEta(&buf, .seeding, 0, 5));
+    try testing.expectEqualStrings("—", formatEta(&buf, .downloading, 100, 0));
+    try testing.expectEqualStrings("10s", formatEta(&buf, .downloading, 1000, 100));
+    try testing.expectEqualStrings("1m 40s", formatEta(&buf, .downloading, 10000, 100));
+    try testing.expectEqualStrings("2h 46m", formatEta(&buf, .downloading, 1_000_000, 100));
+}
+
+test "Manager: init/deinit with config defaults" {
+    const allocator = testing.allocator;
+    var m = try Manager.init(allocator, .{});
+    defer m.deinit();
+    try testing.expectEqualStrings("socks5h://127.0.0.1:9050", m.cfg.socks);
+    try testing.expectEqualStrings(".", m.cfg.download_dir);
+    try testing.expectEqual(api.Route.direct, m.cfg.route);
+
+    // Empty snapshot under arena.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const snap = try m.snapshot(arena.allocator());
+    try testing.expectEqual(@as(usize, 0), snap.len);
+    m.setRoute(.tor);
+    try testing.expectEqual(api.Route.tor, m.cfg.route);
+}

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -27,6 +27,7 @@ const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
 const nip35 = @import("nip35.zig");
 const peer_announce = @import("peer_announce.zig");
+const state_mod = @import("state.zig");
 const nostr_config = @import("nostr_config.zig");
 const nostr_mod = @import("nostr.zig");
 const secp = @import("secp.zig");
@@ -62,6 +63,9 @@ const ManagedTransfer = struct {
     id: []u8,
     name: []u8,
     magnet: []u8,
+    /// Owned recipe to re-create this transfer on restart: the original source
+    /// (magnet/url/.torrent path for a download, file path for a seed).
+    source: []u8,
     hash_hex: [40]u8,
     info_hash: [20]u8,
     route: api.Route,
@@ -110,6 +114,7 @@ const ManagedTransfer = struct {
         self.allocator.free(self.id);
         self.allocator.free(self.name);
         self.allocator.free(self.magnet);
+        self.allocator.free(self.source);
         self.allocator.destroy(self);
     }
 };
@@ -120,6 +125,9 @@ pub const Manager = struct {
     transfers: std.ArrayList(*ManagedTransfer) = .empty,
     next_id: usize = 1,
     cfg: Config,
+    /// While replaying persisted state on startup, suppress per-add persistence
+    /// (we write once at the end of `restore`).
+    restoring: bool = false,
 
     pub fn init(allocator: Allocator, cfg: Config) Allocator.Error!Manager {
         return .{
@@ -172,7 +180,7 @@ pub const Manager = struct {
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, false, magnet);
+        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, false, magnet, source);
     }
 
     /// Create a torrent from a local file (or archive) and start seeding it. The
@@ -223,7 +231,7 @@ pub const Manager = struct {
         };
         defer self.allocator.free(magnet);
 
-        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, true, magnet);
+        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, true, magnet, path);
     }
 
     /// Register a built session as a managed transfer and spawn its thread.
@@ -240,6 +248,7 @@ pub const Manager = struct {
         want_nostr: bool,
         is_seed: bool,
         magnet_src: []const u8,
+        source_src: []const u8,
     ) Error![]u8 {
         var mt_owned = false;
         errdefer if (!mt_owned) {
@@ -263,12 +272,15 @@ pub const Manager = struct {
         errdefer if (!mt_owned) self.allocator.free(name);
         const magnet = try self.allocator.dupe(u8, magnet_src);
         errdefer if (!mt_owned) self.allocator.free(magnet);
+        const source = try self.allocator.dupe(u8, source_src);
+        errdefer if (!mt_owned) self.allocator.free(source);
 
         mt.* = .{
             .allocator = self.allocator,
             .id = id,
             .name = name,
             .magnet = magnet,
+            .source = source,
             .hash_hex = undefined,
             .info_hash = built.info_hash,
             .route = route,
@@ -302,6 +314,7 @@ pub const Manager = struct {
             return error.SessionInitFailed;
         };
 
+        self.persist();
         return self.allocator.dupe(u8, id);
     }
 
@@ -322,6 +335,7 @@ pub const Manager = struct {
 
         if (found) |mt| {
             mt.destroy(); // joins the thread outside the lock
+            self.persist();
             return true;
         }
         return false;
@@ -393,8 +407,9 @@ pub const Manager = struct {
 
     pub fn setRoute(self: *Manager, route: api.Route) void {
         self.mutex.lock();
-        defer self.mutex.unlock();
         self.cfg.route = route;
+        self.mutex.unlock();
+        self.persist();
     }
 
     /// A locked copy of the current download dir (for callers that need to build
@@ -410,10 +425,88 @@ pub const Manager = struct {
     pub fn setDownloadDir(self: *Manager, dir: []const u8) Allocator.Error!void {
         const dup = try self.allocator.dupe(u8, dir);
         self.mutex.lock();
-        defer self.mutex.unlock();
         self.allocator.free(self.cfg.download_dir);
         self.cfg.download_dir = dup;
+        self.mutex.unlock();
         std.fs.cwd().makePath(dup) catch {};
+        self.persist();
+    }
+
+    // -----------------------------------------------------------------------
+    // Persistence — restore the full set of transfers/seeds + settings on
+    // restart so nothing is lost. (Relays persist separately via nostr_config.)
+    // -----------------------------------------------------------------------
+
+    /// Write the current transfers + settings to the state file. Best-effort;
+    /// a no-op while `restore` is replaying. Snapshots under the lock, then does
+    /// file I/O unlocked.
+    pub fn persist(self: *Manager) void {
+        if (self.restoring) return;
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        self.mutex.lock();
+        const route = self.cfg.route;
+        const dir = aa.dupe(u8, self.cfg.download_dir) catch {
+            self.mutex.unlock();
+            return;
+        };
+        var specs: std.ArrayList(state_mod.TransferSpec) = .empty;
+        for (self.transfers.items) |mt| {
+            const src = aa.dupe(u8, mt.source) catch break;
+            specs.append(aa, .{
+                .kind = if (mt.is_seed) .seed else .download,
+                .source = src,
+                .route = mt.route,
+                .nostr = mt.want_nostr,
+            }) catch break;
+        }
+        self.mutex.unlock();
+
+        state_mod.save(self.allocator, route, dir, specs.items) catch |e| {
+            log.warn("failed to persist daemon state: {}", .{e});
+        };
+    }
+
+    /// Replay persisted state on startup: apply settings and re-add every
+    /// transfer/seed. Downloads resume from on-disk pieces; seeds re-hash their
+    /// file. Call once, before serving. Blocking.
+    pub fn restore(self: *Manager) void {
+        const st = (state_mod.load(self.allocator) catch |e| {
+            log.warn("failed to load daemon state: {}", .{e});
+            return;
+        }) orelse return;
+        defer st.deinit(self.allocator);
+
+        self.mutex.lock();
+        self.cfg.route = st.route;
+        if (st.download_dir.len > 0) {
+            if (self.allocator.dupe(u8, st.download_dir)) |d| {
+                self.allocator.free(self.cfg.download_dir);
+                self.cfg.download_dir = d;
+            } else |_| {}
+        }
+        self.mutex.unlock();
+        std.fs.cwd().makePath(self.cfg.download_dir) catch {};
+
+        self.restoring = true;
+        var restored: usize = 0;
+        for (st.transfers) |t| {
+            const res = switch (t.kind) {
+                .download => self.addTransfer(t.source, t.route, t.nostr),
+                .seed => self.addSeed(t.source, t.route, t.nostr),
+            };
+            if (res) |id| {
+                self.allocator.free(id);
+                restored += 1;
+            } else |e| {
+                log.warn("restore: could not re-add '{s}': {}", .{ t.source, e });
+            }
+        }
+        self.restoring = false;
+        self.persist();
+        if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
     }
 
     // -----------------------------------------------------------------------

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -327,6 +327,17 @@ pub const Manager = struct {
         self.cfg.route = route;
     }
 
+    /// Change the directory new transfers download into. Existing transfers keep
+    /// their original directory; this affects subsequently added ones.
+    pub fn setDownloadDir(self: *Manager, dir: []const u8) Allocator.Error!void {
+        const dup = try self.allocator.dupe(u8, dir);
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        self.allocator.free(self.cfg.download_dir);
+        self.cfg.download_dir = dup;
+        std.fs.cwd().makePath(dup) catch {};
+    }
+
     // -----------------------------------------------------------------------
     // Session construction
     // -----------------------------------------------------------------------

--- a/src/metainfo.zig
+++ b/src/metainfo.zig
@@ -303,7 +303,108 @@ pub fn infoHash(raw_info: []const u8) [20]u8 {
     return out;
 }
 
+/// Default piece size for created torrents (256 KiB).
+pub const default_piece_length: u32 = 256 * 1024;
+
+/// Create a single-file torrent (metainfo) from a file on disk: hash it into
+/// `piece_length` pieces, build the canonical info dict, and return a
+/// fully-owned `Metainfo` (free with `deinit`). No trackers — discovery is via
+/// Nostr / DHT. A `.tar`/`.zip`/`.pdf` is just a single file, so this covers the
+/// "seed an archive" case directly. Streams the file so large inputs don't load
+/// into memory at once.
+pub fn createSingleFile(allocator: Allocator, path: []const u8, piece_length: u32) MetainfoError!Metainfo {
+    var file = std.fs.cwd().openFile(path, .{}) catch return error.InvalidTorrent;
+    defer file.close();
+
+    const base = std.fs.path.basename(path);
+    if (base.len == 0) return error.InvalidTorrent;
+    const name = allocator.dupe(u8, base) catch return error.OutOfMemory;
+    errdefer allocator.free(name);
+
+    var pieces_buf: std.ArrayList(u8) = .empty;
+    errdefer pieces_buf.deinit(allocator);
+    const chunk = allocator.alloc(u8, piece_length) catch return error.OutOfMemory;
+    defer allocator.free(chunk);
+
+    var total: u64 = 0;
+    while (true) {
+        const n = file.readAll(chunk) catch return error.InvalidTorrent;
+        if (n == 0) break;
+        var digest: [20]u8 = undefined;
+        std.crypto.hash.Sha1.hash(chunk[0..n], &digest, .{});
+        pieces_buf.appendSlice(allocator, &digest) catch return error.OutOfMemory;
+        total += n;
+        if (n < piece_length) break; // final (partial) piece
+    }
+    const pieces = pieces_buf.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    errdefer allocator.free(pieces);
+
+    // Canonical info dict — keys MUST be in sorted byte order for a stable
+    // info-hash: "length" < "name" < "piece length" < "pieces".
+    const info_val = bencode.Value{ .dict = &[_]bencode.Value.DictEntry{
+        .{ .key = "length", .value = .{ .integer = @intCast(total) } },
+        .{ .key = "name", .value = .{ .string = name } },
+        .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } },
+        .{ .key = "pieces", .value = .{ .string = pieces } },
+    } };
+    const raw_info = bencode.encode(allocator, info_val) catch return error.OutOfMemory;
+    errdefer allocator.free(raw_info);
+
+    const path_comp = allocator.alloc([]const u8, 1) catch return error.OutOfMemory;
+    errdefer allocator.free(path_comp);
+    path_comp[0] = allocator.dupe(u8, name) catch return error.OutOfMemory;
+    errdefer allocator.free(path_comp[0]);
+    const files = allocator.alloc(FileInfo, 1) catch return error.OutOfMemory;
+    errdefer allocator.free(files);
+    files[0] = .{ .length = total, .path = path_comp };
+
+    const announce = allocator.dupe(u8, "") catch return error.OutOfMemory;
+    errdefer allocator.free(announce);
+
+    return Metainfo{
+        .announce = announce,
+        .announce_list = null,
+        .name = name,
+        .piece_length = piece_length,
+        .pieces = pieces,
+        .files = files,
+        .comment = null,
+        .creation_date = null,
+        .created_by = null,
+        .raw_info = raw_info,
+        .url_list = null,
+    };
+}
+
 // --- Tests ---
+
+test "createSingleFile: hashes a file into a valid metainfo" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // 10 bytes with piece_length 4 → 3 pieces (4 + 4 + 2).
+    try tmp.dir.writeFile(.{ .sub_path = "data.bin", .data = "0123456789" });
+    const path = try tmp.dir.realpathAlloc(allocator, "data.bin");
+    defer allocator.free(path);
+
+    const mi = try createSingleFile(allocator, path, 4);
+    defer mi.deinit(allocator);
+
+    try std.testing.expectEqualStrings("data.bin", mi.name);
+    try std.testing.expectEqual(@as(u64, 10), mi.files[0].length);
+    try std.testing.expectEqual(@as(usize, 60), mi.pieces.len); // 3 × 20
+    try std.testing.expectEqual(@as(u64, 4), mi.piece_length);
+
+    // raw_info must re-decode to a dict carrying the expected fields, and the
+    // info-hash is the SHA-1 of those bytes (deterministic).
+    const decoded = try bencode.decode(allocator, mi.raw_info);
+    defer decoded.deinit(allocator);
+    try std.testing.expectEqual(@as(i64, 10), decoded.dictGet("length").?.asInt().?);
+    try std.testing.expectEqualStrings("data.bin", decoded.dictGet("name").?.asString().?);
+    const ih = infoHash(mi.raw_info);
+    try std.testing.expectEqual(@as(usize, 20), ih.len);
+}
 
 test "parse single-file torrent" {
     const allocator = std.testing.allocator;

--- a/src/nostr_config.zig
+++ b/src/nostr_config.zig
@@ -154,6 +154,27 @@ pub fn freeRelays(allocator: Allocator, relays: [][]const u8) void {
     allocator.free(relays);
 }
 
+/// Overwrite `<config>/relays` with `relays` (one per line). Blank entries are
+/// skipped. Used by the daemon's settings endpoint so edits from the GUI
+/// persist and are visible to search, peer-announce, and the CLI.
+pub fn writeRelays(allocator: Allocator, relays: []const []const u8) !void {
+    const dir = try ensureConfigDir(allocator);
+    defer allocator.free(dir);
+
+    const path = try std.fmt.allocPrint(allocator, "{s}/relays", .{dir});
+    defer allocator.free(path);
+
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+
+    for (relays) |r| {
+        const t = std.mem.trim(u8, r, " \t\r\n");
+        if (t.len == 0) continue;
+        try file.writeAll(t);
+        try file.writeAll("\n");
+    }
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================

--- a/src/session.zig
+++ b/src/session.zig
@@ -74,6 +74,12 @@ pub const Session = struct {
     // init struct literal need not set it.
     snapshot_mutex: std.Thread.Mutex = .{},
 
+    // The resolved `.torrent` bytes, built once metadata completes (magnet path)
+    // so the daemon can persist it and resume the torrent fully — verifying
+    // on-disk pieces — instead of re-bootstrapping a magnet. Guarded by
+    // `snapshot_mutex`; freed in deinit. Defaulted so init need not set it.
+    torrent_blob: ?[]u8 = null,
+
     // Choking state
     last_unchoke_time: i64,
     last_optimistic_time: i64,
@@ -238,6 +244,7 @@ pub const Session = struct {
         if (self.dht_instance) |*d| d.deinit();
         if (self.metadata_download) |*md| md.deinit();
         if (self.listener) |*l| l.deinit();
+        if (self.torrent_blob) |b| self.allocator.free(b);
         self.our_bitfield.deinit(self.allocator);
         self.store.deinit();
         // The magnet path replaces `meta` with a session-owned copy; free it.
@@ -259,6 +266,15 @@ pub const Session = struct {
         mode: Mode,
         metadata_only: bool,
     };
+
+    /// A copy of the resolved `.torrent` bytes, or null if metadata isn't in
+    /// yet (or this was never a magnet). Caller owns the result.
+    pub fn copyTorrent(self: *Session, a: Allocator) ?[]u8 {
+        self.snapshot_mutex.lock();
+        defer self.snapshot_mutex.unlock();
+        const blob = self.torrent_blob orelse return null;
+        return a.dupe(u8, blob) catch null;
+    }
 
     pub fn progressSnapshot(self: *Session) Progress {
         self.snapshot_mutex.lock();
@@ -894,6 +910,15 @@ pub const Session = struct {
         self.metadata_only = false;
         if (self.metadata_download) |*md| md.deinit();
         self.metadata_download = null;
+
+        // Capture the now-resolved .torrent so the daemon can persist it and
+        // resume this torrent fully on restart. Built here where `meta` is
+        // settled; published under snapshot_mutex for the reader thread.
+        if (buildTorrentBytes(self.allocator, self.meta)) |blob| {
+            self.snapshot_mutex.lock();
+            self.torrent_blob = blob;
+            self.snapshot_mutex.unlock();
+        } else |_| {}
 
         // Re-parse any bitfields that arrived before we knew the piece count, so
         // peers connected during the metadata phase are usable for downloading
@@ -1627,3 +1652,16 @@ pub const Session = struct {
         }
     }
 };
+
+/// Re-encode a resolved Metainfo into full `.torrent` bytes: a top-level dict
+/// `{ "announce", "info" }`. The info dict is decoded from `raw_info` and
+/// re-encoded canonically, so the info-hash is preserved. Caller owns the result.
+fn buildTorrentBytes(a: Allocator, meta: metainfo.Metainfo) ![]u8 {
+    const info_val = try bencode.decode(a, meta.raw_info);
+    defer info_val.deinit(a);
+    const entries = [_]bencode.Value.DictEntry{
+        .{ .key = "announce", .value = .{ .string = meta.announce } },
+        .{ .key = "info", .value = info_val },
+    };
+    return bencode.encode(a, .{ .dict = &entries });
+}

--- a/src/session.zig
+++ b/src/session.zig
@@ -80,6 +80,14 @@ pub const Session = struct {
     // `snapshot_mutex`; freed in deinit. Defaulted so init need not set it.
     torrent_blob: ?[]u8 = null,
 
+    // Cross-thread progress snapshot. The daemon reads live progress from
+    // another thread; rather than have it touch `our_bitfield`/`peers` (which
+    // the session thread mutates), the session keeps these atomics exact —
+    // restated after every change — and the daemon reads only these. Defaulted
+    // so init need not set them; `init` seeds `have_pieces` from resume.
+    have_pieces: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+    peer_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
     // Choking state
     last_unchoke_time: i64,
     last_optimistic_time: i64,
@@ -136,6 +144,13 @@ pub const Session = struct {
         const total_length = piece_mod.totalLength(meta.files);
         const num_pieces = piece_mod.numPieces(total_length, meta.piece_length);
         const info_hash = metainfo.infoHash(meta.raw_info);
+
+        // Own our copy of output_dir: callers pass arena/manager-owned buffers
+        // (e.g. the seed-upload arena, or cfg.download_dir which setDownloadDir
+        // frees) that don't outlive this session, and we reuse it later when a
+        // magnet resolves (storage re-init). Freed in deinit.
+        const output_dir_owned = try allocator.dupe(u8, output_dir);
+        errdefer allocator.free(output_dir_owned);
 
         var peer_id: [20]u8 = undefined;
         @memcpy(peer_id[0..8], "-CA0010-");
@@ -199,7 +214,8 @@ pub const Session = struct {
             .piece_availability = piece_availability,
             .listener = listener,
             .listen_port = listen_port,
-            .output_dir = output_dir,
+            .output_dir = output_dir_owned,
+            .have_pieces = std.atomic.Value(usize).init(our_bitfield.count()),
             .mode = mode,
             .tracker_interval = 1800,
             .last_announce_time = 0,
@@ -245,6 +261,7 @@ pub const Session = struct {
         if (self.metadata_download) |*md| md.deinit();
         if (self.listener) |*l| l.deinit();
         if (self.torrent_blob) |b| self.allocator.free(b);
+        self.allocator.free(self.output_dir);
         self.our_bitfield.deinit(self.allocator);
         self.store.deinit();
         // The magnet path replaces `meta` with a session-owned copy; free it.
@@ -279,13 +296,17 @@ pub const Session = struct {
     pub fn progressSnapshot(self: *Session) Progress {
         self.snapshot_mutex.lock();
         defer self.snapshot_mutex.unlock();
+        // `have`/`peers` come from atomics the session thread keeps exact, so we
+        // never touch `our_bitfield`/`peers` (mutated lockless on that thread).
+        // `num_pieces`/`total_length` are still read under the mutex because the
+        // metadata-complete transition reassigns them.
         return .{
-            .have = self.our_bitfield.count(),
+            .have = @intCast(self.have_pieces.load(.monotonic)),
             .num_pieces = self.num_pieces,
             .downloaded = self.downloaded,
             .uploaded = self.uploaded,
             .total_length = self.total_length,
-            .peers = @intCast(self.peers.items.len),
+            .peers = @intCast(self.peer_count.load(.monotonic)),
             .mode = self.mode,
             .metadata_only = self.metadata_only,
         };
@@ -599,6 +620,7 @@ pub const Session = struct {
                 };
                 self.our_bitfield.setPiece(pd.index);
                 self.downloaded += pp_ptr.piece_len;
+                self.have_pieces.store(self.our_bitfield.count(), .monotonic);
 
                 self.printProgress() catch {};
 
@@ -895,6 +917,8 @@ pub const Session = struct {
 
             self.our_bitfield.deinit(self.allocator);
             self.our_bitfield = piece_mod.Bitfield.init(self.allocator, self.num_pieces) catch return error.OutOfMemory;
+            // Fresh bitfield for a just-resolved magnet: we have nothing yet.
+            self.have_pieces.store(0, .monotonic);
 
             self.allocator.free(self.piece_availability);
             self.piece_availability = self.allocator.alloc(u32, self.num_pieces) catch return error.OutOfMemory;
@@ -1195,6 +1219,12 @@ pub const Session = struct {
 
     fn maintenance(self: *Session) !void {
         const now = std.time.timestamp();
+
+        // Publish the live peer count for the daemon's cross-thread snapshot.
+        // Refreshed each tick here (and just below after pruning) so the daemon
+        // never reads `self.peers` directly. One tick of staleness is invisible
+        // to the 1 Hz snapshot.
+        self.peer_count.store(self.peers.items.len, .monotonic);
 
         // Remove disconnected peers and update availability
         var i: usize = 0;
@@ -1587,6 +1617,7 @@ pub const Session = struct {
         self.store.writePiece(piece_idx, data) catch return false;
         self.our_bitfield.setPiece(piece_idx);
         self.downloaded += plen;
+        self.have_pieces.store(self.our_bitfield.count(), .monotonic);
 
         self.printProgress() catch {};
 

--- a/src/session.zig
+++ b/src/session.zig
@@ -68,6 +68,12 @@ pub const Session = struct {
     // Control
     running: bool,
 
+    // Guards the fields read by `progressSnapshot` against the metadata-complete
+    // transition (which reallocates `our_bitfield`). Lets the daemon read live
+    // progress from another thread without a use-after-free. Defaulted so the
+    // init struct literal need not set it.
+    snapshot_mutex: std.Thread.Mutex = .{},
+
     // Choking state
     last_unchoke_time: i64,
     last_optimistic_time: i64,
@@ -237,6 +243,36 @@ pub const Session = struct {
         // The magnet path replaces `meta` with a session-owned copy; free it.
         // The original caller-owned `meta` is freed by the caller.
         if (self.meta_owned) self.meta.deinit(self.allocator);
+    }
+
+    /// A consistent, race-safe view of the session's live progress, for other
+    /// threads (the daemon). Reads are taken under `snapshot_mutex` so the
+    /// magnet metadata-complete transition (which reallocates `our_bitfield`)
+    /// can't be observed half-applied.
+    pub const Progress = struct {
+        have: u32,
+        num_pieces: u32,
+        downloaded: u64,
+        uploaded: u64,
+        total_length: u64,
+        peers: u32,
+        mode: Mode,
+        metadata_only: bool,
+    };
+
+    pub fn progressSnapshot(self: *Session) Progress {
+        self.snapshot_mutex.lock();
+        defer self.snapshot_mutex.unlock();
+        return .{
+            .have = self.our_bitfield.count(),
+            .num_pieces = self.num_pieces,
+            .downloaded = self.downloaded,
+            .uploaded = self.uploaded,
+            .total_length = self.total_length,
+            .peers = @intCast(self.peers.items.len),
+            .mode = self.mode,
+            .metadata_only = self.metadata_only,
+        };
     }
 
     pub fn run(self: *Session) !void {
@@ -830,17 +866,24 @@ pub const Session = struct {
         };
         self.meta_owned = true;
 
-        // Now initialize storage and piece tracking
-        self.total_length = piece_mod.totalLength(self.meta.files);
-        self.num_pieces = piece_mod.numPieces(self.total_length, piece_length);
-        self.piece_len = piece_length;
+        // Now initialize storage and piece tracking. Hold snapshot_mutex across
+        // the geometry + bitfield swap so a concurrent `progressSnapshot` never
+        // reads a freed `our_bitfield` (the daemon reads it from another thread).
+        {
+            self.snapshot_mutex.lock();
+            defer self.snapshot_mutex.unlock();
 
-        self.our_bitfield.deinit(self.allocator);
-        self.our_bitfield = piece_mod.Bitfield.init(self.allocator, self.num_pieces) catch return error.OutOfMemory;
+            self.total_length = piece_mod.totalLength(self.meta.files);
+            self.num_pieces = piece_mod.numPieces(self.total_length, piece_length);
+            self.piece_len = piece_length;
 
-        self.allocator.free(self.piece_availability);
-        self.piece_availability = self.allocator.alloc(u32, self.num_pieces) catch return error.OutOfMemory;
-        @memset(self.piece_availability, 0);
+            self.our_bitfield.deinit(self.allocator);
+            self.our_bitfield = piece_mod.Bitfield.init(self.allocator, self.num_pieces) catch return error.OutOfMemory;
+
+            self.allocator.free(self.piece_availability);
+            self.piece_availability = self.allocator.alloc(u32, self.num_pieces) catch return error.OutOfMemory;
+            @memset(self.piece_availability, 0);
+        }
 
         // Reinitialize storage with the real metadata
         self.store.deinit();

--- a/src/state.zig
+++ b/src/state.zig
@@ -1,0 +1,217 @@
+//! Daemon state persistence: the set of transfers/seeds and the editable
+//! settings, written to `<config>/daemon-state.json` so a daemon restart
+//! resumes exactly where it left off (nothing is lost).
+//!
+//! Transfers are persisted as *specs* — the minimal recipe to re-create them
+//! (source + route + nostr) — not live session state. On restart the manager
+//! replays each spec: downloads resume from on-disk pieces (the session
+//! re-verifies them) and seeds re-hash their file. Relays already persist via
+//! `nostr_config`, so they're not duplicated here.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const api = @import("api.zig");
+const nostr_config = @import("nostr_config.zig");
+
+const log = std.log.scoped(.state);
+
+pub const Kind = enum {
+    download,
+    seed,
+
+    fn jsonName(self: Kind) []const u8 {
+        return @tagName(self);
+    }
+
+    fn parse(s: []const u8) ?Kind {
+        return std.meta.stringToEnum(Kind, s);
+    }
+};
+
+/// The recipe to re-create one transfer on restart.
+pub const TransferSpec = struct {
+    kind: Kind,
+    /// magnet / http URL / .torrent path (download) or file path (seed).
+    source: []const u8,
+    route: api.Route,
+    nostr: bool,
+};
+
+pub const State = struct {
+    route: api.Route,
+    download_dir: []const u8,
+    transfers: []const TransferSpec,
+
+    /// Free everything owned by a `State` returned from `load` / `decode`.
+    pub fn deinit(self: State, a: Allocator) void {
+        a.free(self.download_dir);
+        for (self.transfers) |t| a.free(t.source);
+        a.free(self.transfers);
+    }
+};
+
+/// `<config>/daemon-state.json`. Caller owns the returned path.
+pub fn statePath(a: Allocator) ![]u8 {
+    const dir = try nostr_config.configDir(a);
+    defer a.free(dir);
+    return std.fmt.allocPrint(a, "{s}/daemon-state.json", .{dir});
+}
+
+/// Serialize state to JSON bytes. Caller owns the result.
+pub fn encode(
+    a: Allocator,
+    route: api.Route,
+    download_dir: []const u8,
+    specs: []const TransferSpec,
+) Allocator.Error![]u8 {
+    var j = api.Json.init(a);
+    errdefer j.deinit();
+    try j.beginObject();
+    try j.keyString("route", route.jsonName());
+    try j.keyString("downloadDir", download_dir);
+    try j.key("transfers");
+    try j.beginArray();
+    for (specs) |s| {
+        try j.beginObject();
+        try j.keyString("kind", s.kind.jsonName());
+        try j.keyString("source", s.source);
+        try j.keyString("route", s.route.jsonName());
+        try j.keyBool("nostr", s.nostr);
+        try j.endObject();
+    }
+    try j.endArray();
+    try j.endObject();
+    return j.toOwnedSlice();
+}
+
+pub const DecodeError = error{ InvalidJson, OutOfMemory };
+
+/// Parse JSON bytes into an owned `State`. Caller frees via `State.deinit`.
+pub fn decode(a: Allocator, bytes: []const u8) DecodeError!State {
+    const parsed = std.json.parseFromSlice(std.json.Value, a, bytes, .{}) catch return error.InvalidJson;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidJson;
+    const root = parsed.value.object;
+
+    const route = api.Route.parse(strField(root, "route") orelse "direct") orelse .direct;
+    const download_dir = try a.dupe(u8, strField(root, "downloadDir") orelse "");
+    errdefer a.free(download_dir);
+
+    var list: std.ArrayList(TransferSpec) = .empty;
+    errdefer {
+        for (list.items) |t| a.free(t.source);
+        list.deinit(a);
+    }
+    if (root.get("transfers")) |tv| {
+        if (tv == .array) {
+            for (tv.array.items) |item| {
+                if (item != .object) continue;
+                const o = item.object;
+                const kind = Kind.parse(strField(o, "kind") orelse "download") orelse .download;
+                const src_raw = strField(o, "source") orelse continue;
+                const src = try a.dupe(u8, src_raw);
+                errdefer a.free(src);
+                const r = api.Route.parse(strField(o, "route") orelse "direct") orelse .direct;
+                const nostr = if (o.get("nostr")) |nv| (nv == .bool and nv.bool) else false;
+                try list.append(a, .{ .kind = kind, .source = src, .route = r, .nostr = nostr });
+            }
+        }
+    }
+    return .{
+        .route = route,
+        .download_dir = download_dir,
+        .transfers = try list.toOwnedSlice(a),
+    };
+}
+
+/// Write the state file (atomically: write a temp file, then rename). Best
+/// effort — a failure is logged by the caller, never fatal.
+pub fn save(
+    a: Allocator,
+    route: api.Route,
+    download_dir: []const u8,
+    specs: []const TransferSpec,
+) !void {
+    const dir = try nostr_config.ensureConfigDir(a);
+    defer a.free(dir);
+    const path = try std.fmt.allocPrint(a, "{s}/daemon-state.json", .{dir});
+    defer a.free(path);
+    const tmp = try std.fmt.allocPrint(a, "{s}.tmp", .{path});
+    defer a.free(tmp);
+
+    const bytes = try encode(a, route, download_dir, specs);
+    defer a.free(bytes);
+
+    {
+        var file = try std.fs.cwd().createFile(tmp, .{ .truncate = true });
+        defer file.close();
+        try file.writeAll(bytes);
+    }
+    try std.fs.cwd().rename(tmp, path);
+}
+
+/// Load the state file, or null if it doesn't exist yet. Caller frees the
+/// returned `State` via `deinit`.
+pub fn load(a: Allocator) !?State {
+    const path = try statePath(a);
+    defer a.free(path);
+    const data = std.fs.cwd().readFileAlloc(a, path, 8 * 1024 * 1024) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer a.free(data);
+    return try decode(a, data);
+}
+
+fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const v = obj.get(name) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "encode/decode round-trips transfers + settings" {
+    const a = testing.allocator;
+    const specs = [_]TransferSpec{
+        .{ .kind = .download, .source = "magnet:?xt=urn:btih:abc", .route = .tor, .nostr = true },
+        .{ .kind = .seed, .source = "/data/movie.tar", .route = .direct, .nostr = false },
+    };
+    const bytes = try encode(a, .proxy, "/home/u/dl", &specs);
+    defer a.free(bytes);
+
+    const st = try decode(a, bytes);
+    defer st.deinit(a);
+
+    try testing.expectEqual(api.Route.proxy, st.route);
+    try testing.expectEqualStrings("/home/u/dl", st.download_dir);
+    try testing.expectEqual(@as(usize, 2), st.transfers.len);
+    try testing.expectEqual(Kind.download, st.transfers[0].kind);
+    try testing.expectEqualStrings("magnet:?xt=urn:btih:abc", st.transfers[0].source);
+    try testing.expectEqual(api.Route.tor, st.transfers[0].route);
+    try testing.expect(st.transfers[0].nostr);
+    try testing.expectEqual(Kind.seed, st.transfers[1].kind);
+    try testing.expectEqualStrings("/data/movie.tar", st.transfers[1].source);
+    try testing.expect(!st.transfers[1].nostr);
+}
+
+test "decode tolerates empty transfer list and missing fields" {
+    const a = testing.allocator;
+    const st = try decode(a, "{\"route\":\"tor\",\"downloadDir\":\"/x\",\"transfers\":[]}");
+    defer st.deinit(a);
+    try testing.expectEqual(api.Route.tor, st.route);
+    try testing.expectEqual(@as(usize, 0), st.transfers.len);
+
+    const st2 = try decode(a, "{}");
+    defer st2.deinit(a);
+    try testing.expectEqual(api.Route.direct, st2.route);
+    try testing.expectEqualStrings("", st2.download_dir);
+}
+
+test "decode rejects non-object json" {
+    const a = testing.allocator;
+    try testing.expectError(error.InvalidJson, decode(a, "[1,2,3]"));
+}

--- a/src/state.zig
+++ b/src/state.zig
@@ -1,12 +1,15 @@
-//! Daemon state persistence: the set of transfers/seeds and the editable
-//! settings, written to `<config>/daemon-state.json` so a daemon restart
-//! resumes exactly where it left off (nothing is lost).
+//! Daemon state persistence, backed by SQLite (`<config>/carl.db`).
 //!
-//! Transfers are persisted as *specs* — the minimal recipe to re-create them
-//! (source + route + nostr) — not live session state. On restart the manager
-//! replays each spec: downloads resume from on-disk pieces (the session
-//! re-verifies them) and seeds re-hash their file. Relays already persist via
-//! `nostr_config`, so they're not duplicated here.
+//! Stores the editable settings (route, download dir) and the set of
+//! transfers/seeds as re-create *specs* (kind + source + route + nostr) so a
+//! restart resumes exactly where it left off. On metadata completion the
+//! manager rewrites a transfer's source to a generated `.torrent` path (see
+//! manager.zig), so a finished magnet download restores as a full, complete
+//! torrent rather than re-fetching metadata.
+//!
+//! SQLite (not a flat file) gives atomic, crash-safe writes via a transaction
+//! and is the natural store as this grows. Relays/identity persist separately
+//! via `nostr_config`.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -14,6 +17,35 @@ const api = @import("api.zig");
 const nostr_config = @import("nostr_config.zig");
 
 const log = std.log.scoped(.state);
+
+// ---- minimal libsqlite3 bindings (linked via build.zig) -------------------
+const Sqlite = opaque {};
+const Stmt = opaque {};
+extern fn sqlite3_open(filename: [*:0]const u8, ppDb: *?*Sqlite) c_int;
+extern fn sqlite3_close(db: ?*Sqlite) c_int;
+extern fn sqlite3_exec(db: ?*Sqlite, sql: [*:0]const u8, cb: ?*const anyopaque, arg: ?*anyopaque, errmsg: ?*?[*:0]u8) c_int;
+extern fn sqlite3_prepare_v2(db: ?*Sqlite, sql: [*]const u8, n: c_int, stmt: *?*Stmt, tail: ?*?[*]const u8) c_int;
+extern fn sqlite3_step(s: ?*Stmt) c_int;
+extern fn sqlite3_finalize(s: ?*Stmt) c_int;
+extern fn sqlite3_reset(s: ?*Stmt) c_int;
+extern fn sqlite3_bind_text(s: ?*Stmt, i: c_int, t: [*]const u8, n: c_int, d: ?*const anyopaque) c_int;
+extern fn sqlite3_bind_int(s: ?*Stmt, i: c_int, v: c_int) c_int;
+extern fn sqlite3_column_text(s: ?*Stmt, i: c_int) ?[*:0]const u8;
+extern fn sqlite3_column_int(s: ?*Stmt, i: c_int) c_int;
+
+const SQLITE_OK: c_int = 0;
+const SQLITE_ROW: c_int = 100;
+// SQLITE_TRANSIENT = (void*)-1 → tells SQLite to copy bound text immediately.
+const SQLITE_TRANSIENT: ?*const anyopaque = @ptrFromInt(@as(usize, std.math.maxInt(usize)));
+
+const SCHEMA =
+    \\CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    \\CREATE TABLE IF NOT EXISTS transfers(
+    \\  id INTEGER PRIMARY KEY AUTOINCREMENT,
+    \\  kind TEXT NOT NULL, source TEXT NOT NULL, route TEXT NOT NULL, nostr INTEGER NOT NULL);
+;
+
+pub const Error = error{ DbOpen, DbExec, DbPrepare } || Allocator.Error;
 
 pub const Kind = enum {
     download,
@@ -28,10 +60,8 @@ pub const Kind = enum {
     }
 };
 
-/// The recipe to re-create one transfer on restart.
 pub const TransferSpec = struct {
     kind: Kind,
-    /// magnet / http URL / .torrent path (download) or file path (seed).
     source: []const u8,
     route: api.Route,
     nostr: bool,
@@ -42,7 +72,6 @@ pub const State = struct {
     download_dir: []const u8,
     transfers: []const TransferSpec,
 
-    /// Free everything owned by a `State` returned from `load` / `decode`.
     pub fn deinit(self: State, a: Allocator) void {
         a.free(self.download_dir);
         for (self.transfers) |t| a.free(t.source);
@@ -50,82 +79,32 @@ pub const State = struct {
     }
 };
 
-/// `<config>/daemon-state.json`. Caller owns the returned path.
-pub fn statePath(a: Allocator) ![]u8 {
+/// `<config>/carl.db`. Caller owns the returned path.
+pub fn dbPath(a: Allocator) ![]u8 {
     const dir = try nostr_config.configDir(a);
     defer a.free(dir);
-    return std.fmt.allocPrint(a, "{s}/daemon-state.json", .{dir});
+    return std.fmt.allocPrint(a, "{s}/carl.db", .{dir});
 }
 
-/// Serialize state to JSON bytes. Caller owns the result.
-pub fn encode(
-    a: Allocator,
-    route: api.Route,
-    download_dir: []const u8,
-    specs: []const TransferSpec,
-) Allocator.Error![]u8 {
-    var j = api.Json.init(a);
-    errdefer j.deinit();
-    try j.beginObject();
-    try j.keyString("route", route.jsonName());
-    try j.keyString("downloadDir", download_dir);
-    try j.key("transfers");
-    try j.beginArray();
-    for (specs) |s| {
-        try j.beginObject();
-        try j.keyString("kind", s.kind.jsonName());
-        try j.keyString("source", s.source);
-        try j.keyString("route", s.route.jsonName());
-        try j.keyBool("nostr", s.nostr);
-        try j.endObject();
+fn open(path: [:0]const u8) Error!*Sqlite {
+    var db: ?*Sqlite = null;
+    if (sqlite3_open(path, &db) != SQLITE_OK or db == null) {
+        if (db) |d| _ = sqlite3_close(d);
+        return error.DbOpen;
     }
-    try j.endArray();
-    try j.endObject();
-    return j.toOwnedSlice();
+    if (sqlite3_exec(db, SCHEMA, null, null, null) != SQLITE_OK) {
+        _ = sqlite3_close(db);
+        return error.DbExec;
+    }
+    return db.?;
 }
 
-pub const DecodeError = error{ InvalidJson, OutOfMemory };
-
-/// Parse JSON bytes into an owned `State`. Caller frees via `State.deinit`.
-pub fn decode(a: Allocator, bytes: []const u8) DecodeError!State {
-    const parsed = std.json.parseFromSlice(std.json.Value, a, bytes, .{}) catch return error.InvalidJson;
-    defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidJson;
-    const root = parsed.value.object;
-
-    const route = api.Route.parse(strField(root, "route") orelse "direct") orelse .direct;
-    const download_dir = try a.dupe(u8, strField(root, "downloadDir") orelse "");
-    errdefer a.free(download_dir);
-
-    var list: std.ArrayList(TransferSpec) = .empty;
-    errdefer {
-        for (list.items) |t| a.free(t.source);
-        list.deinit(a);
-    }
-    if (root.get("transfers")) |tv| {
-        if (tv == .array) {
-            for (tv.array.items) |item| {
-                if (item != .object) continue;
-                const o = item.object;
-                const kind = Kind.parse(strField(o, "kind") orelse "download") orelse .download;
-                const src_raw = strField(o, "source") orelse continue;
-                const src = try a.dupe(u8, src_raw);
-                errdefer a.free(src);
-                const r = api.Route.parse(strField(o, "route") orelse "direct") orelse .direct;
-                const nostr = if (o.get("nostr")) |nv| (nv == .bool and nv.bool) else false;
-                try list.append(a, .{ .kind = kind, .source = src, .route = r, .nostr = nostr });
-            }
-        }
-    }
-    return .{
-        .route = route,
-        .download_dir = download_dir,
-        .transfers = try list.toOwnedSlice(a),
-    };
+fn exec(db: *Sqlite, sql: [:0]const u8) Error!void {
+    if (sqlite3_exec(db, sql, null, null, null) != SQLITE_OK) return error.DbExec;
 }
 
-/// Write the state file (atomically: write a temp file, then rename). Best
-/// effort — a failure is logged by the caller, never fatal.
+/// Write settings + transfers atomically (a single transaction; the table is
+/// rebuilt from `specs`). Persists to `<config>/carl.db`.
 pub fn save(
     a: Allocator,
     route: api.Route,
@@ -134,38 +113,115 @@ pub fn save(
 ) !void {
     const dir = try nostr_config.ensureConfigDir(a);
     defer a.free(dir);
-    const path = try std.fmt.allocPrint(a, "{s}/daemon-state.json", .{dir});
+    const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
     defer a.free(path);
-    const tmp = try std.fmt.allocPrint(a, "{s}.tmp", .{path});
-    defer a.free(tmp);
+    try saveTo(path, route, download_dir, specs);
+}
 
-    const bytes = try encode(a, route, download_dir, specs);
-    defer a.free(bytes);
+fn saveTo(
+    path: [:0]const u8,
+    route: api.Route,
+    download_dir: []const u8,
+    specs: []const TransferSpec,
+) Error!void {
+    const db = try open(path);
+    defer _ = sqlite3_close(db);
 
-    {
-        var file = try std.fs.cwd().createFile(tmp, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(bytes);
+    try exec(db, "BEGIN IMMEDIATE");
+    errdefer exec(db, "ROLLBACK") catch {};
+
+    try upsertSetting(db, "route", route.jsonName());
+    try upsertSetting(db, "downloadDir", download_dir);
+    try exec(db, "DELETE FROM transfers");
+
+    var stmt: ?*Stmt = null;
+    const sql = "INSERT INTO transfers(kind,source,route,nostr) VALUES(?,?,?,?)";
+    if (sqlite3_prepare_v2(db, sql, @intCast(sql.len), &stmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(stmt);
+    for (specs) |s| {
+        _ = sqlite3_reset(stmt);
+        bindText(stmt, 1, s.kind.jsonName());
+        bindText(stmt, 2, s.source);
+        bindText(stmt, 3, s.route.jsonName());
+        _ = sqlite3_bind_int(stmt, 4, if (s.nostr) 1 else 0);
+        _ = sqlite3_step(stmt);
     }
-    try std.fs.cwd().rename(tmp, path);
+
+    try exec(db, "COMMIT");
 }
 
-/// Load the state file, or null if it doesn't exist yet. Caller frees the
-/// returned `State` via `deinit`.
+/// Load persisted state, or null if no database exists yet. Caller frees via
+/// `State.deinit`.
 pub fn load(a: Allocator) !?State {
-    const path = try statePath(a);
+    const path = try dbPath(a);
     defer a.free(path);
-    const data = std.fs.cwd().readFileAlloc(a, path, 8 * 1024 * 1024) catch |err| switch (err) {
-        error.FileNotFound => return null,
-        else => return err,
-    };
-    defer a.free(data);
-    return try decode(a, data);
+    std.fs.cwd().access(path, .{}) catch return null; // no DB yet
+    const path_z = try a.dupeZ(u8, path);
+    defer a.free(path_z);
+    return try loadFrom(a, path_z);
 }
 
-fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
-    const v = obj.get(name) orelse return null;
-    return if (v == .string) v.string else null;
+fn loadFrom(a: Allocator, path: [:0]const u8) Error!State {
+    const db = try open(path);
+    defer _ = sqlite3_close(db);
+
+    const route_str = try getSetting(a, db, "route");
+    defer if (route_str) |s| a.free(s);
+    const route = api.Route.parse(route_str orelse "direct") orelse .direct;
+    const download_dir = try getSetting(a, db, "downloadDir") orelse try a.dupe(u8, "");
+    errdefer a.free(download_dir);
+
+    var list: std.ArrayList(TransferSpec) = .empty;
+    errdefer {
+        for (list.items) |t| a.free(t.source);
+        list.deinit(a);
+    }
+
+    var stmt: ?*Stmt = null;
+    const sql = "SELECT kind,source,route,nostr FROM transfers ORDER BY id";
+    if (sqlite3_prepare_v2(db, sql, @intCast(sql.len), &stmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(stmt);
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        const kind = Kind.parse(columnText(stmt, 0)) orelse .download;
+        const src = try a.dupe(u8, columnText(stmt, 1));
+        errdefer a.free(src);
+        const r = api.Route.parse(columnText(stmt, 2)) orelse .direct;
+        const nostr = sqlite3_column_int(stmt, 3) != 0;
+        try list.append(a, .{ .kind = kind, .source = src, .route = r, .nostr = nostr });
+    }
+
+    return .{ .route = route, .download_dir = download_dir, .transfers = try list.toOwnedSlice(a) };
+}
+
+fn upsertSetting(db: *Sqlite, key: []const u8, value: []const u8) Error!void {
+    var stmt: ?*Stmt = null;
+    const sql = "INSERT INTO settings(key,value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value";
+    if (sqlite3_prepare_v2(db, sql, @intCast(sql.len), &stmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(stmt);
+    bindText(stmt, 1, key);
+    bindText(stmt, 2, value);
+    _ = sqlite3_step(stmt);
+}
+
+fn getSetting(a: Allocator, db: *Sqlite, key: []const u8) Error!?[]u8 {
+    var stmt: ?*Stmt = null;
+    const sql = "SELECT value FROM settings WHERE key=?";
+    if (sqlite3_prepare_v2(db, sql, @intCast(sql.len), &stmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(stmt);
+    bindText(stmt, 1, key);
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        return try a.dupe(u8, columnText(stmt, 0));
+    }
+    return null;
+}
+
+fn bindText(stmt: ?*Stmt, idx: c_int, text: []const u8) void {
+    _ = sqlite3_bind_text(stmt, idx, text.ptr, @intCast(text.len), SQLITE_TRANSIENT);
+}
+
+fn columnText(stmt: ?*Stmt, idx: c_int) []const u8 {
+    const ptr = sqlite3_column_text(stmt, idx) orelse return "";
+    return std.mem.span(ptr);
 }
 
 // ===========================================================================
@@ -174,18 +230,23 @@ fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
 
 const testing = std.testing;
 
-test "encode/decode round-trips transfers + settings" {
+test "sqlite save/load round-trips settings + transfers" {
     const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+    const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
+    defer a.free(path);
+
     const specs = [_]TransferSpec{
         .{ .kind = .download, .source = "magnet:?xt=urn:btih:abc", .route = .tor, .nostr = true },
         .{ .kind = .seed, .source = "/data/movie.tar", .route = .direct, .nostr = false },
     };
-    const bytes = try encode(a, .proxy, "/home/u/dl", &specs);
-    defer a.free(bytes);
+    try saveTo(path, .proxy, "/home/u/dl", &specs);
 
-    const st = try decode(a, bytes);
+    const st = try loadFrom(a, path);
     defer st.deinit(a);
-
     try testing.expectEqual(api.Route.proxy, st.route);
     try testing.expectEqualStrings("/home/u/dl", st.download_dir);
     try testing.expectEqual(@as(usize, 2), st.transfers.len);
@@ -194,24 +255,25 @@ test "encode/decode round-trips transfers + settings" {
     try testing.expectEqual(api.Route.tor, st.transfers[0].route);
     try testing.expect(st.transfers[0].nostr);
     try testing.expectEqual(Kind.seed, st.transfers[1].kind);
-    try testing.expectEqualStrings("/data/movie.tar", st.transfers[1].source);
     try testing.expect(!st.transfers[1].nostr);
 }
 
-test "decode tolerates empty transfer list and missing fields" {
+test "sqlite save replaces prior transfers (no accumulation)" {
     const a = testing.allocator;
-    const st = try decode(a, "{\"route\":\"tor\",\"downloadDir\":\"/x\",\"transfers\":[]}");
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+    const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
+    defer a.free(path);
+
+    const one = [_]TransferSpec{.{ .kind = .download, .source = "a", .route = .direct, .nostr = false }};
+    try saveTo(path, .direct, "/x", &one);
+    try saveTo(path, .tor, "/y", &one); // overwrite
+
+    const st = try loadFrom(a, path);
     defer st.deinit(a);
+    try testing.expectEqual(@as(usize, 1), st.transfers.len);
     try testing.expectEqual(api.Route.tor, st.route);
-    try testing.expectEqual(@as(usize, 0), st.transfers.len);
-
-    const st2 = try decode(a, "{}");
-    defer st2.deinit(a);
-    try testing.expectEqual(api.Route.direct, st2.route);
-    try testing.expectEqualStrings("", st2.download_dir);
-}
-
-test "decode rejects non-object json" {
-    const a = testing.allocator;
-    try testing.expectError(error.InvalidJson, decode(a, "[1,2,3]"));
+    try testing.expectEqualStrings("/y", st.download_dir);
 }

--- a/src/state.zig
+++ b/src/state.zig
@@ -35,6 +35,7 @@ extern fn sqlite3_column_int(s: ?*Stmt, i: c_int) c_int;
 
 const SQLITE_OK: c_int = 0;
 const SQLITE_ROW: c_int = 100;
+const SQLITE_DONE: c_int = 101;
 // SQLITE_TRANSIENT = (void*)-1 → tells SQLite to copy bound text immediately.
 const SQLITE_TRANSIENT: ?*const anyopaque = @ptrFromInt(@as(usize, std.math.maxInt(usize)));
 
@@ -144,7 +145,7 @@ fn saveTo(
         bindText(stmt, 2, s.source);
         bindText(stmt, 3, s.route.jsonName());
         _ = sqlite3_bind_int(stmt, 4, if (s.nostr) 1 else 0);
-        _ = sqlite3_step(stmt);
+        if (sqlite3_step(stmt) != SQLITE_DONE) return error.DbExec;
     }
 
     try exec(db, "COMMIT");
@@ -200,7 +201,7 @@ fn upsertSetting(db: *Sqlite, key: []const u8, value: []const u8) Error!void {
     defer _ = sqlite3_finalize(stmt);
     bindText(stmt, 1, key);
     bindText(stmt, 2, value);
-    _ = sqlite3_step(stmt);
+    if (sqlite3_step(stmt) != SQLITE_DONE) return error.DbExec;
 }
 
 fn getSetting(a: Allocator, db: *Sqlite, key: []const u8) Error!?[]u8 {

--- a/src/ws_server.zig
+++ b/src/ws_server.zig
@@ -1,0 +1,301 @@
+//! Server-side WebSocket (RFC 6455) for the daemon.
+//!
+//! `ws.zig` is a client (it masks outbound frames and rejects masked inbound
+//! frames), so the daemon needs the mirror image: compute the server handshake
+//! accept key, decode masked client frames, and emit unmasked server frames.
+//! Only the subset the GUI channel needs is implemented — text/close/ping/pong,
+//! single (unfragmented) frames up to a bounded size.
+//!
+//! The pure helpers (`acceptKey`, `encodeFrame`, `decodeFrame`) are unit-tested
+//! against the RFC 6455 examples; the stream helpers wrap them with blocking
+//! `posix.recv`/`posix.send` on `stream.handle`, matching `ws.zig`.
+
+const std = @import("std");
+const posix = std.posix;
+const Allocator = std.mem.Allocator;
+
+/// Per RFC 6455 §1.3 — appended to the client key before hashing.
+const ws_guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/// Reject payloads larger than this when reading client frames. The GUI only
+/// sends tiny control messages, so anything large is malformed or hostile.
+pub const max_payload: usize = 1 << 20; // 1 MiB
+
+pub const Opcode = enum(u4) {
+    continuation = 0x0,
+    text = 0x1,
+    binary = 0x2,
+    close = 0x8,
+    ping = 0x9,
+    pong = 0xA,
+    _,
+};
+
+pub const Error = error{
+    Closed,
+    SendFailed,
+    RecvFailed,
+    /// Client frame was not masked (RFC 6455 requires client→server masking).
+    NotMasked,
+    PayloadTooLarge,
+    Incomplete,
+} || Allocator.Error;
+
+/// A decoded WebSocket frame. `payload` is owned by the caller.
+pub const Frame = struct {
+    opcode: Opcode,
+    fin: bool,
+    payload: []u8,
+
+    pub fn deinit(self: Frame, allocator: Allocator) void {
+        allocator.free(self.payload);
+    }
+};
+
+/// Compute the `Sec-WebSocket-Accept` value for a client key:
+/// base64(sha1(key ++ GUID)). The result is always 28 bytes.
+pub fn acceptKey(client_key: []const u8, out: *[28]u8) void {
+    var hasher = std.crypto.hash.Sha1.init(.{});
+    hasher.update(client_key);
+    hasher.update(ws_guid);
+    var digest: [20]u8 = undefined;
+    hasher.final(&digest);
+    _ = std.base64.standard.Encoder.encode(out, &digest);
+}
+
+/// Encode an unmasked server frame for `payload`. Caller owns the result.
+/// Server frames are never masked (RFC 6455 §5.1).
+pub fn encodeFrame(allocator: Allocator, opcode: Opcode, payload: []const u8) Allocator.Error![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+
+    const b0: u8 = 0x80 | @as(u8, @intFromEnum(opcode)); // FIN=1
+    try buf.append(allocator, b0);
+
+    if (payload.len < 126) {
+        try buf.append(allocator, @intCast(payload.len));
+    } else if (payload.len <= 0xFFFF) {
+        try buf.append(allocator, 126);
+        var len_be: [2]u8 = undefined;
+        std.mem.writeInt(u16, &len_be, @intCast(payload.len), .big);
+        try buf.appendSlice(allocator, &len_be);
+    } else {
+        try buf.append(allocator, 127);
+        var len_be: [8]u8 = undefined;
+        std.mem.writeInt(u64, &len_be, payload.len, .big);
+        try buf.appendSlice(allocator, &len_be);
+    }
+
+    try buf.appendSlice(allocator, payload);
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Result of decoding one frame from a buffer: the frame plus how many bytes
+/// were consumed (so a caller streaming bytes can advance).
+pub const Decoded = struct {
+    frame: Frame,
+    consumed: usize,
+};
+
+/// Decode a single (masked) client frame from `data`. Returns `Incomplete` if
+/// `data` does not yet contain the whole frame. The payload is unmasked into a
+/// freshly allocated buffer owned by the caller.
+pub fn decodeFrame(allocator: Allocator, data: []const u8) Error!Decoded {
+    if (data.len < 2) return error.Incomplete;
+    const b0 = data[0];
+    const b1 = data[1];
+    const fin = (b0 & 0x80) != 0;
+    const opcode: Opcode = @enumFromInt(@as(u4, @truncate(b0 & 0x0F)));
+    const masked = (b1 & 0x80) != 0;
+    if (!masked) return error.NotMasked;
+
+    var off: usize = 2;
+    var payload_len: u64 = b1 & 0x7F;
+    if (payload_len == 126) {
+        if (data.len < off + 2) return error.Incomplete;
+        payload_len = std.mem.readInt(u16, data[off..][0..2], .big);
+        off += 2;
+    } else if (payload_len == 127) {
+        if (data.len < off + 8) return error.Incomplete;
+        payload_len = std.mem.readInt(u64, data[off..][0..8], .big);
+        off += 8;
+    }
+    if (payload_len > max_payload) return error.PayloadTooLarge;
+
+    if (data.len < off + 4) return error.Incomplete;
+    const mask = data[off..][0..4].*;
+    off += 4;
+
+    const plen: usize = @intCast(payload_len);
+    if (data.len < off + plen) return error.Incomplete;
+
+    const payload = try allocator.alloc(u8, plen);
+    errdefer allocator.free(payload);
+    for (data[off .. off + plen], 0..) |c, i| {
+        payload[i] = c ^ mask[i % 4];
+    }
+
+    return .{
+        .frame = .{ .opcode = opcode, .fin = fin, .payload = payload },
+        .consumed = off + plen,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Stream helpers (blocking posix I/O on stream.handle, mirroring ws.zig)
+// ---------------------------------------------------------------------------
+
+fn sendAll(stream: std.net.Stream, buf: []const u8) Error!void {
+    var off: usize = 0;
+    while (off < buf.len) {
+        const n = posix.send(stream.handle, buf[off..], 0) catch return error.SendFailed;
+        if (n == 0) return error.Closed;
+        off += n;
+    }
+}
+
+fn recvExact(stream: std.net.Stream, buf: []u8) Error!void {
+    var off: usize = 0;
+    while (off < buf.len) {
+        const n = posix.recv(stream.handle, buf[off..], 0) catch return error.RecvFailed;
+        if (n == 0) return error.Closed;
+        off += n;
+    }
+}
+
+/// Send a text frame over `stream`.
+pub fn sendText(allocator: Allocator, stream: std.net.Stream, payload: []const u8) Error!void {
+    const framed = try encodeFrame(allocator, .text, payload);
+    defer allocator.free(framed);
+    try sendAll(stream, framed);
+}
+
+/// Send a close frame (no status code). Best-effort.
+pub fn sendClose(allocator: Allocator, stream: std.net.Stream) void {
+    const framed = encodeFrame(allocator, .close, "") catch return;
+    defer allocator.free(framed);
+    sendAll(stream, framed) catch {};
+}
+
+/// Send a pong with the given payload (echoing a ping's body, per RFC 6455).
+pub fn sendPong(allocator: Allocator, stream: std.net.Stream, payload: []const u8) Error!void {
+    const framed = try encodeFrame(allocator, .pong, payload);
+    defer allocator.free(framed);
+    try sendAll(stream, framed);
+}
+
+/// Read one full client frame from `stream`, unmasking the payload. Reads the
+/// 2-byte header, any extended length, the 4-byte mask, then the payload.
+pub fn readFrame(allocator: Allocator, stream: std.net.Stream) Error!Frame {
+    var hdr: [2]u8 = undefined;
+    try recvExact(stream, &hdr);
+    const fin = (hdr[0] & 0x80) != 0;
+    const opcode: Opcode = @enumFromInt(@as(u4, @truncate(hdr[0] & 0x0F)));
+    const masked = (hdr[1] & 0x80) != 0;
+    if (!masked) return error.NotMasked;
+
+    var payload_len: u64 = hdr[1] & 0x7F;
+    if (payload_len == 126) {
+        var ext: [2]u8 = undefined;
+        try recvExact(stream, &ext);
+        payload_len = std.mem.readInt(u16, &ext, .big);
+    } else if (payload_len == 127) {
+        var ext: [8]u8 = undefined;
+        try recvExact(stream, &ext);
+        payload_len = std.mem.readInt(u64, &ext, .big);
+    }
+    if (payload_len > max_payload) return error.PayloadTooLarge;
+
+    var mask: [4]u8 = undefined;
+    try recvExact(stream, &mask);
+
+    const plen: usize = @intCast(payload_len);
+    const payload = try allocator.alloc(u8, plen);
+    errdefer allocator.free(payload);
+    if (plen > 0) {
+        try recvExact(stream, payload);
+        for (payload, 0..) |*c, i| c.* ^= mask[i % 4];
+    }
+    return .{ .opcode = opcode, .fin = fin, .payload = payload };
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "acceptKey: RFC 6455 example" {
+    // RFC 6455 §1.3: key "dGhlIHNhbXBsZSBub25jZQ==" → accept
+    // "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+    var out: [28]u8 = undefined;
+    acceptKey("dGhlIHNhbXBsZSBub25jZQ==", &out);
+    try testing.expectEqualStrings("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", &out);
+}
+
+test "encodeFrame: small text frame, FIN set, unmasked" {
+    const allocator = testing.allocator;
+    const f = try encodeFrame(allocator, .text, "hi");
+    defer allocator.free(f);
+    // 0x81 = FIN + text; 0x02 = len 2 (mask bit clear); then payload.
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x81, 0x02, 'h', 'i' }, f);
+}
+
+test "encodeFrame: 16-bit extended length" {
+    const allocator = testing.allocator;
+    const payload = try allocator.alloc(u8, 300);
+    defer allocator.free(payload);
+    @memset(payload, 'a');
+    const f = try encodeFrame(allocator, .text, payload);
+    defer allocator.free(f);
+    try testing.expectEqual(@as(u8, 0x81), f[0]);
+    try testing.expectEqual(@as(u8, 126), f[1]);
+    try testing.expectEqual(@as(u16, 300), std.mem.readInt(u16, f[2..4], .big));
+    try testing.expectEqual(@as(usize, 4 + 300), f.len);
+}
+
+test "decodeFrame: unmasks a client text frame" {
+    const allocator = testing.allocator;
+    // FIN+text, masked, len 5, mask 0x37fa213d, masked "Hello" per RFC 6455 §5.7
+    const data = [_]u8{ 0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58 };
+    const d = try decodeFrame(allocator, &data);
+    defer d.frame.deinit(allocator);
+    try testing.expectEqual(Opcode.text, d.frame.opcode);
+    try testing.expect(d.frame.fin);
+    try testing.expectEqualStrings("Hello", d.frame.payload);
+    try testing.expectEqual(@as(usize, data.len), d.consumed);
+}
+
+test "decodeFrame: rejects unmasked client frame" {
+    const allocator = testing.allocator;
+    const data = [_]u8{ 0x81, 0x02, 'h', 'i' }; // mask bit clear
+    try testing.expectError(error.NotMasked, decodeFrame(allocator, &data));
+}
+
+test "decodeFrame: Incomplete when header truncated" {
+    const allocator = testing.allocator;
+    try testing.expectError(error.Incomplete, decodeFrame(allocator, &[_]u8{0x81}));
+    // header says masked len 5 but payload missing
+    const partial = [_]u8{ 0x81, 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f };
+    try testing.expectError(error.Incomplete, decodeFrame(allocator, &partial));
+}
+
+test "encode then decode round-trips a masked echo" {
+    const allocator = testing.allocator;
+    // Build a server frame, then hand-mask it as if it were a client frame and
+    // decode it back, exercising the unmask path for a close opcode.
+    const server = try encodeFrame(allocator, .text, "ping me");
+    defer allocator.free(server);
+    // Re-frame as masked: header byte stays, set mask bit, append mask + xor.
+    var masked: std.ArrayList(u8) = .empty;
+    defer masked.deinit(allocator);
+    try masked.append(allocator, server[0]);
+    try masked.append(allocator, 0x80 | @as(u8, @intCast("ping me".len)));
+    const mask = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    try masked.appendSlice(allocator, &mask);
+    for ("ping me", 0..) |c, i| try masked.append(allocator, c ^ mask[i % 4]);
+
+    const d = try decodeFrame(allocator, masked.items);
+    defer d.frame.deinit(allocator);
+    try testing.expectEqualStrings("ping me", d.frame.payload);
+}


### PR DESCRIPTION
## What

Adds `carl daemon` — a loopback HTTP + WebSocket server that backs the desktop GUI (#34) — and wires it to a real `TorrentManager` over `session.zig` (no mock fixtures). Includes durable **SQLite-backed persistence** so the app loses nothing across restarts.

## Highlights

- **HTTP/1.1 + WebSocket API** (hand-rolled, RFC 6455 server frames). `GET /api/state` initial-load payload + a 1 Hz WebSocket push of live progress. Full contract in `docs/daemon-api.md`.
- **Real session wiring** — add/remove transfers (magnet / `.torrent` / HTTP URL), routed direct or through a SOCKS proxy (Tor). Live `pct`/rates/peer counts read from real session counters under a snapshot mutex.
- **SQLite persistence** (`<config>/carl.db`) — transfers, seeds and editable settings written in one transaction on every change; verified intact across `kill -9`. SQLite is **vendored** (amalgamation compiled into a static lib like secp256k1), so there is no system `libsqlite3` dependency and the build is identical everywhere.
- **True resume** — once a magnet's metadata completes, the resolved `.torrent` is written next to the data and the persisted source repointed at it, so a finished download comes back **complete** (pieces re-verified) instead of re-fetching metadata.
- **Live relay health** — a background prober opens/closes a connection per relay every ~30s through the configured route, so `connected`/`unreachable` is real.
- **In-app torrent creation** — `POST /api/seeds` hashes an uploaded file into a torrent in-process (no external tool) and seeds it; optional NIP-35 publish.
- **Editable settings** — `POST /api/settings` updates route, download dir, and the relay list (persisted to the carl config).

## Security

- Binds **127.0.0.1 only**; never exposed off loopback.
- Token-guarded (`X-Carl-Token` header / `?token=` on the WS handshake); constant-time compare.
- The nsec/secret key is **never** serialized — identity exposes `npub` only.

## Testing

- `zig build test` green (incl. SQLite round-trip + replace-not-accumulate, WS accept-key/frame KATs, metainfo creation, magnet metadata-exchange integration test).
- Persistence verified across a hard `kill -9` (state + settings restored).
- Exercised end-to-end against the desktop app in #34.

## Review / merge

Base is `main`; **merge this first**, then #34 (which is stacked on this branch) retargets to `main`. Scope is daemon-only (`src/`, `docs/`, build) — the landing-page commits that previously rode along were dropped by rebasing onto the merged #32.