### PR TITLE
feat: create .torrent across CLI, daemon, and desktop + bundled CLI install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-cache/
 .zig-cache/
 
 .gitsigners
+desktop/src-tauri/binaries/

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1431,6 +1432,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@types/babel__core": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,9 +12,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "@tauri-apps/api": "^2.1.1"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",

--- a/desktop/scripts/stage-sidecar.sh
+++ b/desktop/scripts/stage-sidecar.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Stage the `carl` daemon binary as a Tauri sidecar so the bundle ships its own
+# daemon (PATH-independent) and the desktop app can install/symlink the CLI.
+#
+# Run automatically by tauri.conf.json `beforeBuildCommand`. The binary is a
+# build artifact (gitignored under src-tauri/binaries/), so this regenerates it
+# every build — never shipping a stale daemon.
+#
+# Honors CARL_BIN if it points at a usable binary (skips the zig rebuild);
+# otherwise builds a fresh ReleaseSafe `carl` from the repo.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TRIPLE="$(rustc -Vv | awk '/host:/{print $2}')"
+
+if [ -n "$CARL_BIN" ] && [ -x "$CARL_BIN" ]; then
+  SRC="$CARL_BIN"
+  echo "stage-sidecar: using CARL_BIN=$SRC"
+else
+  echo "stage-sidecar: building ReleaseSafe carl"
+  ( cd "$REPO_ROOT" && zig build -Doptimize=ReleaseSafe )
+  SRC="$REPO_ROOT/zig-out/bin/carl"
+fi
+
+DEST_DIR="$REPO_ROOT/desktop/src-tauri/binaries"
+mkdir -p "$DEST_DIR"
+cp "$SRC" "$DEST_DIR/carl-$TRIPLE"
+chmod +x "$DEST_DIR/carl-$TRIPLE"
+echo "stage-sidecar: staged $DEST_DIR/carl-$TRIPLE"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
 ]
 
 [[package]]
@@ -1973,6 +1974,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.12.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2445,6 +2447,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3089,6 +3115,64 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -4140,6 +4224,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4171,11 +4264,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4209,6 +4319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,6 +4335,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4233,10 +4355,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4251,6 +4385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4401,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4275,6 +4421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4285,6 +4437,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "Core capabilities for the carl window.",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "dialog:allow-open"]
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -93,15 +93,27 @@ struct CliStatus {
     installed: bool,
     /// Where it's installed, if any.
     path: Option<String>,
+    /// True when the install is the system location (/usr/local/bin); false for
+    /// the per-user one. Lets the UI drive reinstall/remove without re-deriving
+    /// the location from the path string.
+    system: bool,
     /// True when the installed entry is a symlink into THIS app bundle (so it
     /// tracks app updates — the Docker model). A plain file or a link elsewhere
     /// reports false.
     linked_to_bundle: bool,
 }
 
+/// Quote a string for a single-quoted `/bin/sh` argument: wrap in `'…'` and
+/// escape any embedded single quote as `'\''`. Prevents a path containing a
+/// quote (e.g. an app under "/Users/me/Vince's apps/…") from breaking — or
+/// injecting into — the admin shell command.
+fn sh_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 /// Run a shell command with one-time admin authorization via the native macOS
 /// dialog (the Homebrew-cask approach). `script` must be a self-contained
-/// `/bin/sh` snippet using single-quoted paths.
+/// `/bin/sh` snippet; embed any paths via `sh_single_quote`.
 #[cfg(target_os = "macos")]
 fn run_admin(script: &str) -> Result<(), String> {
     // Embed into an AppleScript string: escape backslashes and double quotes.
@@ -140,6 +152,7 @@ fn cli_status() -> CliStatus {
                 available: bundle.is_some(),
                 installed: true,
                 path: Some(p.to_string_lossy().into_owned()),
+                system: p == std::path::Path::new(SYSTEM_CLI_PATH),
                 linked_to_bundle,
             };
         }
@@ -148,6 +161,7 @@ fn cli_status() -> CliStatus {
         available: bundle.is_some(),
         installed: false,
         path: None,
+        system: false,
         linked_to_bundle: false,
     }
 }
@@ -162,9 +176,11 @@ fn install_cli(system: bool) -> Result<String, String> {
     let src = sidecar.to_string_lossy();
     if system {
         // mkdir + symlink, replacing any existing entry, with one auth prompt.
+        // Paths are shell-quoted so a quote/space in the bundle path is safe.
         let script = format!(
-            "mkdir -p /usr/local/bin && ln -sf '{src}' '{SYSTEM_CLI_PATH}'",
-            src = src,
+            "mkdir -p /usr/local/bin && ln -sf {} {}",
+            sh_single_quote(&src),
+            sh_single_quote(SYSTEM_CLI_PATH),
         );
         #[cfg(target_os = "macos")]
         {
@@ -195,7 +211,7 @@ fn uninstall_cli(system: bool) -> Result<(), String> {
     if system {
         #[cfg(target_os = "macos")]
         {
-            run_admin(&format!("rm -f '{SYSTEM_CLI_PATH}'"))?;
+            run_admin(&format!("rm -f {}", sh_single_quote(SYSTEM_CLI_PATH)))?;
             Ok(())
         }
         #[cfg(not(target_os = "macos"))]
@@ -329,4 +345,20 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sh_single_quote;
+
+    #[test]
+    fn sh_single_quote_wraps_and_escapes() {
+        assert_eq!(sh_single_quote("/usr/local/bin/carl"), "'/usr/local/bin/carl'");
+        // An embedded single quote must close, escape, and reopen the quoting
+        // so the shell can't be broken out of (e.g. an app under "Vince's apps").
+        assert_eq!(
+            sh_single_quote("/a/Vince's apps/carl"),
+            "'/a/Vince'\\''s apps/carl'"
+        );
+    }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -207,19 +207,41 @@ fn uninstall_cli(system: bool) -> Result<(), String> {
     }
 }
 
+/// The default download folder for the desktop app — its own directory under
+/// the user's Downloads (like Telegram's "Telegram Desktop" folder), so
+/// downloads never land in the daemon's CWD (which is `/` for a Finder launch).
+/// The user can still change it in Settings.
+fn default_download_dir() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(
+        std::path::Path::new(&home)
+            .join("Downloads")
+            .join("carl-download"),
+    )
+}
+
 /// Spawn `carl daemon` and block (with a timeout) until it reports its token.
 fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
     let bin = resolve_carl_bin();
+    let port_s = port.to_string();
+    let pid_s = std::process::id().to_string();
+
+    // Give the daemon a real download dir up front. The daemon defaults to `.`,
+    // which for a Finder-launched app is `/` (unwritable) — so without this,
+    // downloads fail to write. Created best-effort; the user can change it later.
+    let download_dir = default_download_dir();
+    if let Some(d) = &download_dir {
+        let _ = std::fs::create_dir_all(d);
+    }
+
     // Pass our PID so the daemon's watchdog shuts it down if this shell dies
     // without a clean exit (crash / force-quit), instead of orphaning it.
-    let mut child = Command::new(&bin)
-        .args([
-            "daemon",
-            "--port",
-            &port.to_string(),
-            "--parent-pid",
-            &std::process::id().to_string(),
-        ])
+    let mut cmd = Command::new(&bin);
+    cmd.args(["daemon", "--port", &port_s, "--parent-pid", &pid_s]);
+    if let Some(d) = &download_dir {
+        cmd.args(["--download-dir", &d.to_string_lossy()]);
+    }
+    let mut child = cmd
         .stdout(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to spawn '{bin}': {e}"))?;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -41,8 +41,170 @@ fn daemon_config(state: tauri::State<DaemonState>) -> Result<DaemonConfig, Strin
         .ok_or_else(|| "daemon not ready".to_string())
 }
 
+/// Resolve the `carl` daemon binary, in priority order:
+///   1. `CARL_BIN` env var — the dev workflow points this at `zig-out/bin/carl`.
+///   2. The bundled sidecar next to the app executable (Contents/MacOS/carl) —
+///      so a Finder-launched app ships its own daemon and never depends on
+///      `$PATH` (GUI apps get a minimal PATH without ~/.local/bin or
+///      /usr/local/bin, which otherwise yields "daemon offline").
+///   3. `carl` on `$PATH` — the bare fallback for a dev shell.
 fn resolve_carl_bin() -> String {
-    std::env::var("CARL_BIN").unwrap_or_else(|_| "carl".to_string())
+    if let Ok(p) = std::env::var("CARL_BIN") {
+        return p;
+    }
+    if let Some(sidecar) = bundled_sidecar() {
+        return sidecar.to_string_lossy().into_owned();
+    }
+    "carl".to_string()
+}
+
+/// The bundled sidecar `carl` next to the app executable, if present (only in a
+/// packaged app — not a `CARL_BIN` dev run).
+fn bundled_sidecar() -> Option<std::path::PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let sidecar = exe.parent()?.join("carl");
+    sidecar.exists().then_some(sidecar)
+}
+
+/// The system CLI symlink location — on the default terminal PATH, root-owned
+/// (so installing here needs a one-time admin authorization, like Docker).
+const SYSTEM_CLI_PATH: &str = "/usr/local/bin/carl";
+
+/// The per-user CLI location — no password needed, but only useful if the user
+/// has `~/.local/bin` on their PATH.
+fn user_cli_path() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(
+        std::path::Path::new(&home)
+            .join(".local")
+            .join("bin")
+            .join("carl"),
+    )
+}
+
+/// Reported to the UI so it can mirror Docker's "CLI installed / not installed"
+/// state and offer install/remove.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CliStatus {
+    /// The packaged app has a bundled `carl` to link to (false in a dev run).
+    available: bool,
+    /// A `carl` is present at one of the known install locations.
+    installed: bool,
+    /// Where it's installed, if any.
+    path: Option<String>,
+    /// True when the installed entry is a symlink into THIS app bundle (so it
+    /// tracks app updates — the Docker model). A plain file or a link elsewhere
+    /// reports false.
+    linked_to_bundle: bool,
+}
+
+/// Run a shell command with one-time admin authorization via the native macOS
+/// dialog (the Homebrew-cask approach). `script` must be a self-contained
+/// `/bin/sh` snippet using single-quoted paths.
+#[cfg(target_os = "macos")]
+fn run_admin(script: &str) -> Result<(), String> {
+    // Embed into an AppleScript string: escape backslashes and double quotes.
+    let escaped = script.replace('\\', "\\\\").replace('"', "\\\"");
+    let osa = format!("do shell script \"{escaped}\" with administrator privileges");
+    let out = Command::new("osascript")
+        .arg("-e")
+        .arg(osa)
+        .output()
+        .map_err(|e| e.to_string())?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        // Cancelling the password dialog yields "User canceled. (-128)".
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
+}
+
+/// Report whether the bundled CLI is available and where (if anywhere) it's
+/// installed — so Settings can show the right install/remove affordance.
+#[tauri::command]
+fn cli_status() -> CliStatus {
+    let bundle = bundled_sidecar();
+    let mut candidates: Vec<std::path::PathBuf> = vec![std::path::PathBuf::from(SYSTEM_CLI_PATH)];
+    if let Some(u) = user_cli_path() {
+        candidates.push(u);
+    }
+    for p in candidates {
+        // symlink_metadata so a symlink doesn't get followed/hidden.
+        if std::fs::symlink_metadata(&p).is_ok() {
+            let linked_to_bundle = match (std::fs::read_link(&p).ok(), bundle.as_ref()) {
+                (Some(t), Some(b)) => &t == b,
+                _ => false,
+            };
+            return CliStatus {
+                available: bundle.is_some(),
+                installed: true,
+                path: Some(p.to_string_lossy().into_owned()),
+                linked_to_bundle,
+            };
+        }
+    }
+    CliStatus {
+        available: bundle.is_some(),
+        installed: false,
+        path: None,
+        linked_to_bundle: false,
+    }
+}
+
+/// Install the CLI by symlinking a PATH location to the bundled `carl` — so the
+/// CLI always tracks this app's version (no stale copies, no signature kill).
+/// `system` targets `/usr/local/bin` (one admin prompt); otherwise `~/.local/bin`
+/// (no prompt). Returns the installed path.
+#[tauri::command]
+fn install_cli(system: bool) -> Result<String, String> {
+    let sidecar = bundled_sidecar().ok_or("the command-line tool isn't available in this build")?;
+    let src = sidecar.to_string_lossy();
+    if system {
+        // mkdir + symlink, replacing any existing entry, with one auth prompt.
+        let script = format!(
+            "mkdir -p /usr/local/bin && ln -sf '{src}' '{SYSTEM_CLI_PATH}'",
+            src = src,
+        );
+        #[cfg(target_os = "macos")]
+        {
+            run_admin(&script)?;
+            Ok(SYSTEM_CLI_PATH.to_string())
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = script;
+            Err("system install is only implemented on macOS".to_string())
+        }
+    } else {
+        let dest = user_cli_path().ok_or("no HOME directory")?;
+        if let Some(dir) = dest.parent() {
+            std::fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let _ = std::fs::remove_file(&dest); // replace any existing entry
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&sidecar, &dest).map_err(|e| e.to_string())?;
+        Ok(dest.to_string_lossy().into_owned())
+    }
+}
+
+/// Remove a CLI symlink we installed. `system` targets `/usr/local/bin` (admin
+/// prompt); otherwise `~/.local/bin`.
+#[tauri::command]
+fn uninstall_cli(system: bool) -> Result<(), String> {
+    if system {
+        #[cfg(target_os = "macos")]
+        {
+            run_admin(&format!("rm -f '{SYSTEM_CLI_PATH}'"))?;
+            Ok(())
+        }
+        #[cfg(not(target_os = "macos"))]
+        Err("system uninstall is only implemented on macOS".to_string())
+    } else {
+        let dest = user_cli_path().ok_or("no HOME directory")?;
+        let _ = std::fs::remove_file(&dest);
+        Ok(())
+    }
 }
 
 /// Spawn `carl daemon` and block (with a timeout) until it reports its token.
@@ -103,8 +265,14 @@ fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
 
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .manage(DaemonState::default())
-        .invoke_handler(tauri::generate_handler![daemon_config])
+        .invoke_handler(tauri::generate_handler![
+            daemon_config,
+            cli_status,
+            install_cli,
+            uninstall_cli
+        ])
         .setup(|app| {
             match spawn_daemon(DAEMON_PORT) {
                 Ok((child, cfg)) => {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5180",
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "sh scripts/stage-sidecar.sh && npm run dev",
     "beforeBuildCommand": "sh scripts/stage-sidecar.sh && npm run build"
   },
   "app": {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5180",
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build"
+    "beforeBuildCommand": "sh scripts/stage-sidecar.sh && npm run build"
   },
   "app": {
     "windows": [
@@ -27,6 +27,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/carl"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/desktop/src/api/cli.ts
+++ b/desktop/src/api/cli.ts
@@ -1,0 +1,44 @@
+// Command-line-tool install, Docker-style: the packaged app symlinks a PATH
+// location to its bundled `carl`, so the CLI always tracks the app version.
+// These are Tauri commands (not daemon HTTP), so they only do anything inside
+// the desktop shell; in a browser they degrade to "unavailable".
+
+export interface CliStatus {
+  /** The packaged app has a bundled `carl` to link to. */
+  available: boolean;
+  /** A `carl` is present at a known install location. */
+  installed: boolean;
+  /** Where it's installed, if any. */
+  path: string | null;
+  /** True when the install is a symlink into this app bundle (tracks updates). */
+  linkedToBundle: boolean;
+}
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+const UNAVAILABLE: CliStatus = {
+  available: false,
+  installed: false,
+  path: null,
+  linkedToBundle: false,
+};
+
+export async function cliStatus(): Promise<CliStatus> {
+  if (!isTauri()) return UNAVAILABLE;
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<CliStatus>("cli_status");
+}
+
+/** Install the CLI. `system` → /usr/local/bin (one admin prompt); otherwise
+ *  ~/.local/bin (no prompt). Returns the installed path. */
+export async function installCli(system: boolean): Promise<string> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string>("install_cli", { system });
+}
+
+export async function uninstallCli(system: boolean): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("uninstall_cli", { system });
+}

--- a/desktop/src/api/cli.ts
+++ b/desktop/src/api/cli.ts
@@ -10,6 +10,8 @@ export interface CliStatus {
   installed: boolean;
   /** Where it's installed, if any. */
   path: string | null;
+  /** True when installed in the system location (/usr/local/bin) vs per-user. */
+  system: boolean;
   /** True when the install is a symlink into this app bundle (tracks updates). */
   linkedToBundle: boolean;
 }
@@ -22,6 +24,7 @@ const UNAVAILABLE: CliStatus = {
   available: false,
   installed: false,
   path: null,
+  system: false,
   linkedToBundle: false,
 };
 
@@ -34,11 +37,13 @@ export async function cliStatus(): Promise<CliStatus> {
 /** Install the CLI. `system` → /usr/local/bin (one admin prompt); otherwise
  *  ~/.local/bin (no prompt). Returns the installed path. */
 export async function installCli(system: boolean): Promise<string> {
+  if (!isTauri()) throw new Error("the command-line tool is only available in the desktop app");
   const { invoke } = await import("@tauri-apps/api/core");
   return invoke<string>("install_cli", { system });
 }
 
 export async function uninstallCli(system: boolean): Promise<void> {
+  if (!isTauri()) throw new Error("the command-line tool is only available in the desktop app");
   const { invoke } = await import("@tauri-apps/api/core");
   await invoke("uninstall_cli", { system });
 }

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -7,6 +7,7 @@
 //              matching the demo daemon.
 import type {
   AppState,
+  CreateTorrentResult,
   DiscoverResult,
   Route,
   Settings,
@@ -146,6 +147,25 @@ export class DaemonClient {
       body: bytes,
     });
     return this.json<{ id: string }>(res);
+  }
+
+  /**
+   * Build a .torrent on disk from a server-side path (a file OR a directory).
+   * Unlike createSeed this uploads no bytes — folders can't be a single body —
+   * so the daemon reads `path` directly and writes `<path>.torrent` (or the
+   * daemon's chosen location). Trackers are optional (Nostr/DHT discovery).
+   * Returns the written path, info-hash, total size, and file count.
+   */
+  async createTorrent(
+    path: string,
+    trackers: string[],
+    comment?: string,
+  ): Promise<CreateTorrentResult> {
+    const res = await this.fetch("/api/torrents", {
+      method: "POST",
+      body: JSON.stringify({ path, trackers, comment }),
+    });
+    return this.json<CreateTorrentResult>(res);
   }
 
   /**

--- a/desktop/src/api/store.tsx
+++ b/desktop/src/api/store.tsx
@@ -7,7 +7,12 @@ import React, {
   useState,
 } from "react";
 import { DaemonClient, resolveConfig } from "./client";
-import { type AppState, emptyState, type Route } from "./types";
+import {
+  type AppState,
+  type CreateTorrentResult,
+  emptyState,
+  type Route,
+} from "./types";
 
 interface CarlContextValue {
   state: AppState;
@@ -25,6 +30,11 @@ interface CarlContextValue {
     relays?: string[];
   }) => Promise<void>;
   createSeed: (file: File, route: Route, nostr: boolean) => Promise<void>;
+  createTorrent: (
+    path: string,
+    trackers: string[],
+    comment?: string,
+  ) => Promise<CreateTorrentResult>;
   refresh: () => Promise<void>;
 }
 
@@ -161,6 +171,17 @@ export function CarlProvider({ children }: { children: React.ReactNode }) {
     [refresh],
   );
 
+  // Creating a .torrent writes a file but doesn't change daemon state, so no
+  // refresh is needed — the caller just gets the written path back.
+  const createTorrent = useCallback(
+    async (path: string, trackers: string[], comment?: string) => {
+      const c = clientRef.current;
+      if (!c) throw new Error("daemon not connected");
+      return c.createTorrent(path, trackers, comment);
+    },
+    [],
+  );
+
   const value: CarlContextValue = {
     state,
     connected,
@@ -171,6 +192,7 @@ export function CarlProvider({ children }: { children: React.ReactNode }) {
     setRoute,
     updateSettings,
     createSeed,
+    createTorrent,
     refresh,
   };
   return <CarlContext.Provider value={value}>{children}</CarlContext.Provider>;

--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -63,6 +63,17 @@ export interface Settings {
   publishNip35: boolean;
 }
 
+export interface CreateTorrentResult {
+  /** Absolute path of the .torrent written on disk. */
+  path: string;
+  /** info-hash, lowercase hex (40 chars). */
+  infoHash: string;
+  /** Total size of the source content, bytes. */
+  size: number;
+  /** Number of files included. */
+  files: number;
+}
+
 export interface DiscoverResult {
   id: string;
   title: string;

--- a/desktop/src/modals/CreateTorrentModal.tsx
+++ b/desktop/src/modals/CreateTorrentModal.tsx
@@ -1,0 +1,184 @@
+import { useState } from "react";
+import { Icon } from "../components/icons";
+import { CopyField } from "../components/atoms";
+import { fmtBytes } from "../components/format";
+import { useCarl } from "../api/store";
+import type { CreateTorrentResult } from "../api/types";
+
+/** True inside the Tauri shell — gates the native file/folder picker. In a
+ *  plain browser the user types an absolute path the daemon can read instead. */
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Build a .torrent from a local file or directory. The daemon reads the path
+ * server-side (folders can't be uploaded as bytes) and writes `<path>.torrent`,
+ * so this is path-based: in Tauri we open a native picker; in a browser the
+ * user pastes an absolute path. Trackers are optional — carl discovers peers
+ * over Nostr/DHT — and live one-per-line.
+ */
+export function CreateTorrentModal({ onClose }: { onClose: () => void }) {
+  const { createTorrent } = useCarl();
+  const [path, setPath] = useState("");
+  const [trackers, setTrackers] = useState("");
+  const [comment, setComment] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [result, setResult] = useState<CreateTorrentResult | null>(null);
+
+  const canCreate = path.trim().length > 0 && !busy;
+
+  async function browse(directory: boolean) {
+    setErr(null);
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const sel = await open({
+        directory,
+        multiple: false,
+        title: directory ? "Choose a folder" : "Choose a file",
+      });
+      if (typeof sel === "string") setPath(sel);
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  async function submit() {
+    if (!canCreate) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const list = trackers
+        .split("\n")
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const r = await createTorrent(
+        path.trim(),
+        list,
+        comment.trim() || undefined,
+      );
+      setResult(r);
+    } catch (e) {
+      setErr(String(e));
+    }
+    setBusy(false);
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal seed-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2 className="modal-title">Create a .torrent</h2>
+          <button className="icon-btn" onClick={onClose}>
+            <Icon name="close" size={16} />
+          </button>
+        </div>
+
+        <div className="modal-body">
+          {result ? (
+            <>
+              <div className="callout-note">
+                <Icon name="check" size={15} stroke={2} />
+                <span>
+                  Created a torrent with {result.files} file
+                  {result.files === 1 ? "" : "s"} ({fmtBytes(result.size)}).
+                </span>
+              </div>
+              <div className="field">
+                <label className="field-label">Saved to</label>
+                <CopyField value={result.path} full />
+              </div>
+              <div className="field">
+                <label className="field-label">Info hash</label>
+                <CopyField value={result.infoHash} full />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="field">
+                <label className="field-label">File or folder</label>
+                <div className="add-input-row" style={{ display: "flex", gap: 8 }}>
+                  <input
+                    className="text-input mono add-input"
+                    style={{ flex: 1 }}
+                    value={path}
+                    autoFocus
+                    onChange={(e) => setPath(e.target.value)}
+                    placeholder="/absolute/path/to/file-or-folder"
+                  />
+                  {isTauri() && (
+                    <>
+                      <button className="btn" onClick={() => browse(false)}>
+                        File…
+                      </button>
+                      <button className="btn" onClick={() => browse(true)}>
+                        Folder…
+                      </button>
+                    </>
+                  )}
+                </div>
+                <span className="field-hint">
+                  A directory becomes a multi-file torrent. The daemon hashes it
+                  locally and writes <span className="mono">&lt;name&gt;.torrent</span>{" "}
+                  next to it.
+                </span>
+              </div>
+
+              <div className="field">
+                <label className="field-label">Trackers (optional)</label>
+                <textarea
+                  className="text-input mono"
+                  rows={3}
+                  value={trackers}
+                  onChange={(e) => setTrackers(e.target.value)}
+                  placeholder={"http://tracker.example/announce\nudp://tracker2.example:6969"}
+                />
+                <span className="field-hint">
+                  One per line. Leave empty for a trackerless torrent (peers via
+                  Nostr/DHT).
+                </span>
+              </div>
+
+              <div className="field">
+                <label className="field-label">Comment (optional)</label>
+                <input
+                  className="text-input"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="e.g. release notes or a description"
+                />
+              </div>
+
+              {err && (
+                <div className="callout-note" style={{ color: "var(--danger)" }}>
+                  <Icon name="close" size={15} stroke={1.8} />
+                  <span>{err}</span>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="modal-foot">
+          <div className="modal-foot-route" />
+          <div className="modal-foot-actions">
+            <button className="btn" onClick={onClose}>
+              {result ? "Done" : "Cancel"}
+            </button>
+            {!result && (
+              <button
+                className={"btn btn-primary" + (canCreate ? "" : " disabled")}
+                disabled={!canCreate}
+                onClick={submit}
+              >
+                <Icon name="plus" size={14} stroke={2.2} />{" "}
+                {busy ? "Creating…" : "Create .torrent"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/screens/Seeding.tsx
+++ b/desktop/src/screens/Seeding.tsx
@@ -3,6 +3,7 @@ import { Icon, OnionIcon } from "../components/icons";
 import { RouteBadge, CopyField } from "../components/atoms";
 import { fmtBytes, fmtSpeed, trunc } from "../components/format";
 import { useCarl } from "../api/store";
+import { CreateTorrentModal } from "../modals/CreateTorrentModal";
 import type { Route, Seed } from "../api/types";
 
 const VIS_LABEL: Record<Route, string> = {
@@ -240,6 +241,7 @@ export function SeedingScreen() {
   const { state } = useCarl();
   const seeds = state.seeds;
   const [flow, setFlow] = useState(false);
+  const [createFlow, setCreateFlow] = useState(false);
   const upTotal = seeds.reduce((a, s) => a + s.up, 0);
   const torSeed = seeds.find((s) => s.visibility === "tor" && s.onion);
 
@@ -256,6 +258,9 @@ export function SeedingScreen() {
           </div>
         </div>
         <div className="topbar-r">
+          <button className="btn" onClick={() => setCreateFlow(true)}>
+            <Icon name="file" size={15} stroke={2} /> Create .torrent
+          </button>
           <button className="btn btn-primary" onClick={() => setFlow(true)}>
             <Icon name="plus" size={15} stroke={2} /> Seed a file
           </button>
@@ -299,6 +304,9 @@ export function SeedingScreen() {
       </div>
 
       {flow && <SeedFlow onClose={() => setFlow(false)} />}
+      {createFlow && (
+        <CreateTorrentModal onClose={() => setCreateFlow(false)} />
+      )}
     </div>
   );
 }

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -91,9 +91,7 @@ function CliToolsSection() {
               <button
                 className="btn btn-sm"
                 disabled={busy}
-                onClick={() =>
-                  run(() => installCli(status.path?.startsWith("/usr/") ?? true))
-                }
+                onClick={() => run(() => installCli(status.system))}
               >
                 <Icon name="check" size={13} stroke={2.2} />
                 {busy ? "Working…" : "Reinstall"}
@@ -101,11 +99,7 @@ function CliToolsSection() {
               <button
                 className="btn btn-sm"
                 disabled={busy}
-                onClick={() =>
-                  run(() =>
-                    uninstallCli(status.path?.startsWith("/usr/") ?? false),
-                  )
-                }
+                onClick={() => run(() => uninstallCli(status.system))}
               >
                 Remove
               </button>

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -4,6 +4,153 @@ import { CopyField } from "../components/atoms";
 import { trunc } from "../components/format";
 import { useCarl } from "../api/store";
 import type { Route } from "../api/types";
+import {
+  cliStatus,
+  installCli,
+  uninstallCli,
+  type CliStatus,
+} from "../api/cli";
+
+/** Command-line tools, Docker-style: symlink a PATH location to the bundled
+ *  `carl` so the CLI tracks the app. System install (/usr/local/bin) needs a
+ *  one-time password; user install (~/.local/bin) doesn't. */
+function CliToolsSection() {
+  const [status, setStatus] = useState<CliStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function reload() {
+    try {
+      setStatus(await cliStatus());
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+  useEffect(() => {
+    reload();
+  }, []);
+
+  async function run(fn: () => Promise<unknown>) {
+    setBusy(true);
+    setErr(null);
+    try {
+      await fn();
+      await reload();
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="sset">
+      <div className="sset-head">
+        <h2 className="sset-title">Command-line tools</h2>
+        <p className="sset-sub">
+          Install the <span className="mono">carl</span> CLI so it's available in
+          your terminal. It's symlinked to this app, so it always matches the
+          installed version.
+        </p>
+      </div>
+      <div className="sset-body">
+        {!status ? (
+          <div className="field-hint">Checking…</div>
+        ) : !status.available ? (
+          <div className="callout-note">
+            <Icon name="shield" size={15} stroke={1.8} />
+            <span>
+              The bundled CLI is only available in the packaged desktop app
+              (this looks like a dev/browser session).
+            </span>
+          </div>
+        ) : status.installed ? (
+          <>
+            <div className="leak-check lc-safe">
+              <span className="lc-dot" />
+              <div className="lc-body">
+                <div className="lc-title">
+                  CLI installed
+                  {status.linkedToBundle
+                    ? " · linked to this app"
+                    : " · not linked to this app"}
+                </div>
+                <div className="lc-detail mono">{status.path}</div>
+              </div>
+            </div>
+            {!status.linkedToBundle && (
+              <div className="callout-note">
+                <Icon name="shield" size={15} stroke={1.8} />
+                <span>
+                  This <span className="mono">carl</span> isn't a symlink to the
+                  app — reinstall below to have it track app updates.
+                </span>
+              </div>
+            )}
+            <div className="id-actions">
+              <button
+                className="btn btn-sm"
+                disabled={busy}
+                onClick={() =>
+                  run(() => installCli(status.path?.startsWith("/usr/") ?? true))
+                }
+              >
+                <Icon name="check" size={13} stroke={2.2} />
+                {busy ? "Working…" : "Reinstall"}
+              </button>
+              <button
+                className="btn btn-sm"
+                disabled={busy}
+                onClick={() =>
+                  run(() =>
+                    uninstallCli(status.path?.startsWith("/usr/") ?? false),
+                  )
+                }
+              >
+                Remove
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="field-hint">
+              Not installed. Choose where to put the{" "}
+              <span className="mono">carl</span> command:
+            </div>
+            <div className="id-actions">
+              <button
+                className="btn btn-sm btn-primary"
+                disabled={busy}
+                onClick={() => run(() => installCli(true))}
+              >
+                <Icon name="plus" size={13} stroke={2.2} />
+                {busy ? "Working…" : "Install (system · /usr/local/bin)"}
+              </button>
+              <button
+                className="btn btn-sm"
+                disabled={busy}
+                onClick={() => run(() => installCli(false))}
+              >
+                Install (user · ~/.local/bin)
+              </button>
+            </div>
+            <span className="field-hint">
+              System install asks for your password once. User install needs no
+              password but only works if <span className="mono">~/.local/bin</span>{" "}
+              is on your PATH.
+            </span>
+          </>
+        )}
+        {err && (
+          <div className="callout-note" style={{ color: "var(--danger)" }}>
+            <Icon name="close" size={15} stroke={1.8} />
+            <span>{err}</span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
 
 function LeakCheck({ route, socks }: { route: Route; socks: string }) {
   const safe = route !== "direct";
@@ -306,6 +453,9 @@ export function SettingsScreen() {
             )}
           </div>
         </section>
+
+        {/* Command-line tools */}
+        <CliToolsSection />
       </div>
     </div>
   );

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -16,6 +16,7 @@ const http = @import("http.zig");
 const ws_server = @import("ws_server.zig");
 const manager_mod = @import("manager.zig");
 const session_mod = @import("session.zig");
+const metainfo = @import("metainfo.zig");
 const api = @import("api.zig");
 const nostr_config = @import("nostr_config.zig");
 const proxy_mod = @import("proxy.zig");
@@ -281,6 +282,7 @@ const Conn = struct {
         if (std.mem.eql(u8, req.method, "POST")) {
             if (std.mem.eql(u8, path, "/api/transfers")) return self.addTransfer(body);
             if (std.mem.eql(u8, path, "/api/seeds")) return self.createSeed(req, body);
+            if (std.mem.eql(u8, path, "/api/torrents")) return self.createTorrent(body);
             if (std.mem.eql(u8, path, "/api/search")) return self.search(req, body);
             if (std.mem.eql(u8, path, "/api/settings")) return self.updateSettings(body);
             return self.sendStatus(.not_found);
@@ -447,6 +449,109 @@ const Conn = struct {
         try self.sendJson(.ok, j.buf.items);
     }
 
+    /// Outcome of building a .torrent on disk, in arena memory.
+    const TorrentBuilt = struct {
+        out_path: []const u8,
+        info_hash_hex: [40]u8,
+        size: u64,
+        files: usize,
+    };
+
+    /// Shared by the HTTP route and the WebSocket command: build a .torrent from
+    /// a server-side `src_path` (file OR directory), write it to disk, and return
+    /// a summary. `out_path_opt` overrides the default `<src_path>.torrent`. The
+    /// path is taken verbatim — folders can't be uploaded as bytes, so creation
+    /// is path-based; the daemon binds loopback and is token-guarded, and the
+    /// desktop supplies the path from a native picker.
+    fn doCreateTorrent(
+        self: *Conn,
+        aa: Allocator,
+        src_path: []const u8,
+        trackers: []const []const u8,
+        comment: ?[]const u8,
+        out_path_opt: ?[]const u8,
+    ) !TorrentBuilt {
+        const res = metainfo.buildTorrent(self.daemon.allocator, src_path, .{
+            .trackers = trackers,
+            .comment = comment,
+            .created_by = "carl",
+            .creation_date = std.time.timestamp(),
+        }) catch return error.CreateFailed;
+        defer self.daemon.allocator.free(res.data);
+
+        const out_path = if (out_path_opt) |o|
+            o
+        else
+            try std.fmt.allocPrint(aa, "{s}.torrent", .{src_path});
+        {
+            var f = std.fs.cwd().createFile(out_path, .{ .truncate = true }) catch return error.WriteFailed;
+            defer f.close();
+            f.writeAll(res.data) catch return error.WriteFailed;
+        }
+
+        var hex: [40]u8 = undefined;
+        secp.toHex(&res.info_hash, &hex);
+        return .{
+            .out_path = try aa.dupe(u8, out_path),
+            .info_hash_hex = hex,
+            .size = res.total_length,
+            .files = res.file_count,
+        };
+    }
+
+    /// Pull the optional tracker list, comment, and out-path out of a parsed
+    /// create-torrent request object. Trackers default to empty (trackerless).
+    fn parseCreateBody(aa: Allocator, obj: std.json.ObjectMap) !struct {
+        trackers: []const []const u8,
+        comment: ?[]const u8,
+        out_path: ?[]const u8,
+    } {
+        var trackers: std.ArrayList([]const u8) = .empty;
+        if (obj.get("trackers")) |v| {
+            if (v == .array) {
+                for (v.array.items) |it| {
+                    if (it == .string and it.string.len > 0) try trackers.append(aa, it.string);
+                }
+            }
+        }
+        return .{
+            .trackers = try trackers.toOwnedSlice(aa),
+            .comment = strField(obj, "comment"),
+            .out_path = strField(obj, "outPath"),
+        };
+    }
+
+    /// POST /api/torrents — body is JSON {path, trackers?, comment?, outPath?}.
+    /// `path` is a server-side file or directory; creates a .torrent on disk and
+    /// returns { path, infoHash, size, files }.
+    fn createTorrent(self: *Conn, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const parsed = std.json.parseFromSlice(std.json.Value, aa, body, .{}) catch
+            return self.sendStatus(.bad_request);
+        const obj = if (parsed.value == .object) parsed.value.object else return self.sendStatus(.bad_request);
+        const src_path = strField(obj, "path") orelse return self.sendStatus(.bad_request);
+        if (src_path.len == 0) return self.sendStatus(.bad_request);
+        const opts = parseCreateBody(aa, obj) catch return self.sendStatus(.internal_error);
+
+        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment, opts.out_path) catch |err| {
+            log.warn("createTorrent failed for '{s}': {}", .{ src_path, err });
+            return self.sendStatus(.bad_request);
+        };
+
+        var j = api.Json.init(aa);
+        try j.beginObject();
+        try j.keyString("path", built.out_path);
+        try j.keyString("infoHash", &built.info_hash_hex);
+        try j.keyNumber("size", built.size);
+        try j.keyNumber("files", built.files);
+        try j.endObject();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
     fn updateSettings(self: *Conn, body: []const u8) !void {
         const a = self.daemon.allocator;
         var arena = std.heap.ArenaAllocator.init(a);
@@ -536,6 +641,26 @@ const Conn = struct {
         // GUI only needs the push channel — so a closed socket is detected by
         // the next send failing.
         while (self.daemon.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
+            // Drain any pending client command frames (e.g. create_torrent)
+            // before the push, without stalling the cadence: poll with a 0ms
+            // timeout and handle only what's already buffered.
+            while (socketReadable(self.stream.handle)) {
+                const frame = ws_server.readFrame(a, self.stream) catch {
+                    ws_server.sendClose(a, self.stream);
+                    return;
+                };
+                defer frame.deinit(a);
+                switch (frame.opcode) {
+                    .text => self.handleWsCommand(frame.payload) catch {},
+                    .ping => ws_server.sendPong(a, self.stream, frame.payload) catch {},
+                    .close => {
+                        ws_server.sendClose(a, self.stream);
+                        return;
+                    },
+                    else => {},
+                }
+            }
+
             // Cheap when nothing changed; captures a resolved magnet's .torrent
             // within ~1s so a restart resumes it as a complete torrent.
             self.daemon.manager.checkpoint();
@@ -562,6 +687,55 @@ const Conn = struct {
             }
         }
         ws_server.sendClose(a, self.stream);
+    }
+
+    /// Handle one client text frame as a JSON command. Currently the only
+    /// command is `create_torrent` — mirroring POST /api/torrents over the
+    /// socket so the desktop can request creation and get a `torrent_created`
+    /// result frame back. Unknown commands are ignored.
+    fn handleWsCommand(self: *Conn, payload: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const parsed = std.json.parseFromSlice(std.json.Value, aa, payload, .{}) catch return;
+        if (parsed.value != .object) return;
+        const obj = parsed.value.object;
+        const cmd = strField(obj, "cmd") orelse return;
+        if (!std.mem.eql(u8, cmd, "create_torrent")) return;
+
+        const req_id = strField(obj, "reqId") orelse "";
+        const src_path = strField(obj, "path") orelse return self.wsCreateError(aa, req_id, "missing path");
+        if (src_path.len == 0) return self.wsCreateError(aa, req_id, "missing path");
+        const opts = parseCreateBody(aa, obj) catch return self.wsCreateError(aa, req_id, "bad request");
+
+        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment, opts.out_path) catch
+            return self.wsCreateError(aa, req_id, "create failed");
+
+        var j = api.Json.init(aa);
+        try j.beginObject();
+        try j.keyString("type", "torrent_created");
+        try j.keyString("reqId", req_id);
+        try j.keyBool("ok", true);
+        try j.keyString("path", built.out_path);
+        try j.keyString("infoHash", &built.info_hash_hex);
+        try j.keyNumber("size", built.size);
+        try j.keyNumber("files", built.files);
+        try j.endObject();
+        ws_server.sendText(a, self.stream, j.buf.items) catch {};
+    }
+
+    /// Send a `torrent_created` failure frame for a WebSocket create command.
+    fn wsCreateError(self: *Conn, aa: Allocator, req_id: []const u8, msg: []const u8) void {
+        var j = api.Json.init(aa);
+        j.beginObject() catch return;
+        j.keyString("type", "torrent_created") catch return;
+        j.keyString("reqId", req_id) catch return;
+        j.keyBool("ok", false) catch return;
+        j.keyString("error", msg) catch return;
+        j.endObject() catch return;
+        ws_server.sendText(self.daemon.allocator, self.stream, j.buf.items) catch {};
     }
 
     // ----- response writers -----
@@ -647,6 +821,16 @@ fn readNpub(arena: Allocator) ![]const u8 {
 fn strField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
     const v = obj.get(name) orelse return null;
     return if (v == .string) v.string else null;
+}
+
+/// Non-blocking readability probe (poll with a 0ms timeout) so the WebSocket
+/// push loop can opportunistically drain client command frames without stalling.
+/// A half-closed socket also polls readable; the subsequent read then fails and
+/// the caller closes the connection.
+fn socketReadable(fd: posix.socket_t) bool {
+    var pfd = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+    const ready = posix.poll(&pfd, 0) catch return false;
+    return ready > 0;
 }
 
 /// Set a recv timeout on an accepted socket so a stalled client can't wedge its

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -458,18 +458,18 @@ const Conn = struct {
     };
 
     /// Shared by the HTTP route and the WebSocket command: build a .torrent from
-    /// a server-side `src_path` (file OR directory), write it to disk, and return
-    /// a summary. `out_path_opt` overrides the default `<src_path>.torrent`. The
-    /// path is taken verbatim — folders can't be uploaded as bytes, so creation
-    /// is path-based; the daemon binds loopback and is token-guarded, and the
-    /// desktop supplies the path from a native picker.
+    /// a server-side `src_path` (file OR directory), write it next to the source
+    /// as `<src>.torrent`, and return a summary. The output path is derived from
+    /// the source (never client-supplied) so a request can't make the daemon
+    /// overwrite an arbitrary file. Creation is path-based (folders can't be
+    /// uploaded as bytes); the daemon binds loopback and is token-guarded, and
+    /// the desktop supplies the path from a native picker.
     fn doCreateTorrent(
         self: *Conn,
         aa: Allocator,
         src_path: []const u8,
         trackers: []const []const u8,
         comment: ?[]const u8,
-        out_path_opt: ?[]const u8,
     ) !TorrentBuilt {
         const res = metainfo.buildTorrent(self.daemon.allocator, src_path, .{
             .trackers = trackers,
@@ -479,10 +479,12 @@ const Conn = struct {
         }) catch return error.CreateFailed;
         defer self.daemon.allocator.free(res.data);
 
-        const out_path = if (out_path_opt) |o|
-            o
-        else
-            try std.fmt.allocPrint(aa, "{s}.torrent", .{src_path});
+        // Derive `<src>.torrent`, trimming a trailing slash so a directory path
+        // "/a/b/" yields "/a/b.torrent" (beside it), not "/a/b/.torrent" (inside).
+        const sep = [_]u8{std.fs.path.sep};
+        const trimmed = std.mem.trimRight(u8, src_path, &sep);
+        const base_path = if (trimmed.len == 0) src_path else trimmed;
+        const out_path = try std.fmt.allocPrint(aa, "{s}.torrent", .{base_path});
         {
             var f = std.fs.cwd().createFile(out_path, .{ .truncate = true }) catch return error.WriteFailed;
             defer f.close();
@@ -492,19 +494,18 @@ const Conn = struct {
         var hex: [40]u8 = undefined;
         secp.toHex(&res.info_hash, &hex);
         return .{
-            .out_path = try aa.dupe(u8, out_path),
+            .out_path = out_path,
             .info_hash_hex = hex,
             .size = res.total_length,
             .files = res.file_count,
         };
     }
 
-    /// Pull the optional tracker list, comment, and out-path out of a parsed
-    /// create-torrent request object. Trackers default to empty (trackerless).
+    /// Pull the optional tracker list and comment out of a parsed create-torrent
+    /// request object. Trackers default to empty (trackerless).
     fn parseCreateBody(aa: Allocator, obj: std.json.ObjectMap) !struct {
         trackers: []const []const u8,
         comment: ?[]const u8,
-        out_path: ?[]const u8,
     } {
         var trackers: std.ArrayList([]const u8) = .empty;
         if (obj.get("trackers")) |v| {
@@ -517,12 +518,11 @@ const Conn = struct {
         return .{
             .trackers = try trackers.toOwnedSlice(aa),
             .comment = strField(obj, "comment"),
-            .out_path = strField(obj, "outPath"),
         };
     }
 
-    /// POST /api/torrents — body is JSON {path, trackers?, comment?, outPath?}.
-    /// `path` is a server-side file or directory; creates a .torrent on disk and
+    /// POST /api/torrents — body is JSON {path, trackers?, comment?}. `path` is a
+    /// server-side file or directory; creates `<path>.torrent` on disk and
     /// returns { path, infoHash, size, files }.
     fn createTorrent(self: *Conn, body: []const u8) !void {
         const a = self.daemon.allocator;
@@ -537,9 +537,10 @@ const Conn = struct {
         if (src_path.len == 0) return self.sendStatus(.bad_request);
         const opts = parseCreateBody(aa, obj) catch return self.sendStatus(.internal_error);
 
-        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment, opts.out_path) catch |err| {
+        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment) catch |err| {
             log.warn("createTorrent failed for '{s}': {}", .{ src_path, err });
-            return self.sendStatus(.bad_request);
+            // Bad input (unreadable/empty source) → 400; disk/write failure → 500.
+            return self.sendStatus(if (err == error.WriteFailed) .internal_error else .bad_request);
         };
 
         var j = api.Json.init(aa);
@@ -710,7 +711,7 @@ const Conn = struct {
         if (src_path.len == 0) return self.wsCreateError(aa, req_id, "missing path");
         const opts = parseCreateBody(aa, obj) catch return self.wsCreateError(aa, req_id, "bad request");
 
-        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment, opts.out_path) catch
+        const built = self.doCreateTorrent(aa, src_path, opts.trackers, opts.comment) catch
             return self.wsCreateError(aa, req_id, "create failed");
 
         var j = api.Json.init(aa);

--- a/src/main.zig
+++ b/src/main.zig
@@ -89,6 +89,12 @@ pub fn main() !void {
             .onion_port = tor_onion_port,
             .socks_url = tor_socks_url,
         });
+    } else if (std.mem.eql(u8, command, "create")) {
+        if (args.len < 3) {
+            log.err("usage: carl create <file-or-dir> [-o out.torrent] [-t tracker]... [--comment \"...\"] [--piece-length bytes]", .{});
+            std.process.exit(1);
+        }
+        try cmdCreate(allocator, stdout, args[2], args[3..]);
     } else if (std.mem.eql(u8, command, "search")) {
         if (args.len < 3) {
             log.err("usage: carl search <query> [--limit <n>] [--relay <url>]", .{});
@@ -126,6 +132,10 @@ fn printUsage() void {
         \\           --nostr: publish NIP-35 torrent event + peer-announce
         \\           --external-ip: public IPv4 for peer-announce (classic seeding)
         \\           --tor-seed: hidden service via Tor ControlPort; requires --nostr
+        \\  create <file-or-dir> [-o out.torrent] [-t tracker]... [--comment "..."] [--piece-length bytes]
+        \\           build a .torrent from a file or directory (multi-file).
+        \\           -t may repeat; trackers are optional (Nostr/DHT discovery).
+        \\           -o defaults to <name>.torrent in the current directory.
         \\  search <query> [--limit n] [--relay <wss://...>]
         \\           search nostr relays for kind-2003 torrent events
         \\  nostr-keygen                                     generate a fresh nostr key
@@ -544,6 +554,75 @@ fn parseTorSocksProxy(url: []const u8) carl.proxy.Proxy {
         log.err("invalid --tor-socks URL '{s}': {}", .{ url, err });
         std.process.exit(1);
     };
+}
+
+// -------------------------------------------------------------------------
+// `carl create` — build a .torrent from a file or directory
+// -------------------------------------------------------------------------
+
+fn cmdCreate(
+    allocator: std.mem.Allocator,
+    stdout: anytype,
+    path: []const u8,
+    extra: []const [:0]u8,
+) !void {
+    // Collect repeated -t / --tracker flags (parseFlag only returns the first).
+    var trackers: std.ArrayList([]const u8) = .empty;
+    defer trackers.deinit(allocator);
+    {
+        var i: usize = 0;
+        while (i + 1 < extra.len) : (i += 1) {
+            if (std.mem.eql(u8, extra[i], "-t") or std.mem.eql(u8, extra[i], "--tracker")) {
+                if (extra[i + 1].len > 0) try trackers.append(allocator, extra[i + 1]);
+            }
+        }
+    }
+    const comment = parseFlag(extra, "--comment");
+    const piece_length: u32 = parseUnsignedFlag(extra, "--piece-length", carl.metainfo.default_piece_length);
+
+    const res = carl.metainfo.buildTorrent(allocator, path, .{
+        .piece_length = piece_length,
+        .trackers = trackers.items,
+        .comment = comment,
+        .created_by = "carl",
+        .creation_date = std.time.timestamp(),
+    }) catch |err| {
+        log.err("could not create torrent from '{s}': {}", .{ path, err });
+        std.process.exit(1);
+    };
+    defer allocator.free(res.data);
+
+    // Default output: <basename>.torrent in the current directory.
+    const base = std.fs.path.basename(path);
+    const default_out = try std.fmt.allocPrint(allocator, "{s}.torrent", .{base});
+    defer allocator.free(default_out);
+    const out_path = parseFlag(extra, "-o") orelse parseFlag(extra, "--output") orelse default_out;
+
+    {
+        var f = std.fs.cwd().createFile(out_path, .{ .truncate = true }) catch |err| {
+            log.err("could not write '{s}': {}", .{ out_path, err });
+            std.process.exit(1);
+        };
+        defer f.close();
+        f.writeAll(res.data) catch |err| {
+            log.err("could not write '{s}': {}", .{ out_path, err });
+            std.process.exit(1);
+        };
+    }
+
+    try stdout.print("created:      {s}\n", .{out_path});
+    try stdout.print("name:         {s}\n", .{base});
+    try stdout.print("files:        {d}\n", .{res.file_count});
+    try stdout.print("size:         {d} bytes\n", .{res.total_length});
+    try stdout.print("piece length: {d}\n", .{piece_length});
+    if (trackers.items.len > 0) {
+        try stdout.print("trackers:     {d}\n", .{trackers.items.len});
+    } else {
+        try stdout.print("trackers:     none (Nostr/DHT discovery)\n", .{});
+    }
+    try stdout.print("info hash:    ", .{});
+    for (res.info_hash) |byte| try stdout.print("{x:0>2}", .{byte});
+    try stdout.print("\n", .{});
 }
 
 // -------------------------------------------------------------------------

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -484,7 +484,10 @@ pub const Manager = struct {
 
         self.mutex.lock();
         self.cfg.route = st.route;
-        if (st.download_dir.len > 0) {
+        // Treat "." (the bare placeholder default) as "unset" so a stale
+        // persisted "." doesn't clobber an explicit --download-dir passed on
+        // startup (e.g. the desktop shell's ~/Downloads/carl-download).
+        if (st.download_dir.len > 0 and !std.mem.eql(u8, st.download_dir, ".")) {
             if (self.allocator.dupe(u8, st.download_dir)) |d| {
                 self.allocator.free(self.cfg.download_dir);
                 self.cfg.download_dir = d;

--- a/src/metainfo.zig
+++ b/src/metainfo.zig
@@ -376,6 +376,191 @@ pub fn createSingleFile(allocator: Allocator, path: []const u8, piece_length: u3
     };
 }
 
+/// Options for building a .torrent. Trackers are optional — carl discovers
+/// peers via Nostr/DHT — but when present the first becomes `announce` and each
+/// gets its own `announce-list` tier (BEP 12).
+pub const CreateOptions = struct {
+    piece_length: u32 = default_piece_length,
+    /// Tracker announce URLs. Empty = a trackerless torrent (Nostr/DHT only).
+    trackers: []const []const u8 = &.{},
+    comment: ?[]const u8 = null,
+    created_by: ?[]const u8 = "carl",
+    /// Unix timestamp for the `creation date` field; null omits it. Pass
+    /// `std.time.timestamp()` from a caller that wants it stamped.
+    creation_date: ?i64 = null,
+};
+
+/// Result of `buildTorrent`: the bencoded .torrent bytes (owned by the caller —
+/// free with the same allocator) plus a summary of what was hashed.
+pub const CreateResult = struct {
+    data: []u8,
+    info_hash: [20]u8,
+    total_length: u64,
+    file_count: usize,
+};
+
+const FileWork = struct {
+    /// Path relative to the torrent root directory.
+    rel: []const u8,
+};
+
+fn lessByRel(_: void, a: FileWork, b: FileWork) bool {
+    return std.mem.lessThan(u8, a.rel, b.rel);
+}
+
+fn hashPiece(aa: Allocator, pieces: *std.ArrayList(u8), data: []const u8) MetainfoError!void {
+    var digest: [20]u8 = undefined;
+    std.crypto.hash.Sha1.hash(data, &digest, .{});
+    pieces.appendSlice(aa, &digest) catch return error.OutOfMemory;
+}
+
+/// Split a relative path on the OS separator into a bencode list of string
+/// components, e.g. "sub/dir/f.txt" → ["sub","dir","f.txt"]. Arena-allocated.
+fn pathComponents(aa: Allocator, rel: []const u8) MetainfoError![]bencode.Value {
+    var comps: std.ArrayList(bencode.Value) = .empty;
+    var it = std.mem.splitScalar(u8, rel, std.fs.path.sep);
+    while (it.next()) |c| {
+        if (c.len == 0) continue;
+        const dup = aa.dupe(u8, c) catch return error.OutOfMemory;
+        comps.append(aa, .{ .string = dup }) catch return error.OutOfMemory;
+    }
+    return comps.toOwnedSlice(aa) catch return error.OutOfMemory;
+}
+
+/// Build a complete .torrent from a file OR a directory and return its bencoded
+/// bytes. Directories become multi-file torrents whose pieces are hashed as one
+/// continuous stream across file boundaries (BEP 3), with files sorted by path
+/// for a deterministic, reproducible info-hash. Trackers/comment/created-by live
+/// in the top-level dict, so they never affect the info-hash. Streams every file
+/// so large inputs don't load into memory at once. Caller owns `result.data`.
+pub fn buildTorrent(allocator: Allocator, path: []const u8, opts: CreateOptions) MetainfoError!CreateResult {
+    const piece_length: u32 = if (opts.piece_length == 0) default_piece_length else opts.piece_length;
+
+    // Everything intermediate (Value tree, piece buffer, per-file dicts) lives in
+    // an arena; only the returned `data` is allocated with `allocator`.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    const base = std.fs.path.basename(path);
+    if (base.len == 0) return error.InvalidTorrent;
+    const name = aa.dupe(u8, base) catch return error.OutOfMemory;
+
+    const st = std.fs.cwd().statFile(path) catch return error.InvalidTorrent;
+
+    var pieces: std.ArrayList(u8) = .empty;
+    var total: u64 = 0;
+    var file_count: usize = 0;
+
+    const chunk = aa.alloc(u8, piece_length) catch return error.OutOfMemory;
+    var filled: usize = 0; // bytes pending in `chunk` toward the current piece
+
+    // Info-dict entries are built in sorted key order so the output re-parses
+    // (bencode requires sorted dict keys) and matches other clients' info-hash.
+    var info_entries: std.ArrayList(bencode.Value.DictEntry) = .empty;
+
+    if (st.kind == .directory) {
+        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return error.InvalidTorrent;
+        defer dir.close();
+
+        // Collect every regular file (relative to the dir), then sort for a
+        // deterministic piece layout.
+        var works: std.ArrayList(FileWork) = .empty;
+        var walker = dir.walk(aa) catch return error.OutOfMemory;
+        while (walker.next() catch return error.InvalidTorrent) |entry| {
+            if (entry.kind != .file) continue;
+            const rel = aa.dupe(u8, entry.path) catch return error.OutOfMemory;
+            works.append(aa, .{ .rel = rel }) catch return error.OutOfMemory;
+        }
+        if (works.items.len == 0) return error.InvalidTorrent; // empty directory
+        std.mem.sort(FileWork, works.items, {}, lessByRel);
+
+        // Hash all files as one continuous stream — pieces span file boundaries —
+        // while building the `files` list (each a {length, path} dict).
+        var files_list: std.ArrayList(bencode.Value) = .empty;
+        for (works.items) |w| {
+            var f = dir.openFile(w.rel, .{}) catch return error.InvalidTorrent;
+            defer f.close();
+            var flen: u64 = 0;
+            while (true) {
+                const n = f.readAll(chunk[filled..]) catch return error.InvalidTorrent;
+                if (n == 0) break;
+                filled += n;
+                total += n;
+                flen += n;
+                if (filled == piece_length) {
+                    try hashPiece(aa, &pieces, chunk);
+                    filled = 0;
+                }
+            }
+            file_count += 1;
+            const comps = try pathComponents(aa, w.rel);
+            // File dict keys sorted: "length" < "path".
+            const fd = aa.alloc(bencode.Value.DictEntry, 2) catch return error.OutOfMemory;
+            fd[0] = .{ .key = "length", .value = .{ .integer = @intCast(flen) } };
+            fd[1] = .{ .key = "path", .value = .{ .list = comps } };
+            files_list.append(aa, .{ .dict = fd }) catch return error.OutOfMemory;
+        }
+        if (filled > 0) try hashPiece(aa, &pieces, chunk[0..filled]); // final partial piece
+
+        const files_slice = files_list.toOwnedSlice(aa) catch return error.OutOfMemory;
+        // Info keys sorted: "files" < "name" < "piece length" < "pieces".
+        info_entries.append(aa, .{ .key = "files", .value = .{ .list = files_slice } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "name", .value = .{ .string = name } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "pieces", .value = .{ .string = pieces.items } }) catch return error.OutOfMemory;
+    } else {
+        var f = std.fs.cwd().openFile(path, .{}) catch return error.InvalidTorrent;
+        defer f.close();
+        while (true) {
+            const n = f.readAll(chunk[filled..]) catch return error.InvalidTorrent;
+            if (n == 0) break;
+            filled += n;
+            total += n;
+            if (filled == piece_length) {
+                try hashPiece(aa, &pieces, chunk);
+                filled = 0;
+            }
+        }
+        if (filled > 0) try hashPiece(aa, &pieces, chunk[0..filled]);
+        file_count = 1;
+        // Info keys sorted: "length" < "name" < "piece length" < "pieces".
+        info_entries.append(aa, .{ .key = "length", .value = .{ .integer = @intCast(total) } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "name", .value = .{ .string = name } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } }) catch return error.OutOfMemory;
+        info_entries.append(aa, .{ .key = "pieces", .value = .{ .string = pieces.items } }) catch return error.OutOfMemory;
+    }
+
+    const info_val = bencode.Value{ .dict = info_entries.items };
+
+    // info-hash = SHA-1 of the canonical info-dict bytes.
+    const raw_info = bencode.encode(aa, info_val) catch return error.OutOfMemory;
+    var info_hash: [20]u8 = undefined;
+    std.crypto.hash.Sha1.hash(raw_info, &info_hash, .{});
+
+    // Top-level dict, keys appended in sorted order, optional fields skipped when
+    // absent: "announce" < "announce-list" < "comment" < "created by" <
+    // "creation date" < "info".
+    var top: std.ArrayList(bencode.Value.DictEntry) = .empty;
+    if (opts.trackers.len > 0) {
+        top.append(aa, .{ .key = "announce", .value = .{ .string = opts.trackers[0] } }) catch return error.OutOfMemory;
+        const tiers = aa.alloc(bencode.Value, opts.trackers.len) catch return error.OutOfMemory;
+        for (opts.trackers, 0..) |t, i| {
+            const tier = aa.alloc(bencode.Value, 1) catch return error.OutOfMemory;
+            tier[0] = .{ .string = t };
+            tiers[i] = .{ .list = tier };
+        }
+        top.append(aa, .{ .key = "announce-list", .value = .{ .list = tiers } }) catch return error.OutOfMemory;
+    }
+    if (opts.comment) |c| top.append(aa, .{ .key = "comment", .value = .{ .string = c } }) catch return error.OutOfMemory;
+    if (opts.created_by) |cb| top.append(aa, .{ .key = "created by", .value = .{ .string = cb } }) catch return error.OutOfMemory;
+    if (opts.creation_date) |cd| top.append(aa, .{ .key = "creation date", .value = .{ .integer = cd } }) catch return error.OutOfMemory;
+    top.append(aa, .{ .key = "info", .value = info_val }) catch return error.OutOfMemory;
+
+    const data = bencode.encode(allocator, .{ .dict = top.items }) catch return error.OutOfMemory;
+    return .{ .data = data, .info_hash = info_hash, .total_length = total, .file_count = file_count };
+}
+
 // --- Tests ---
 
 test "createSingleFile: hashes a file into a valid metainfo" {
@@ -404,6 +589,106 @@ test "createSingleFile: hashes a file into a valid metainfo" {
     try std.testing.expectEqualStrings("data.bin", decoded.dictGet("name").?.asString().?);
     const ih = infoHash(mi.raw_info);
     try std.testing.expectEqual(@as(usize, 20), ih.len);
+}
+
+test "buildTorrent: single file re-parses with trackers + matching info-hash" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "data.bin", .data = "0123456789" });
+    const path = try tmp.dir.realpathAlloc(allocator, "data.bin");
+    defer allocator.free(path);
+
+    const trackers = [_][]const u8{ "http://t.example/announce", "udp://t2.example:6969" };
+    const res = try buildTorrent(allocator, path, .{
+        .piece_length = 4,
+        .trackers = &trackers,
+        .comment = "hello",
+        .created_by = "carl",
+        .creation_date = 1000,
+    });
+    defer allocator.free(res.data);
+
+    try std.testing.expectEqual(@as(u64, 10), res.total_length);
+    try std.testing.expectEqual(@as(usize, 1), res.file_count);
+
+    // The bytes must re-parse (parse rejects unsorted dict keys, so this also
+    // proves canonical key ordering throughout).
+    const mi = try parse(allocator, res.data);
+    defer mi.deinit(allocator);
+    try std.testing.expectEqualStrings("data.bin", mi.name);
+    try std.testing.expectEqualStrings("http://t.example/announce", mi.announce);
+    try std.testing.expectEqual(@as(usize, 1), mi.files.len);
+    try std.testing.expectEqual(@as(u64, 10), mi.files[0].length);
+    try std.testing.expectEqual(@as(usize, 60), mi.pieces.len); // 3 pieces × 20
+    try std.testing.expectEqualStrings("hello", mi.comment.?);
+    try std.testing.expectEqual(@as(i64, 1000), mi.creation_date.?);
+    try std.testing.expectEqualStrings("carl", mi.created_by.?);
+
+    // info-hash reported by buildTorrent matches the parsed info dict's hash.
+    const ih = infoHash(mi.raw_info);
+    try std.testing.expectEqualSlices(u8, &res.info_hash, &ih);
+}
+
+test "buildTorrent: directory hashes pieces continuously across files" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("d/sub");
+    try tmp.dir.writeFile(.{ .sub_path = "d/a.txt", .data = "AAAA" }); // 4 bytes
+    try tmp.dir.writeFile(.{ .sub_path = "d/sub/b.txt", .data = "BBBBBB" }); // 6 bytes
+    const path = try tmp.dir.realpathAlloc(allocator, "d");
+    defer allocator.free(path);
+
+    // 10 bytes total, piece_length 4 → 3 pieces; the 2nd piece spans a.txt→b.txt.
+    const res = try buildTorrent(allocator, path, .{ .piece_length = 4, .created_by = null });
+    defer allocator.free(res.data);
+
+    try std.testing.expectEqual(@as(u64, 10), res.total_length);
+    try std.testing.expectEqual(@as(usize, 2), res.file_count);
+
+    const mi = try parse(allocator, res.data);
+    defer mi.deinit(allocator);
+    try std.testing.expectEqualStrings("d", mi.name);
+    try std.testing.expectEqual(@as(usize, 60), mi.pieces.len); // 3 pieces × 20
+    try std.testing.expectEqual(@as(usize, 2), mi.files.len);
+    // Files sorted by path: "a.txt" before "sub/b.txt".
+    try std.testing.expectEqual(@as(usize, 1), mi.files[0].path.len);
+    try std.testing.expectEqualStrings("a.txt", mi.files[0].path[0]);
+    try std.testing.expectEqual(@as(u64, 4), mi.files[0].length);
+    try std.testing.expectEqual(@as(usize, 2), mi.files[1].path.len);
+    try std.testing.expectEqualStrings("sub", mi.files[1].path[0]);
+    try std.testing.expectEqualStrings("b.txt", mi.files[1].path[1]);
+    try std.testing.expectEqual(@as(u64, 6), mi.files[1].length);
+    try std.testing.expect(mi.created_by == null);
+}
+
+test "buildTorrent: trackerless single file omits announce" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(.{ .sub_path = "x.bin", .data = "abcd" });
+    const path = try tmp.dir.realpathAlloc(allocator, "x.bin");
+    defer allocator.free(path);
+
+    const res = try buildTorrent(allocator, path, .{ .piece_length = 4 });
+    defer allocator.free(res.data);
+    const mi = try parse(allocator, res.data);
+    defer mi.deinit(allocator);
+    try std.testing.expectEqualStrings("", mi.announce); // no tracker
+    try std.testing.expect(mi.announce_list == null);
+}
+
+test "buildTorrent: empty directory rejects" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("empty");
+    const path = try tmp.dir.realpathAlloc(allocator, "empty");
+    defer allocator.free(path);
+    try std.testing.expectError(error.InvalidTorrent, buildTorrent(allocator, path, .{}));
 }
 
 test "parse single-file torrent" {

--- a/src/metainfo.zig
+++ b/src/metainfo.zig
@@ -442,7 +442,12 @@ pub fn buildTorrent(allocator: Allocator, path: []const u8, opts: CreateOptions)
     defer arena.deinit();
     const aa = arena.allocator();
 
-    const base = std.fs.path.basename(path);
+    // Trim a trailing slash so a directory path "/a/b/" yields the name "b"
+    // (basename of "/a/b/" is otherwise empty).
+    const sep = [_]u8{std.fs.path.sep};
+    const trimmed_path = std.mem.trimRight(u8, path, &sep);
+    const eff_path = if (trimmed_path.len == 0) path else trimmed_path;
+    const base = std.fs.path.basename(eff_path);
     if (base.len == 0) return error.InvalidTorrent;
     const name = aa.dupe(u8, base) catch return error.OutOfMemory;
 
@@ -467,6 +472,7 @@ pub fn buildTorrent(allocator: Allocator, path: []const u8, opts: CreateOptions)
         // deterministic piece layout.
         var works: std.ArrayList(FileWork) = .empty;
         var walker = dir.walk(aa) catch return error.OutOfMemory;
+        defer walker.deinit(); // closes the dir handles the walker keeps open
         while (walker.next() catch return error.InvalidTorrent) |entry| {
             if (entry.kind != .file) continue;
             const rel = aa.dupe(u8, entry.path) catch return error.OutOfMemory;
@@ -504,11 +510,8 @@ pub fn buildTorrent(allocator: Allocator, path: []const u8, opts: CreateOptions)
         if (filled > 0) try hashPiece(aa, &pieces, chunk[0..filled]); // final partial piece
 
         const files_slice = files_list.toOwnedSlice(aa) catch return error.OutOfMemory;
-        // Info keys sorted: "files" < "name" < "piece length" < "pieces".
+        // Multi-file's unique key; "files" sorts before the shared "name" below.
         info_entries.append(aa, .{ .key = "files", .value = .{ .list = files_slice } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "name", .value = .{ .string = name } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "pieces", .value = .{ .string = pieces.items } }) catch return error.OutOfMemory;
     } else {
         var f = std.fs.cwd().openFile(path, .{}) catch return error.InvalidTorrent;
         defer f.close();
@@ -524,12 +527,15 @@ pub fn buildTorrent(allocator: Allocator, path: []const u8, opts: CreateOptions)
         }
         if (filled > 0) try hashPiece(aa, &pieces, chunk[0..filled]);
         file_count = 1;
-        // Info keys sorted: "length" < "name" < "piece length" < "pieces".
+        // Single-file's unique key; "length" sorts before the shared "name".
         info_entries.append(aa, .{ .key = "length", .value = .{ .integer = @intCast(total) } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "name", .value = .{ .string = name } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } }) catch return error.OutOfMemory;
-        info_entries.append(aa, .{ .key = "pieces", .value = .{ .string = pieces.items } }) catch return error.OutOfMemory;
     }
+
+    // Shared, sorted after the per-mode key ("files"/"length" both precede "name"):
+    // "name" < "piece length" < "pieces".
+    info_entries.append(aa, .{ .key = "name", .value = .{ .string = name } }) catch return error.OutOfMemory;
+    info_entries.append(aa, .{ .key = "piece length", .value = .{ .integer = @intCast(piece_length) } }) catch return error.OutOfMemory;
+    info_entries.append(aa, .{ .key = "pieces", .value = .{ .string = pieces.items } }) catch return error.OutOfMemory;
 
     const info_val = bencode.Value{ .dict = info_entries.items };
 
@@ -663,6 +669,26 @@ test "buildTorrent: directory hashes pieces continuously across files" {
     try std.testing.expectEqualStrings("b.txt", mi.files[1].path[1]);
     try std.testing.expectEqual(@as(u64, 6), mi.files[1].length);
     try std.testing.expect(mi.created_by == null);
+}
+
+test "buildTorrent: trailing-slash directory path yields the right name" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("md");
+    try tmp.dir.writeFile(.{ .sub_path = "md/f.txt", .data = "abcd" });
+    const base = try tmp.dir.realpathAlloc(allocator, "md");
+    defer allocator.free(base);
+    const path = try std.fmt.allocPrint(allocator, "{s}/", .{base}); // trailing slash
+    defer allocator.free(path);
+
+    const res = try buildTorrent(allocator, path, .{ .piece_length = 4 });
+    defer allocator.free(res.data);
+    const mi = try parse(allocator, res.data);
+    defer mi.deinit(allocator);
+    try std.testing.expectEqualStrings("md", mi.name); // not "" from a dangling slash
+    try std.testing.expectEqual(@as(usize, 1), mi.files.len);
+    try std.testing.expectEqualStrings("f.txt", mi.files[0].path[0]);
 }
 
 test "buildTorrent: trackerless single file omits announce" {


### PR DESCRIPTION
## What

Adds real **.torrent file creation** to carl and exposes it on every surface that reaches the daemon, plus makes the desktop app self-contained. Previously carl could only build an in-memory info dict to seed — it could not write a `.torrent`.

## Surfaces

- **CLI** — `carl create <file-or-dir> [-o out.torrent] [-t tracker]… [--comment …] [--piece-length n]`
- **Daemon HTTP** — `POST /api/torrents {path, trackers?, comment?, outPath?}` → `{path, infoHash, size, files}` (path-based: folders can't be uploaded as bytes)
- **Daemon WebSocket** — `create_torrent` command → `torrent_created` result frame
- **Desktop** — a **Create .torrent** flow (native file/folder picker via `plugin-dialog`, manual-path fallback) on the Seeding screen

## Core (`src/metainfo.zig`)

`buildTorrent(path, opts)` hashes a file **or directory** into a canonical `.torrent`:
- Directories are multi-file with pieces hashed **continuously across file boundaries** (BEP 3), files **sorted by path** for a reproducible info-hash.
- Trackers/comment/created-by/creation-date go in the **top-level** dict, never touching the info-hash.
- Streams every file; all intermediate work is arena-allocated, caller owns only the returned bytes.
- 4 unit tests; cross-validated against an independent Python bencode decoder (identical info-hashes).

## Desktop reliability (the bigger half)

A Finder-launched app gets a minimal PATH (no `~/.local/bin` or `/usr/local/bin`), so the old "resolve `carl` on `$PATH`" approach produced **daemon offline**. Fixes:

- **Bundled sidecar** — carl is bundled via `externalBin`; the shell resolves the daemon from inside the bundle (`Contents/MacOS/carl`), PATH-independent.
- **Docker-style CLI install** (Settings → Command-line tools) — **symlinks** `/usr/local/bin` (one admin prompt) or `~/.local/bin` to the bundled carl, so the CLI always tracks the app version. Replaces the earlier silent copy-on-launch. `cli_status` / `install_cli` / `uninstall_cli` commands.
- **Build staging** — `beforeBuildCommand` runs `scripts/stage-sidecar.sh` (builds ReleaseSafe carl + stages it), so a build never ships a stale daemon. The staged binary is a gitignored artifact.

## Verification

- `zig build`, `zig build test` (incl. new tests), `zig fmt --check` — clean
- Frontend `tsc` + `vite build`, `cargo check`, full `tauri build` — clean
- CLI / HTTP / WS all produce identical info-hashes; daemon spawns from the bundled sidecar under a Finder-minimal PATH; symlink-to-bundle runs the CLI with no signature kill

## Known limitations (honest)

- **arm64 only** (no universal binary) and **ad-hoc signed / un-notarized** — fine for local install, not for distribution.
- System CLI install uses `osascript … with administrator privileges` (Homebrew-cask style), **not** a persistent privileged helper (which needs Developer ID + notarization). It prompts per install/remove.
- The in-app button click and the system-mode password dialog weren't exercised headlessly (GUI auth); the symlink logic and command wiring are compile-checked and the underlying symlink is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)