### PR TITLE
feat: I2P transport (native SAM v3) — outbound, behind Route.i2p (#35)

### DIFF
--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -1,6 +1,6 @@
 // Mirrors the carl daemon JSON contract (docs/daemon-api.md).
 
-export type Route = "direct" | "proxy" | "tor";
+export type Route = "direct" | "proxy" | "tor" | "i2p";
 export type Status =
   | "downloading"
   | "seeding"

--- a/desktop/src/components/atoms.tsx
+++ b/desktop/src/components/atoms.tsx
@@ -7,6 +7,7 @@ const ROUTE_META: Record<Route, { label: string; cls: string; icon: string }> = 
   direct: { label: "clearnet", cls: "rt-clearnet", icon: "globe" },
   proxy: { label: "proxied", cls: "rt-proxy", icon: "shield" },
   tor: { label: "tor", cls: "rt-tor", icon: "onion" },
+  i2p: { label: "i2p", cls: "rt-tor", icon: "onion" },
 };
 
 export function RouteBadge({

--- a/desktop/src/screens/Seeding.tsx
+++ b/desktop/src/screens/Seeding.tsx
@@ -10,6 +10,7 @@ const VIS_LABEL: Record<Route, string> = {
   direct: "Public IP",
   proxy: "Proxy",
   tor: "Tor hidden service",
+  i2p: "I2P destination",
 };
 
 function OnionCallout({ onion, relays }: { onion: string; relays: number }) {
@@ -91,6 +92,7 @@ const VIS_DESC: Record<Route, string> = {
   direct: "Announced to peers over your IP.",
   proxy: "Outbound via SOCKS5. Trackers/DHT disabled; peers via Nostr.",
   tor: "Routed through Tor. No clearnet IP exposed.",
+  i2p: "Native I2P (SAM v3). No clearnet IP exposed; peers via Nostr.",
 };
 
 function SeedFlow({ onClose }: { onClose: () => void }) {

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -193,6 +193,12 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
   );
 }
 
+// Routes the GUI can select as its global anonymity setting. I2P is deliberately
+// absent: desktop downloads are Tor-only (see AddModal/Discover) and i2p seeding
+// is rejected by the daemon, so selecting i2p here would have no usable effect.
+// I2P is a daemon/CLI route (`carl daemon --route i2p`, see docs/i2p.md); the
+// Route type, ROUTE_META, badges and VIS_LABEL still carry i2p so a transfer
+// surfaced by a CLI-run daemon renders correctly.
 const ROUTES: [Route, string, string, string][] = [
   ["direct", "Direct", "Connect straight to peers. Fastest, no privacy.", "globe"],
   ["proxy", "SOCKS5 proxy", "Tunnel all traffic through a SOCKS5 proxy.", "shield"],

--- a/docs/brainstorms/2026-06-08-i2p-transport-sam.md
+++ b/docs/brainstorms/2026-06-08-i2p-transport-sam.md
@@ -1,0 +1,99 @@
+# I2P transport support (native SAM v3) — issue #35
+
+## Clarified Problem Statement
+
+**Goal:** Add I2P as a first-class transport (`Route.i2p`) via a native SAM v3
+bridge — carl dials and accepts BitTorrent peers as `.b32.i2p` destinations,
+seeds under a stable destination, and discovers peers via both carl's nostr
+layer and I2P-native trackers/DHT — without disturbing the direct/proxy/tor
+paths.
+
+Decisions (from brainstorm):
+- Scope: **full native SAM v3** (not a SOCKS shim, not docs-only).
+- Transport: **native SAM v3 module**.
+- Discovery: **I2P-native (trackers/DHT) in scope**, alongside nostr.
+- Route surface: **new `i2p` route**.
+
+**Constraints:**
+- Must not regress `direct` / `proxy` / `tor`. SAM is additive.
+- Requires a running I2P router (i2pd or Java I2P) with the SAM bridge enabled
+  (default `127.0.0.1:7656`) — a documented prerequisite, like "Tor must run."
+- I2P peers have no IP:port — they're destinations + a virtual stream port.
+  Needs an `Endpoint.i2p` type; `PeerConnection.connect_host` (the hostname slot
+  used today for `.onion`) can carry the `.b32.i2p`, with a new connect branch
+  that calls SAM instead of SOCKS.
+- A persistent destination key (stable `.b32.i2p` across restarts for
+  seeding/discovery), stored in the config dir like the nostr `nsec` / Tor key.
+- Zig 0.15, blocking-socket style matching `src/proxy.zig` / `src/ws.zig`.
+
+**Non-goals:** I2P outproxy (I2P→clearnet); datagram/µTP over I2P (BT uses I2P
+streaming = TCP-like); replacing nostr discovery; a SOCKS-to-I2P shim.
+
+**Success criteria:**
+- Leech a torrent from another carl I2P peer over native SAM (no SOCKS), peer
+  dialed by `.b32.i2p`.
+- Seed: stable `.b32.i2p`, accepts inbound SAM streams, announces its
+  destination over nostr.
+- I2P tracker announce works (HTTP-over-SAM to a `.i2p` tracker); peers found
+  via I2P DHT.
+- `--route i2p` selectable end-to-end; the other three routes unchanged.
+- `docs/proxy.md` documents Tor-vs-I2P; a `docs/i2p.md` covers setup/usage.
+
+## Approaches Considered
+
+### Approach A: Vertical slice first, then widen — phased native SAM (recommended)
+- Sketch: native SAM in reviewable phases behind the new route.
+  - P1: `src/i2p_sam.zig` (session + `STREAM CONNECT`) + `Endpoint.i2p` + dial
+    nostr-announced `.b32.i2p` peers → working leech over SAM.
+  - P2: persistent destination + `STREAM FORWARD` inbound + announce our
+    `.b32.i2p` → seeding.
+  - P3: I2P trackers (HTTP-over-SAM announce).
+  - P4: I2P DHT (spin to its own issue — largest/riskiest piece).
+- Affected: new `src/i2p_sam.zig`; `src/peer.zig` (third connect branch);
+  `src/session.zig` (accept loop + I2P tracker dial); `src/api.zig`
+  (`Route.i2p`); `src/peer_announce.zig` (i2p endpoint); `src/manager.zig` +
+  `src/main.zig` (flags/threading); `src/nostr_config.zig` (persist i2p key);
+  `docs/proxy.md`, `docs/i2p.md`.
+- Tradeoffs: proves the SAM protocol end-to-end before the expensive parts;
+  small PRs. Cost: the route is leech-only for a while; DHT lands last.
+- Effort: L (multi-PR)
+
+### Approach B: Transport-interface refactor, then SAM behind it
+- Sketch: introduce a `Transport` seam (`dial(dest)→stream`, `listen()→stream`)
+  abstracting direct/SOCKS/Tor and unifying today's `.onion` special-casing,
+  then implement SAM as a second backend.
+- Tradeoffs: cleanest long-term; pays down onion special-casing debt — but
+  refactors the working Tor path (regression risk) for upfront architecture.
+- Effort: L+
+
+### Approach C: Big-bang full native in one branch
+- Sketch: SAM outbound + inbound + destination + I2P trackers + I2P DHT + route
+  in one PR.
+- Tradeoffs: matches "full" literally, but huge review surface; I2P DHT alone is
+  a multi-week subproject that would block everything.
+- Effort: XL
+
+## Recommendation
+
+**Approach A.** Delivers the full native-SAM target, sequenced so the first PR
+is a working outbound leech over SAM (validating the protocol and the
+`Endpoint.i2p`/route plumbing) before the costly inbound, tracker, and DHT
+phases. **I2P DHT should be its own phase/issue** — it's the largest/riskiest
+piece, and carl's nostr peer-announce already yields a working I2P swarm among
+carl users without it (DHT mainly buys interop with the i2psnark/postman
+ecosystem). Start P1 now; spin DHT off.
+
+## Open questions
+- Destination persistence: persisted key in the config dir (reuse the nostr
+  config-dir convention) — yes, persisted (needed for seeding/discovery).
+- I2P DHT: spin off to its own issue (recommended).
+- Router assumption: target the SAM bridge generically (i2pd and Java I2P),
+  router-agnostic.
+- Virtual stream port convention for BT-over-I2P (i2psnark conventions) —
+  confirm during P1.
+
+## Implementation note (this environment)
+No I2P router is installed on the dev host, so the SAM client is verified with
+in-process mock-SAM-server unit tests (handshake + STREAM CONNECT byte-level
+assertions and reply parsing). Full swarm interop requires a running router and
+is documented as a manual test procedure in `docs/i2p.md`.

--- a/docs/i2p.md
+++ b/docs/i2p.md
@@ -1,0 +1,144 @@
+# Using carl over I2P
+
+carl can route BitTorrent transport over **I2P**, a peer-to-peer anonymity
+network purpose-built for P2P traffic. Unlike Tor — which is discouraged for
+BitTorrent (slow, hard on the Tor network, leak-prone if misconfigured) — I2P
+is designed for swarms and has a mature torrenting ecosystem.
+
+Peers are addressed by **`.b32.i2p` destinations** (not IP:port). carl speaks
+**SAM v3** to a local I2P router and dials each peer as a destination, the same
+way the Tor path dials `.onion` hostnames.
+
+> **Status (P1):** this is the first slice — **outbound** connections (leeching)
+> over native SAM. Seeding (inbound), I2P trackers, and the I2P DHT are tracked
+> follow-ups (see issue #35). Today, peers are discovered via carl's Nostr
+> peer-announce layer (a `.b32.i2p` destination is carried like a `.onion` host).
+
+## Prerequisites: a running I2P router with SAM
+
+carl does **not** embed an I2P router; it connects to the SAM bridge of one you
+run, exactly like the Tor path expects a running Tor daemon.
+
+### i2pd (recommended, lightweight C++)
+
+```sh
+# macOS
+brew install i2pd
+
+# Enable the SAM bridge in i2pd.conf (usually ~/.i2pd/i2pd.conf or
+# /opt/homebrew/etc/i2pd/i2pd.conf):
+[sam]
+enabled = true
+address = 127.0.0.1
+port = 7656
+
+i2pd            # start the router
+```
+
+### Java I2P
+
+In the router console (http://127.0.0.1:7657) → **I2P Internals → Clients**,
+ensure the **SAM application bridge** is enabled and set to start. It listens on
+`127.0.0.1:7656` by default.
+
+Give the router a few minutes after first start to integrate into the network
+before expecting connections.
+
+Verify the bridge is reachable:
+
+```sh
+nc -z 127.0.0.1 7656 && echo "SAM bridge up"
+```
+
+## Running carl on the I2P route
+
+The I2P transport is a daemon **route** (like `direct` / `proxy` / `tor`):
+
+```sh
+carl daemon --route i2p --i2p-sam 127.0.0.1:7656
+```
+
+- `--route i2p` makes the daemon dial peers over native I2P (SAM v3).
+- `--i2p-sam host:port` points at your router's SAM bridge
+  (default `127.0.0.1:7656`; you may also write `sam://127.0.0.1:7656`).
+
+The I2P route is **daemon/CLI-only** for now. The desktop app keeps downloads on
+Tor (its route picker omits I2P, and it has no SAM-bridge setting), so use
+`carl daemon --route i2p --i2p-sam …` as above; a desktop I2P workflow is a
+follow-up (see issue #35).
+
+When the I2P route is active, the **BitTorrent transport fails closed** the same
+way the proxy/Tor routes do: clearnet DHT, UDP/HTTP trackers, web seeds, and the
+inbound listener are all disabled, so no swarm traffic bypasses I2P. **One
+caveat:** Nostr peer discovery — the only way to find `.b32.i2p` peers today —
+still queries relays over **clearnet**, so a relay sees your IP and the
+info-hashes you look up. See *Known limitations* below; for relay privacy run
+discovery on the `tor`/`proxy` route.
+
+## How it works (SAM v3)
+
+1. **Session** — carl opens a control connection to the SAM bridge, performs the
+   `HELLO` version handshake, and `SESSION CREATE STYLE=STREAM` to get its own
+   I2P destination. The control connection is held open for the transfer's
+   lifetime (closing it tears the session down).
+2. **Dial** — for each peer, carl opens a fresh socket to the bridge, does
+   `HELLO` + `STREAM CONNECT` to the peer's `.b32.i2p` destination; on
+   `RESULT=OK` the socket becomes a transparent bidirectional stream and the
+   normal BitTorrent handshake runs over it.
+
+See `src/i2p_sam.zig` for the implementation.
+
+## Tor vs I2P (which to use)
+
+| | Tor (`--route tor`) | I2P (`--route i2p`) |
+|---|---|---|
+| Built for | general anonymity / browsing | peer-to-peer / file sharing |
+| BitTorrent fit | discouraged (slow, strains the network) | purpose-built |
+| Addressing | `.onion` (v3) | `.b32.i2p` destination |
+| carl transport | SOCKS5h proxy (`--socks`) | native SAM v3 (`--i2p-sam`) |
+| Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | follow-up (P2) |
+
+Either way, carl's **discovery layer is the same** — signed NIP-35 / kind-30078
+events over Nostr — so the privacy network you pick is independent of how you
+find torrents.
+
+## Verifying end to end (manual)
+
+CI cannot run a live I2P router, so swarm interop is verified manually:
+
+1. Start a router with SAM enabled on two hosts (or two routers locally).
+2. On host A, seed a torrent over I2P (P2) — or use any existing `.b32.i2p`
+   peer — and publish/obtain its destination.
+3. On host B: `carl daemon --route i2p`, add the magnet, and confirm carl dials
+   the `.b32.i2p` peer and the transfer makes progress.
+
+If the SAM bridge is unreachable, adding an I2P transfer fails fast with a clear
+error (the daemon stays up); check that your router is running and the
+`--i2p-sam` address matches its SAM port.
+
+## Known limitations (P1)
+
+- **Outbound/leech only.** Seeding over I2P (inbound `STREAM FORWARD` + a stable,
+  persisted destination) is a follow-up; today the i2p route downloads, dialing
+  peers discovered via Nostr.
+- **Nostr relays are not yet routed over I2P.** On the i2p route, relay traffic
+  is clearnet (the same as the transfer side), so a relay sees your IP and the
+  info-hashes you query. Routing Nostr over I2P is a follow-up. If you need relay
+  privacy today, run the daemon on the `tor`/`proxy` route for discovery.
+- **The SAM control connection has no keepalive/reconnect.** If the I2P router
+  drops the idle session, subsequent peer dials fail until the transfer is
+  re-added (restart the transfer). Auto-reconnect is a follow-up.
+- **IPv4 SAM bridge only.** carl connects to the SAM bridge over IPv4; point
+  `--i2p-sam` at an IPv4 address (e.g. `127.0.0.1:7656`).
+- **No I2P trackers / I2P DHT yet** — peer discovery is via Nostr peer-announce
+  (`.b32.i2p` carried like a `.onion` host). I2P-native discovery is tracked
+  separately.
+
+## Troubleshooting
+
+- **"failed to add transfer" / SessionInitFailed** — the SAM bridge isn't
+  reachable. Confirm the router is running and SAM is enabled on the configured
+  address/port.
+- **No peers** — give the router time to integrate; confirm the peer's
+  `.b32.i2p` destination is reachable (I2P addresses can take time to resolve on
+  first use).

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -244,3 +244,20 @@ Optional flags: `--tor-control host:port`, `--tor-cookie path`,
 - **IPv4 only** -- consistent with the rest of carl.
 - **Connects are blocking** -- each proxied peer handshake runs synchronously
   (up to ~10s), so a batch of unreachable peers can briefly stall progress.
+
+## Tor vs I2P for BitTorrent
+
+The `--proxy`/Tor path tunnels over SOCKS5/SOCKS5h/HTTP. carl also supports
+**I2P** as a separate transport route (`--route i2p`, native SAM v3), which is
+purpose-built for P2P and avoids the Tor-over-BitTorrent baggage (Tor is slow
+for swarms, strains the network, and is leak-prone if misconfigured).
+
+| | Tor / `--proxy` | I2P (`--route i2p`) |
+|---|---|---|
+| Built for | general anonymity | peer-to-peer / file sharing |
+| BitTorrent fit | discouraged | purpose-built |
+| Addressing | `.onion` (v3) | `.b32.i2p` destination |
+| carl transport | SOCKS5h (`--proxy`/`--socks`) | native SAM v3 (`--i2p-sam`) |
+
+carl's discovery (signed NIP-35 / kind-30078 over Nostr) is the same on either
+network. See [i2p.md](i2p.md) for I2P setup and usage.

--- a/src/api.zig
+++ b/src/api.zig
@@ -18,6 +18,8 @@ pub const Route = enum {
     direct,
     proxy,
     tor,
+    /// Native I2P transport via the SAM v3 bridge (see src/i2p_sam.zig).
+    i2p,
 
     pub fn jsonName(self: Route) []const u8 {
         return @tagName(self);
@@ -25,6 +27,14 @@ pub const Route = enum {
 
     pub fn parse(s: []const u8) ?Route {
         return std.meta.stringToEnum(Route, s);
+    }
+
+    /// True when this route tunnels TCP through the configured SOCKS endpoint.
+    /// `direct` doesn't tunnel at all; `i2p` uses the SAM bridge, not SOCKS, so
+    /// SOCKS health/probing and relay-over-SOCKS logic must skip it too — a
+    /// single gate keeps every call site in lockstep.
+    pub fn usesSocks(self: Route) bool {
+        return self == .proxy or self == .tor;
     }
 };
 

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -156,7 +156,10 @@ pub const Daemon = struct {
         const raw = self.manager.cfg.socks;
         const rbuf = try arena.alloc(u8, raw.len + 4);
         const endpoint = try arena.dupe(u8, proxy_mod.redactUrl(raw, rbuf));
-        if (self.manager.cfg.route == .direct)
+        // direct doesn't use the SOCKS endpoint and neither does i2p (SAM
+        // bridge): reporting SOCKS state on those routes would show a bogus
+        // proxy error in the GUI.
+        if (!self.manager.cfg.route.usesSocks())
             return .{ .state = "disabled", .endpoint = endpoint };
 
         self.health_mutex.lock();
@@ -179,11 +182,12 @@ pub const Daemon = struct {
     /// Probe the SOCKS proxy once (proxy/tor route only) and cache the result.
     /// Never opens an upstream connection (greeting only) — see classifySocks5.
     fn probeProxy(self: *Daemon) void {
-        if (self.manager.cfg.route == .direct) {
+        if (!self.manager.cfg.route.usesSocks()) {
             // Don't fabricate an "ok": mark unprobed so that if the route later
             // switches to proxy/tor, the snapshot shows an honest "checking"
             // until a real probe lands (rather than a stale/false "ok"). The
-            // direct route is reported as "disabled" by the snapshot regardless.
+            // direct and i2p routes are reported as "disabled" by the snapshot
+            // regardless (i2p talks to the SAM bridge, not the SOCKS endpoint).
             self.health_mutex.lock();
             self.proxy_probed = false;
             self.health_mutex.unlock();
@@ -233,7 +237,10 @@ pub const Daemon = struct {
         defer nostr_config.freeRelays(a, urls);
 
         var proxy: ?proxy_mod.Proxy = null;
-        if (self.manager.cfg.route != .direct) {
+        // Only proxy/Tor route relay traffic through the SOCKS endpoint. The i2p
+        // route's `socks` is irrelevant (SAM, not SOCKS); routing relays over it
+        // would (wrongly) require Tor. Nostr-over-I2P is a follow-up.
+        if (self.manager.cfg.route.usesSocks()) {
             proxy = proxy_mod.parseUrl(self.manager.cfg.socks) catch null;
         }
 
@@ -974,9 +981,11 @@ fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
     const health = daemon.healthSnapshot(arena) catch &.{};
 
     // Match the route the manager is configured for, so search over Tor/proxy
-    // doesn't leak the real IP.
+    // doesn't leak the real IP. The i2p route's `socks` is a SAM endpoint, not a
+    // SOCKS proxy, so don't route relay search through it (Nostr-over-I2P is a
+    // follow-up; until then i2p relay search is clearnet like the transfer side).
     var proxy: ?proxy_mod.Proxy = null;
-    if (daemon.manager.cfg.route != .direct) {
+    if (daemon.manager.cfg.route.usesSocks()) {
         proxy = proxy_mod.parseUrl(daemon.manager.cfg.socks) catch null;
     }
 

--- a/src/i2p_sam.zig
+++ b/src/i2p_sam.zig
@@ -1,0 +1,456 @@
+//! Native I2P transport via the SAM v3 bridge.
+//!
+//! I2P exposes a local "Simple Anonymous Messaging" (SAM) bridge — a TCP control
+//! protocol (default 127.0.0.1:7656) — through which an application creates a
+//! session (its own I2P destination) and opens streams to remote `.b32.i2p`
+//! destinations. This is the I2P analog of carl's Tor path: instead of a SOCKS5h
+//! proxy plus an onion hostname, we speak SAM v3 and dial destinations.
+//!
+//! SAM v3 model implemented here:
+//!   1. A long-lived CONTROL connection: `HELLO` + `SESSION CREATE` keeps the
+//!      I2P session (our destination) alive for as long as the socket is open.
+//!   2. Per-stream connections: each outbound peer gets a FRESH socket that does
+//!      `HELLO` + `STREAM CONNECT` (referencing the session id); on `RESULT=OK`
+//!      the socket becomes a transparent bidirectional stream to the peer, ready
+//!      for the BitTorrent handshake — the same "connected stream" contract as
+//!      `proxy.zig`.
+//!
+//! Inbound (`STREAM ACCEPT`/`FORWARD` for seeding), I2P trackers, and I2P DHT
+//! are follow-up phases; this module covers session setup + outbound dial.
+//!
+//! Requires a running I2P router (i2pd or Java I2P) with the SAM bridge enabled.
+//! See docs/i2p.md. The handshake is synchronous and blocking (bounded by
+//! SO_SNDTIMEO/SO_RCVTIMEO), matching proxy.zig.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const posix = std.posix;
+
+const log = std.log.scoped(.i2p);
+
+pub const SamError = error{
+    InvalidBridgeUrl,
+    SocketFailed,
+    ConnectFailed,
+    HandshakeFailed,
+    SessionFailed,
+    StreamFailed,
+    InvalidResponse,
+    OutOfMemory,
+};
+
+pub const default_host = "127.0.0.1";
+pub const default_port: u16 = 7656;
+
+/// SAM bridge location. `host` borrows from the URL buffer passed to parseUrl.
+pub const Bridge = struct {
+    host: []const u8 = default_host,
+    port: u16 = default_port,
+};
+
+/// SAM streams traverse multi-hop I2P tunnels; setup is slow, so give the
+/// control + connect operations a generous timeout.
+const timeout_secs: u32 = 60;
+
+/// Parse a SAM bridge address: `sam://host:port`, `host:port`, or `host`
+/// (defaulting the port). Borrows `host` from `url`.
+pub fn parseUrl(url: []const u8) SamError!Bridge {
+    var rest = url;
+    if (std.mem.indexOf(u8, rest, "://")) |idx| {
+        if (!std.mem.eql(u8, rest[0..idx], "sam")) return error.InvalidBridgeUrl;
+        rest = rest[idx + 3 ..];
+    }
+    // Strip any trailing path.
+    rest = rest[0 .. std.mem.indexOfScalar(u8, rest, '/') orelse rest.len];
+    if (rest.len == 0) return error.InvalidBridgeUrl;
+    if (std.mem.lastIndexOfScalar(u8, rest, ':')) |colon| {
+        const host = rest[0..colon];
+        if (host.len == 0) return error.InvalidBridgeUrl;
+        const port = std.fmt.parseUnsigned(u16, rest[colon + 1 ..], 10) catch
+            return error.InvalidBridgeUrl;
+        return .{ .host = host, .port = port };
+    }
+    return .{ .host = rest, .port = default_port };
+}
+
+// --- low-level socket helpers (blocking, bounded; mirrors proxy.zig) ---
+
+fn dial(allocator: Allocator, bridge: Bridge) SamError!std.net.Stream {
+    const list = std.net.getAddressList(allocator, bridge.host, bridge.port) catch
+        return error.ConnectFailed;
+    defer list.deinit();
+    var target: ?std.net.Address = null;
+    for (list.addrs) |a| {
+        if (a.any.family == posix.AF.INET) {
+            target = a;
+            break;
+        }
+    }
+    const addr = target orelse return error.ConnectFailed;
+
+    const sock = posix.socket(
+        posix.AF.INET,
+        posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
+        posix.IPPROTO.TCP,
+    ) catch return error.SocketFailed;
+    errdefer posix.close(sock);
+
+    const tv = posix.timeval{ .sec = @intCast(timeout_secs), .usec = 0 };
+    posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch {};
+    posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+    posix.connect(sock, &addr.any, addr.getOsSockLen()) catch return error.ConnectFailed;
+    return std.net.Stream{ .handle = sock };
+}
+
+fn writeAll(stream: std.net.Stream, bytes: []const u8) SamError!void {
+    var off: usize = 0;
+    while (off < bytes.len) {
+        const n = stream.write(bytes[off..]) catch return error.HandshakeFailed;
+        if (n == 0) return error.HandshakeFailed;
+        off += n;
+    }
+}
+
+/// Read a single newline-terminated SAM reply line into `buf` (without the
+/// trailing CR/LF). Reads one byte at a time so we never consume past the line
+/// into the subsequent data stream. Errors if the line exceeds `buf`.
+fn readLine(stream: std.net.Stream, buf: []u8) SamError![]u8 {
+    var i: usize = 0;
+    while (true) {
+        if (i >= buf.len) return error.InvalidResponse;
+        var b: [1]u8 = undefined;
+        const n = stream.read(&b) catch return error.HandshakeFailed;
+        if (n == 0) return error.HandshakeFailed; // EOF before newline
+        if (b[0] == '\n') break;
+        buf[i] = b[0];
+        i += 1;
+    }
+    if (i > 0 and buf[i - 1] == '\r') i -= 1;
+    return buf[0..i];
+}
+
+// --- SAM reply parsing (pure; unit-tested) ---
+
+/// Value of a `KEY=VALUE` token in a SAM line (everything after the first '=',
+/// so base64 values with '=' padding survive). Null if the key isn't present.
+pub fn samField(line: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.tokenizeScalar(u8, line, ' ');
+    while (it.next()) |tok| {
+        const eq = std.mem.indexOfScalar(u8, tok, '=') orelse continue;
+        if (std.mem.eql(u8, tok[0..eq], key)) return tok[eq + 1 ..];
+    }
+    return null;
+}
+
+/// True if the line carries `RESULT=OK`.
+pub fn samOk(line: []const u8) bool {
+    const r = samField(line, "RESULT") orelse return false;
+    return std.mem.eql(u8, r, "OK");
+}
+
+/// A negotiated SAM protocol version (`major.minor`). Used to gate features that
+/// only exist in newer SAM revisions (e.g. `TO_PORT`, SAM 3.2+).
+pub const Version = struct {
+    major: u16,
+    minor: u16,
+
+    pub fn atLeast(self: Version, major: u16, minor: u16) bool {
+        if (self.major != major) return self.major > major;
+        return self.minor >= minor;
+    }
+};
+
+/// Parse a SAM `VERSION` value like `3.2`. Anything malformed/missing parses as
+/// `0.0`, which compares older than every real version (so version-gated
+/// features stay disabled rather than being assumed available).
+pub fn parseVersion(s: []const u8) Version {
+    var it = std.mem.splitScalar(u8, s, '.');
+    const major = std.fmt.parseUnsigned(u16, it.first(), 10) catch return .{ .major = 0, .minor = 0 };
+    const minor = std.fmt.parseUnsigned(u16, it.next() orelse "0", 10) catch 0;
+    return .{ .major = major, .minor = minor };
+}
+
+/// Perform the SAM `HELLO` version handshake and return the version the bridge
+/// negotiated (the highest within our MIN..MAX it supports).
+fn hello(stream: std.net.Stream) SamError!Version {
+    try writeAll(stream, "HELLO VERSION MIN=3.0 MAX=3.3\n");
+    var buf: [256]u8 = undefined;
+    const line = try readLine(stream, &buf);
+    if (!std.mem.startsWith(u8, line, "HELLO REPLY") or !samOk(line))
+        return error.HandshakeFailed;
+    // A 3.x bridge always echoes VERSION; default to 3.0 if it somehow doesn't.
+    return parseVersion(samField(line, "VERSION") orelse "3.0");
+}
+
+// --- public API ---
+
+/// A live SAM STREAM session. Owns the control connection that keeps the I2P
+/// session (and our destination) alive — closing it tears the session down.
+pub const Session = struct {
+    allocator: Allocator,
+    bridge: Bridge,
+    id: []u8,
+    /// Our private destination (base64). Kept for P2 (seeding/announce); the
+    /// public `.b32.i2p` address is derived from it in a later phase.
+    destination: []u8,
+    control: std.net.Stream,
+
+    /// Create a SAM STREAM session with a transient destination. `id_prefix` is
+    /// a human label; a random suffix makes the SAM session id unique.
+    pub fn create(allocator: Allocator, bridge: Bridge, id_prefix: []const u8) SamError!Session {
+        var control = try dial(allocator, bridge);
+        errdefer control.close();
+        _ = try hello(control); // control connection sends no version-gated commands
+
+        var rnd: [4]u8 = undefined;
+        std.crypto.random.bytes(&rnd);
+        const suffix = std.mem.readInt(u32, &rnd, .little);
+        const id = std.fmt.allocPrint(allocator, "{s}-{x:0>8}", .{ id_prefix, suffix }) catch
+            return error.OutOfMemory;
+        errdefer allocator.free(id);
+
+        const cmd = std.fmt.allocPrint(
+            allocator,
+            "SESSION CREATE STYLE=STREAM ID={s} DESTINATION=TRANSIENT\n",
+            .{id},
+        ) catch return error.OutOfMemory;
+        defer allocator.free(cmd);
+        try writeAll(control, cmd);
+
+        var buf: [4096]u8 = undefined; // destination keys are long
+        const line = try readLine(control, &buf);
+        if (!std.mem.startsWith(u8, line, "SESSION STATUS") or !samOk(line))
+            return error.SessionFailed;
+        const dest_b64 = samField(line, "DESTINATION") orelse return error.SessionFailed;
+        const destination = allocator.dupe(u8, dest_b64) catch return error.OutOfMemory;
+
+        return .{
+            .allocator = allocator,
+            .bridge = bridge,
+            .id = id,
+            .destination = destination,
+            .control = control,
+        };
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.control.close();
+        self.allocator.free(self.id);
+        self.allocator.free(self.destination);
+    }
+
+    /// Open a stream to a remote destination (`*.b32.i2p` or a full base64
+    /// destination). Returns a connected stream ready for the BitTorrent
+    /// handshake. A fresh socket per stream (SAM v3), referencing this session.
+    ///
+    /// `port` is the I2CP destination port the peer advertised (BitTorrent peer
+    /// announces carry one). A destination can multiplex services by port, so a
+    /// non-zero port is passed through as `TO_PORT` — but only when the bridge
+    /// negotiated **SAM 3.2+**, which introduced `TO_PORT`. Sending it to a
+    /// 3.0/3.1 bridge can have the CONNECT rejected, so on older bridges we omit
+    /// it and dial the destination's default port (best effort). `port == 0`
+    /// always omits it.
+    pub fn connect(self: *Session, dest: []const u8, port: u16) SamError!std.net.Stream {
+        var stream = try dial(self.allocator, self.bridge);
+        errdefer stream.close();
+        const ver = try hello(stream);
+
+        const cmd = if (port != 0 and ver.atLeast(3, 2))
+            std.fmt.allocPrint(
+                self.allocator,
+                "STREAM CONNECT ID={s} DESTINATION={s} TO_PORT={d} SILENT=false\n",
+                .{ self.id, dest, port },
+            )
+        else
+            std.fmt.allocPrint(
+                self.allocator,
+                "STREAM CONNECT ID={s} DESTINATION={s} SILENT=false\n",
+                .{ self.id, dest },
+            );
+        const cmd_buf = cmd catch return error.OutOfMemory;
+        defer self.allocator.free(cmd_buf);
+        try writeAll(stream, cmd_buf);
+
+        var buf: [512]u8 = undefined;
+        const line = try readLine(stream, &buf);
+        if (!std.mem.startsWith(u8, line, "STREAM STATUS") or !samOk(line))
+            return error.StreamFailed;
+        // On RESULT=OK the rest of the socket is the bidirectional peer stream.
+        return stream;
+    }
+};
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "i2p_sam: samField extracts values incl. base64 padding" {
+    try testing.expectEqualStrings("OK", samField("STREAM STATUS RESULT=OK", "RESULT").?);
+    try testing.expectEqualStrings(
+        "3.1",
+        samField("HELLO REPLY RESULT=OK VERSION=3.1", "VERSION").?,
+    );
+    // base64 value with '=' padding must survive (split on first '=' only).
+    try testing.expectEqualStrings(
+        "ZmFrZQ==",
+        samField("SESSION STATUS RESULT=OK DESTINATION=ZmFrZQ==", "DESTINATION").?,
+    );
+    try testing.expect(samField("HELLO REPLY RESULT=OK", "MISSING") == null);
+}
+
+test "i2p_sam: samOk" {
+    try testing.expect(samOk("HELLO REPLY RESULT=OK VERSION=3.1"));
+    try testing.expect(!samOk("STREAM STATUS RESULT=CANT_REACH_PEER"));
+    try testing.expect(!samOk("STREAM STATUS")); // no RESULT
+}
+
+test "i2p_sam: parseUrl forms" {
+    const a = try parseUrl("sam://127.0.0.1:7656");
+    try testing.expectEqualStrings("127.0.0.1", a.host);
+    try testing.expectEqual(@as(u16, 7656), a.port);
+
+    const b = try parseUrl("10.0.0.5:2600");
+    try testing.expectEqualStrings("10.0.0.5", b.host);
+    try testing.expectEqual(@as(u16, 2600), b.port);
+
+    const c = try parseUrl("127.0.0.1"); // bare host → default port
+    try testing.expectEqual(default_port, c.port);
+
+    try testing.expectError(error.InvalidBridgeUrl, parseUrl("socks5://x:1"));
+    try testing.expectError(error.InvalidBridgeUrl, parseUrl("sam://:7656"));
+    try testing.expectError(error.InvalidBridgeUrl, parseUrl(""));
+}
+
+// --- mock SAM bridge: exercises the real wire format end-to-end ---
+
+fn mockHandleConn(stream: std.net.Stream, version: []const u8) void {
+    defer stream.close();
+    var buf: [4096]u8 = undefined;
+    _ = readLine(stream, &buf) catch return; // HELLO VERSION
+    var hbuf: [64]u8 = undefined;
+    const hello_reply = std.fmt.bufPrint(&hbuf, "HELLO REPLY RESULT=OK VERSION={s}\n", .{version}) catch return;
+    writeAll(stream, hello_reply) catch return;
+    const cmd = readLine(stream, &buf) catch return;
+    if (std.mem.startsWith(u8, cmd, "SESSION CREATE")) {
+        writeAll(stream, "SESSION STATUS RESULT=OK DESTINATION=ZmFrZWRlc3Q=\n") catch return;
+    } else if (std.mem.startsWith(u8, cmd, "STREAM CONNECT")) {
+        // Reject any destination containing "bad" to exercise the error path.
+        if (std.mem.indexOf(u8, cmd, "bad") != null) {
+            writeAll(stream, "STREAM STATUS RESULT=CANT_REACH_PEER\n") catch return;
+        } else {
+            // The success-path tests dial with a non-zero port. TO_PORT is SAM
+            // 3.2+, so it must appear on the wire iff the negotiated version is
+            // >= 3.2. Assert both directions by failing closed on a mismatch.
+            const has_to_port = std.mem.indexOf(u8, cmd, "TO_PORT=6881") != null;
+            const want_to_port = parseVersion(version).atLeast(3, 2);
+            if (has_to_port != want_to_port) {
+                writeAll(stream, "STREAM STATUS RESULT=I2P_ERROR\n") catch return;
+                return;
+            }
+            writeAll(stream, "STREAM STATUS RESULT=OK\n") catch return;
+            writeAll(stream, "BTpayload") catch return; // simulated peer data
+        }
+    }
+}
+
+const MockCtx = struct {
+    server: *std.net.Server,
+    stop: std.atomic.Value(bool),
+    /// SAM version the mock bridge advertises in its HELLO REPLY.
+    version: []const u8 = "3.3",
+};
+
+fn mockRun(ctx: *MockCtx) void {
+    // poll() the listen socket with a timeout so we only accept() when a
+    // connection is ready, and otherwise loop to observe `stop`. This is the
+    // portable way to make the thread exit (neither closing the listener nor
+    // SO_RCVTIMEO reliably unblocks a parked accept() across Linux + macOS) and
+    // mirrors the daemon's own serve loop.
+    var pfd = [_]std.posix.pollfd{.{ .fd = ctx.server.stream.handle, .events = std.posix.POLL.IN, .revents = 0 }};
+    while (!ctx.stop.load(.acquire)) {
+        const ready = std.posix.poll(&pfd, 200) catch 0;
+        if (ready == 0) continue; // timeout → re-check stop
+        const conn = ctx.server.accept() catch continue;
+        mockHandleConn(conn.stream, ctx.version);
+    }
+}
+
+test "i2p_sam: session create + stream connect against a mock SAM bridge" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    // Stop the thread (it polls `stop` between accept timeouts), join, then close
+    // — runs on both success and assertion-failure paths, so the test never hangs.
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+
+    var sess = try Session.create(allocator, bridge, "carltest");
+    defer sess.deinit();
+    try testing.expectEqualStrings("ZmFrZWRlc3Q=", sess.destination);
+    try testing.expect(std.mem.startsWith(u8, sess.id, "carltest-"));
+
+    // Successful CONNECT: the advertised port is threaded as TO_PORT (the mock
+    // rejects the connect if it's missing), and the returned stream carries the
+    // simulated peer bytes.
+    var peer = try sess.connect("examplepeer.b32.i2p", 6881);
+    var rbuf: [32]u8 = undefined;
+    var got: usize = 0;
+    while (got < "BTpayload".len) {
+        const n = peer.read(rbuf[got..]) catch break;
+        if (n == 0) break;
+        got += n;
+    }
+    peer.close();
+    try testing.expectEqualStrings("BTpayload", rbuf[0..got]);
+
+    // Failed CONNECT surfaces as StreamFailed (port 0 → no TO_PORT on the wire).
+    try testing.expectError(error.StreamFailed, sess.connect("bad.b32.i2p", 0));
+}
+
+test "i2p_sam: parseVersion + atLeast" {
+    try testing.expectEqual(@as(u16, 3), parseVersion("3.2").major);
+    try testing.expectEqual(@as(u16, 2), parseVersion("3.2").minor);
+    try testing.expect(parseVersion("3.2").atLeast(3, 2));
+    try testing.expect(parseVersion("3.3").atLeast(3, 2));
+    try testing.expect(parseVersion("4.0").atLeast(3, 2));
+    try testing.expect(!parseVersion("3.1").atLeast(3, 2));
+    try testing.expect(!parseVersion("3.0").atLeast(3, 2));
+    try testing.expect(!parseVersion("2.9").atLeast(3, 2));
+    // Malformed/missing minor parse as 0 → older than any version-gated feature.
+    try testing.expect(!parseVersion("garbage").atLeast(3, 2));
+    try testing.expect(parseVersion("3").atLeast(3, 0));
+}
+
+test "i2p_sam: TO_PORT omitted on a pre-3.2 bridge (best-effort default port)" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    // 3.1 bridge: the mock fails the CONNECT if TO_PORT appears, so a passing
+    // test proves we omit TO_PORT (rather than send an unsupported parameter).
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false), .version = "3.1" };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+    var sess = try Session.create(allocator, bridge, "carltest");
+    defer sess.deinit();
+
+    // Dials with a non-zero port; on a 3.1 bridge it must still succeed with
+    // TO_PORT omitted.
+    var peer = try sess.connect("examplepeer.b32.i2p", 6881);
+    peer.close();
+}

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -11,6 +11,7 @@ const storage_mod = @import("storage.zig");
 const session_mod = @import("session.zig");
 const extension = @import("extension.zig");
 const proxy_mod = @import("proxy.zig");
+const i2p_sam = @import("i2p_sam.zig");
 
 /// Generate deterministic test data of a given size.
 fn generateTestData(allocator: std.mem.Allocator, size: usize) ![]u8 {
@@ -252,6 +253,7 @@ fn seederThread(args: SeederArgs) void {
         null,
         .any,
         false,
+        null,
     ) catch return;
     defer sess.deinit();
 
@@ -329,6 +331,7 @@ test "full session seed and download over loopback" {
         null,
         .any,
         false,
+        null,
     ) catch {
         session_mod.shutdown_requested.store(true, .release);
         seeder_handle.join();
@@ -426,6 +429,7 @@ test "magnet metadata exchange then download over loopback" {
         null,
         .loopback,
         false,
+        null,
     ) catch return;
     defer seeder.deinit();
     // init opens the inbound listener for seed mode; read back the real port.
@@ -466,6 +470,7 @@ test "magnet metadata exchange then download over loopback" {
         null,
         .loopback,
         false,
+        null,
     ) catch return;
     defer dl.deinit();
     dl.info_hash = info_hash;
@@ -536,6 +541,7 @@ test "connectOnionPeer cleans up exactly once when the dial fails" {
         proxy,
         .any,
         false,
+        null,
     );
     defer sess.deinit();
 
@@ -543,5 +549,55 @@ test "connectOnionPeer cleans up exactly once when the dial fails" {
     // exactly once. On the pre-fix code this double-frees and the test aborts.
     try std.testing.expectError(error.ConnectionFailed, sess.connectOnionPeer("examplepeer.onion", 6881));
     // The failed peer must not have been adopted into the peer set.
+    try std.testing.expectEqual(@as(usize, 0), sess.peers.items.len);
+}
+
+// The I2P path shares finishPeerConnect's single-owner contract: connectI2pPeer
+// sets up the PeerConnection with `errdefer p.deinit()` and finishPeerConnect
+// must NOT also free it when the SAM dial fails — the same double-free shape as
+// the onion regression above, on the path where failed dials (CANT_REACH_PEER)
+// are the common case.
+test "connectI2pPeer cleans up exactly once when the SAM dial fails" {
+    const allocator = std.testing.allocator;
+
+    const test_data = try generateTestData(allocator, 1024);
+    defer allocator.free(test_data);
+
+    var tm = try buildTestMetainfo(allocator, test_data, 1024, "i2p_double_free.bin");
+    defer tm.deinit();
+
+    var dir = std.testing.tmpDir(.{});
+    defer dir.cleanup();
+    const dir_path = try dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    // SAM session whose bridge refuses immediately, so the dial fails fast
+    // without touching the network. `connect` only reads allocator/bridge/id;
+    // control/destination are never touched, so dummies are fine (no deinit —
+    // this Session owns nothing).
+    var sam = i2p_sam.Session{
+        .allocator = allocator,
+        .bridge = .{ .host = "127.0.0.1", .port = 1 },
+        .id = @constCast("carltest-0"),
+        .destination = @constCast(""),
+        .control = undefined,
+    };
+
+    var sess = try session_mod.Session.init(
+        allocator,
+        tm.meta,
+        dir_path,
+        .download,
+        0,
+        null,
+        .any,
+        false,
+        &sam,
+    );
+    defer sess.deinit();
+
+    // Must surface the error and free the peer exactly once (the testing
+    // allocator aborts on a double free, failing the test on the buggy code).
+    try std.testing.expectError(error.ConnectionFailed, sess.connectI2pPeer("examplepeer.b32.i2p", 6881));
     try std.testing.expectEqual(@as(usize, 0), sess.peers.items.len);
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -19,6 +19,7 @@ pub const nip35 = @import("nip35.zig");
 pub const peer_announce = @import("peer_announce.zig");
 pub const seeding = @import("seeding.zig");
 pub const tor_control = @import("tor_control.zig");
+pub const i2p_sam = @import("i2p_sam.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
 pub const api = @import("api.zig");
@@ -49,6 +50,7 @@ test {
     _ = nip35;
     _ = peer_announce;
     _ = tor_control;
+    _ = i2p_sam;
     _ = relay;
     _ = nostr_config;
     _ = api;

--- a/src/main.zig
+++ b/src/main.zig
@@ -159,10 +159,12 @@ fn printUsage() void {
         \\  search <query> [--limit n] [--relay <wss://...>]
         \\           search nostr relays for kind-2003 torrent events
         \\  nostr-keygen                                     generate a fresh nostr key
-        \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url]
-        \\         [--download-dir d] [--token tok] [--parent-pid pid]
+        \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor|i2p] [--socks url]
+        \\         [--i2p-sam host:port] [--download-dir d] [--token tok] [--parent-pid pid]
         \\         [--tor-control host:port] [--tor-cookie path] [--tor-onion-port p]
         \\           run a localhost HTTP+WebSocket API for the desktop GUI.
+        \\           --route i2p connects peers over native I2P (SAM v3); set the
+        \\           SAM bridge with --i2p-sam (default 127.0.0.1:7656). See docs/i2p.md.
         \\           --tor-* configure the ControlPort used to create hidden
         \\           services for tor-route seeds (default 127.0.0.1:9051).
         \\           binds 127.0.0.1 only; every request needs the printed token
@@ -393,7 +395,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         defer mi.deinit(allocator);
 
         std.fs.cwd().makePath(output_dir) catch {};
-        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false) catch |err| {
+        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
             log.err("failed to initialize session: {}", .{err});
             std.process.exit(1);
         };
@@ -434,7 +436,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
 
 fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool, want_seed: bool) void {
     std.fs.cwd().makePath(output_dir) catch {};
-    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -570,7 +572,7 @@ fn cmdSeed(
     }
 
     const listen_bind: carl.session.ListenBind = if (tor_seed) .loopback else .any;
-    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -864,12 +866,14 @@ fn parentWatchdog(parent_pid: std.posix.pid_t) void {
 fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u8) !void {
     const port = parsePortFlag(extra, "--port", 8088);
     const bt_port = parsePortFlag(extra, "--bt-port", 6881);
-    const route_str = parseFlag(extra, "--route") orelse "direct";
+    const route_flag = parseFlag(extra, "--route");
+    const route_str = route_flag orelse "direct";
     const route = carl.api.Route.parse(route_str) orelse {
-        log.err("invalid --route '{s}' (expected direct|proxy|tor)", .{route_str});
+        log.err("invalid --route '{s}' (expected direct|proxy|tor|i2p)", .{route_str});
         std.process.exit(1);
     };
     const socks = parseFlag(extra, "--socks") orelse "";
+    const i2p_sam = parseFlag(extra, "--i2p-sam") orelse "";
     // Default to the unified carl work dir (CARL_DIR > persisted Settings
     // value > ~/Downloads/carl) so the daemon/GUI and the CLI share one
     // download + seed directory. An explicit flag or $CARL_DIR outranks the
@@ -911,7 +915,9 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
 
     var mgr = carl.manager.Manager.init(allocator, .{
         .route = route,
+        .route_explicit = route_flag != null,
         .socks = socks,
+        .i2p_sam = i2p_sam,
         .download_dir = download_dir,
         .download_dir_pinned = download_dir_pinned,
         .listen_port = bt_port,
@@ -955,7 +961,9 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
 
     // On a proxy/tor route, check the SOCKS proxy up front and say clearly why
     // it's unreachable (the daemon keeps running and the GUI shows live health).
-    if (route != .direct) {
+    // The i2p route doesn't use SOCKS (SAM bridge) — probing it here would warn
+    // about Tor on a route that doesn't need it.
+    if (route.usesSocks()) {
         // Mask any user:pass@ credentials before logging the proxy URL. redactUrl
         // is credential-safe even if this buffer is too small (it then returns
         // the bare host:port), so a fixed buffer can't leak the password.
@@ -1102,6 +1110,15 @@ fn collectNostrPeers(
                     }
                     session.connectOnionPeer(ep.host, ep.port) catch continue;
                     added += 1;
+                },
+                .i2p => |ep| {
+                    // I2P peers need the daemon's `--route i2p` (a SAM session);
+                    // the bare CLI download path has no I2P transport wired.
+                    log.warn(
+                        "nostr peer {s} is an I2P destination; run the daemon with --route i2p to connect",
+                        .{ep.host},
+                    );
+                    continue;
                 },
             }
         }

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -23,6 +23,7 @@ const session_mod = @import("session.zig");
 const metainfo = @import("metainfo.zig");
 const magnet_mod = @import("magnet.zig");
 const proxy_mod = @import("proxy.zig");
+const i2p_sam = @import("i2p_sam.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
 const peer_announce = @import("peer_announce.zig");
@@ -43,6 +44,11 @@ pub const Error = error{
     HttpFailed,
     BadProxy,
     SessionInitFailed,
+    /// The requested operation has no I2P-routed implementation yet, so doing it
+    /// would either leak over clearnet or produce an unreachable transfer. We
+    /// fail closed rather than silently fall back. Covers HTTP `.torrent`
+    /// fetches and seeding on the `i2p` route (see #35 P2/P3 follow-ups).
+    UnsupportedOnI2p,
     /// Failed to stand up the Tor hidden service for a `.tor` seed (Tor
     /// ControlPort unreachable, cookie auth failed, etc.). Fails closed rather
     /// than creating a seed nobody can reach.
@@ -54,7 +60,14 @@ pub const Error = error{
 /// are owned; setters free and re-dup.
 pub const Config = struct {
     route: api.Route = .direct,
+    /// True when `route` came from an explicit `--route` flag. `restore` then
+    /// keeps it instead of applying the persisted (GUI-set) route: silently
+    /// downgrading e.g. `--route i2p`/`tor` to a stale persisted `direct` would
+    /// put a daemon the user asked to anonymize on the clearnet.
+    route_explicit: bool = false,
     socks: []const u8 = "",
+    /// I2P SAM bridge address for the `i2p` route (e.g. `127.0.0.1:7656`).
+    i2p_sam: []const u8 = "",
     download_dir: []const u8 = "",
     /// True when `download_dir` came from a source that outranks the persisted
     /// setting (an explicit --download-dir flag or $CARL_DIR), so `restore`
@@ -98,6 +111,9 @@ const ManagedTransfer = struct {
     /// Owned copy of the socks URL the proxy slices borrow from.
     socks_owned: ?[]u8,
     proxy: ?proxy_mod.Proxy,
+    /// Owned SAM session for the `i2p` route (the session borrows it). Torn down
+    /// in `destroy` after the session thread has stopped.
+    i2p_session: ?*i2p_sam.Session,
     /// Tor hidden service backing a `.tor` seed (the onion leechers dial).
     /// Owned; torn down (DEL_ONION) in `destroy` after the session stops.
     hidden: ?tor_control.HiddenService,
@@ -131,6 +147,11 @@ const ManagedTransfer = struct {
         // gone, so we DEL_ONION only once nothing is forwarding to it.
         if (self.hidden) |*h| h.deinit();
         self.meta.deinit(self.allocator);
+        // The session (now stopped) borrowed this SAM session; tear it down last.
+        if (self.i2p_session) |s| {
+            s.deinit();
+            self.allocator.destroy(s);
+        }
         if (self.socks_owned) |s| self.allocator.free(s);
         self.allocator.free(self.id);
         self.allocator.free(self.name);
@@ -154,13 +175,22 @@ pub const Manager = struct {
     /// of the override, so an ephemeral override never clobbers the setting on
     /// disk. Cleared when the user picks a new dir via `setDownloadDir`. Owned.
     saved_download_dir: ?[]u8 = null,
+    /// Persisted transfer specs that failed to re-add on `restore` (the SAM
+    /// bridge / I2P router or Tor still starting, a proxy down, a seed file on
+    /// a not-yet-mounted disk). They aren't live (no session), but `persist`
+    /// re-includes them so a failure at startup never deletes a user's saved
+    /// transfers — the next restart retries them. Sources are owned by
+    /// `allocator`.
+    retained_specs: std.ArrayList(state_mod.TransferSpec) = .empty,
 
     pub fn init(allocator: Allocator, cfg: Config) Allocator.Error!Manager {
         return .{
             .allocator = allocator,
             .cfg = .{
                 .route = cfg.route,
+                .route_explicit = cfg.route_explicit,
                 .socks = try allocator.dupe(u8, if (cfg.socks.len > 0) cfg.socks else "socks5h://127.0.0.1:9050"),
+                .i2p_sam = try allocator.dupe(u8, if (cfg.i2p_sam.len > 0) cfg.i2p_sam else "127.0.0.1:7656"),
                 .download_dir = try allocator.dupe(u8, if (cfg.download_dir.len > 0) cfg.download_dir else "."),
                 .download_dir_pinned = cfg.download_dir_pinned,
                 .listen_port = cfg.listen_port,
@@ -178,7 +208,10 @@ pub const Manager = struct {
         // No lock: deinit happens after the server loop has stopped.
         for (self.transfers.items) |mt| mt.destroy();
         self.transfers.deinit(self.allocator);
+        for (self.retained_specs.items) |s| self.allocator.free(s.source);
+        self.retained_specs.deinit(self.allocator);
         self.allocator.free(self.cfg.socks);
+        self.allocator.free(self.cfg.i2p_sam);
         self.allocator.free(self.cfg.download_dir);
         if (self.saved_download_dir) |d| self.allocator.free(d);
         self.allocator.free(self.cfg.tor_control);
@@ -192,31 +225,60 @@ pub const Manager = struct {
     /// Add a transfer from a magnet URI, .torrent path, or HTTP(S) URL on the
     /// given route. Spawns the session thread. Returns the new transfer id
     /// (owned by the caller).
-    pub fn addTransfer(self: *Manager, source: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
-        // Each transfer owns the socks URL its Proxy slices borrow from, so a
-        // later `setRoute`/config change can't dangle a running transfer.
-        var socks_owned: ?[]u8 = null;
-        var resolved_proxy: ?proxy_mod.Proxy = null;
-        if (route != .direct) {
-            const dup = try self.allocator.dupe(u8, self.cfg.socks);
-            socks_owned = dup;
-            resolved_proxy = proxy_mod.parseUrl(dup) catch {
-                self.allocator.free(dup);
-                return error.BadProxy;
-            };
+    /// Open a SAM session for the `i2p` route (the per-transfer transport,
+    /// analogous to resolving a proxy). Caller owns the returned session.
+    fn resolveI2p(self: *Manager) Error!*i2p_sam.Session {
+        const bridge = i2p_sam.parseUrl(self.cfg.i2p_sam) catch return error.BadProxy;
+        const sam = self.allocator.create(i2p_sam.Session) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(sam);
+        sam.* = i2p_sam.Session.create(self.allocator, bridge, "carl") catch return error.SessionInitFailed;
+        return sam;
+    }
+
+    /// The per-transfer transport resolved from a route: a proxy (with its owned
+    /// socks URL) for proxy/Tor, a SAM session for I2P, or nothing for direct.
+    const Transport = struct {
+        socks_owned: ?[]u8 = null,
+        proxy: ?proxy_mod.Proxy = null,
+        i2p: ?*i2p_sam.Session = null,
+    };
+
+    /// Resolve the transport for `route`. Each transfer owns its transport so a
+    /// later config change can't dangle a running one. On error nothing leaks.
+    fn resolveTransport(self: *Manager, route: api.Route) Error!Transport {
+        if (route == .i2p) return .{ .i2p = try self.resolveI2p() };
+        if (route == .direct) return .{};
+        const dup = try self.allocator.dupe(u8, self.cfg.socks);
+        const proxy = proxy_mod.parseUrl(dup) catch {
+            self.allocator.free(dup);
+            return error.BadProxy;
+        };
+        return .{ .socks_owned = dup, .proxy = proxy };
+    }
+
+    /// Free a resolved transport on a pre-`register` error path (after `register`
+    /// succeeds, the ManagedTransfer owns it). Idempotent over the null fields.
+    fn freeTransport(self: *Manager, t: Transport) void {
+        if (t.socks_owned) |s| self.allocator.free(s);
+        if (t.i2p) |s| {
+            s.deinit();
+            self.allocator.destroy(s);
         }
+    }
+
+    pub fn addTransfer(self: *Manager, source: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
+        const t = try self.resolveTransport(route);
 
         std.fs.cwd().makePath(self.cfg.download_dir) catch {};
 
-        const built = self.buildSession(source, resolved_proxy) catch |err| {
-            if (socks_owned) |s| self.allocator.free(s);
+        const built = self.buildSession(source, t.proxy, t.i2p) catch |err| {
+            self.freeTransport(t);
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, resolved_proxy, socks_owned, null, want_nostr, false, magnet, source);
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, want_nostr, false, magnet, source);
     }
 
-    /// Create a torrent from a local file (or archive) and start seeding it. The
     /// Bind a throwaway loopback socket to discover a free port. Each `.tor`
     /// seed needs its own listener port: every seed otherwise reuses
     /// `cfg.listen_port`, but only one Session can bind a given port, so a second
@@ -231,22 +293,20 @@ pub const Manager = struct {
         return server.listen_address.getPort();
     }
 
+    /// Create a torrent from a local file (or archive) and start seeding it. The
     /// file is hashed in-process — carl needs no external torrent tool. With
     /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
     pub fn addSeed(self: *Manager, path: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
-        var socks_owned: ?[]u8 = null;
-        var resolved_proxy: ?proxy_mod.Proxy = null;
-        if (route != .direct) {
-            const dup = try self.allocator.dupe(u8, self.cfg.socks);
-            socks_owned = dup;
-            resolved_proxy = proxy_mod.parseUrl(dup) catch {
-                self.allocator.free(dup);
-                return error.BadProxy;
-            };
-        }
+        // I2P inbound seeding (STREAM ACCEPT/FORWARD + a persisted destination +
+        // an `.b32.i2p` peer-announce) is P2 follow-up work (#35). Without it an
+        // i2p seed would suppress the clearnet listener yet expose no reachable
+        // endpoint — advertised as private but unreachable. Fail closed instead
+        // of creating a dead seed.
+        if (route == .i2p) return error.UnsupportedOnI2p;
+        const t = try self.resolveTransport(route);
 
         const mi = metainfo.createSingleFile(self.allocator, path, metainfo.default_piece_length) catch |e| {
-            if (socks_owned) |s| self.allocator.free(s);
+            self.freeTransport(t);
             return switch (e) {
                 error.OutOfMemory => error.OutOfMemory,
                 else => error.InvalidTorrent,
@@ -263,7 +323,7 @@ pub const Manager = struct {
         // over Tor; the session itself takes no proxy (inbound-only via the onion).
         // Fails closed (`TorControlFailed`) rather than creating an unreachable seed.
         var hidden: ?tor_control.HiddenService = null;
-        var session_proxy = resolved_proxy;
+        var session_proxy = t.proxy;
         var listen_bind: session_mod.ListenBind = .any;
         var tor_hidden = false;
         var seed_port = self.cfg.listen_port;
@@ -277,7 +337,7 @@ pub const Manager = struct {
                 .local_port = seed_port,
                 .onion_port = self.cfg.tor_onion_port,
             }) catch {
-                if (socks_owned) |s| self.allocator.free(s);
+                self.freeTransport(t);
                 mi.deinit(self.allocator);
                 return error.TorControlFailed;
             };
@@ -287,13 +347,13 @@ pub const Manager = struct {
         }
 
         const session = self.allocator.create(session_mod.Session) catch {
-            if (socks_owned) |s| self.allocator.free(s);
+            self.freeTransport(t);
             if (hidden) |*h| h.deinit();
             mi.deinit(self.allocator);
             return error.OutOfMemory;
         };
-        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden) catch {
-            if (socks_owned) |s| self.allocator.free(s);
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden, t.i2p) catch {
+            self.freeTransport(t);
             if (hidden) |*h| h.deinit();
             self.allocator.destroy(session);
             mi.deinit(self.allocator);
@@ -309,7 +369,7 @@ pub const Manager = struct {
         var hex: [40]u8 = undefined;
         secp.toHex(&session.info_hash, &hex);
         const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch {
-            if (socks_owned) |s| self.allocator.free(s);
+            self.freeTransport(t);
             if (hidden) |*h| h.deinit();
             session.deinit();
             self.allocator.destroy(session);
@@ -318,7 +378,7 @@ pub const Manager = struct {
         };
         defer self.allocator.free(magnet);
 
-        return self.register(built, route, resolved_proxy, socks_owned, hidden, want_nostr, true, magnet, path);
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, hidden, want_nostr, true, magnet, path);
     }
 
     /// Register a built session as a managed transfer and spawn its thread.
@@ -332,6 +392,7 @@ pub const Manager = struct {
         route: api.Route,
         resolved_proxy: ?proxy_mod.Proxy,
         socks_owned: ?[]u8,
+        i2p_session: ?*i2p_sam.Session,
         hidden: ?tor_control.HiddenService,
         want_nostr: bool,
         is_seed: bool,
@@ -348,6 +409,10 @@ pub const Manager = struct {
             }
             built.meta.deinit(self.allocator);
             if (socks_owned) |s| self.allocator.free(s);
+            if (i2p_session) |s| {
+                s.deinit();
+                self.allocator.destroy(s);
+            }
         };
 
         const mt = try self.allocator.create(ManagedTransfer);
@@ -382,6 +447,7 @@ pub const Manager = struct {
             .has_http_tracker = std.mem.startsWith(u8, built.meta.announce, "http"),
             .socks_owned = socks_owned,
             .proxy = resolved_proxy,
+            .i2p_session = i2p_session,
             .hidden = hidden,
             .session = built.session,
             .meta = built.meta,
@@ -397,15 +463,24 @@ pub const Manager = struct {
             mt.destroy();
             return err;
         };
-        self.mutex.unlock();
-
         // Spawn after publishing so a snapshot taken mid-spawn sees the row.
+        // (spawn doesn't block on the child, and we never join under the lock,
+        // so holding the mutex across it is safe.)
         mt.thread = std.Thread.spawn(.{}, runThread, .{mt}) catch {
             // Roll back: remove from the list and destroy (frees `id` too, so we
             // must not touch it afterward on this path).
+            self.mutex.unlock();
             _ = self.removeTransfer(id) catch {};
             return error.SessionInitFailed;
         };
+
+        // The spec is live for real (spawn succeeded): drop any retained copy of
+        // the same source so `persist` doesn't write it twice (a duplicate would
+        // re-add the transfer twice on the next restart — two sessions on the
+        // same files). Only after the spawn: dropping earlier would let the
+        // failed-spawn rollback persist state with the saved spec already gone.
+        self.dropRetained(source_src);
+        self.mutex.unlock();
 
         self.persist();
         return self.allocator.dupe(u8, id);
@@ -561,6 +636,18 @@ pub const Manager = struct {
                 .nostr = mt.want_nostr,
             }) catch break;
         }
+        // Re-include transfers whose transport was unavailable at restore so a
+        // transient outage doesn't erase them on the next persist (which any
+        // add/remove triggers). They carry no live session, just the saved spec.
+        for (self.retained_specs.items) |s| {
+            const src = aa.dupe(u8, s.source) catch break;
+            specs.append(aa, .{
+                .kind = s.kind,
+                .source = src,
+                .route = s.route,
+                .nostr = s.nostr,
+            }) catch break;
+        }
         self.mutex.unlock();
 
         state_mod.save(self.allocator, route, dir, specs.items) catch |e| {
@@ -579,7 +666,9 @@ pub const Manager = struct {
         defer st.deinit(self.allocator);
 
         self.mutex.lock();
-        self.cfg.route = st.route;
+        // An explicit --route wins over the persisted (GUI-set) route; the
+        // persisted one only fills in when the user didn't ask for anything.
+        if (!self.cfg.route_explicit) self.cfg.route = st.route;
         // Apply the persisted downloadDir only when it doesn't get outranked:
         // a pinned dir (explicit --download-dir or $CARL_DIR) wins over the DB
         // value so the daemon matches the CLI's `$CARL_DIR > setting > default`
@@ -603,7 +692,7 @@ pub const Manager = struct {
 
         self.restoring = true;
         var restored: usize = 0;
-        var failed: usize = 0;
+        var retained: usize = 0;
         for (st.transfers) |t| {
             const res = switch (t.kind) {
                 .download => self.addTransfer(t.source, t.route, t.nostr),
@@ -613,22 +702,61 @@ pub const Manager = struct {
                 self.allocator.free(id);
                 restored += 1;
             } else |e| {
-                failed += 1;
-                log.warn("restore: could not re-add '{s}': {} (keeping it on disk)", .{ t.source, e });
+                // Never drop a saved spec on a failed re-add: the cause is often
+                // transient (the SAM bridge / I2P router or Tor still starting, a
+                // proxy down, a seed file on a not-yet-mounted disk). Keep it in
+                // `retained_specs` so every `persist` — at the end of restore AND
+                // any later add/remove — re-includes it, and the next restart
+                // retries instead of silently deleting the user's transfer.
+                // (Genuinely-invalid specs cost a warning per startup; that beats
+                // data loss.) Only an OOM on the copy can drop one.
+                if (self.retainSpec(t)) {
+                    retained += 1;
+                    log.warn("restore: could not re-add '{s}' ({}); keeping it for retry", .{ t.source, e });
+                } else {
+                    log.warn("restore: dropping '{s}': {} (out of memory)", .{ t.source, e });
+                }
             }
         }
         self.restoring = false;
-        // Only re-persist when every saved transfer came back. `persist` rewrites
-        // the DB purely from the live set, so persisting after a failure would
-        // permanently delete the dropped specs — e.g. a `tor` seed whose hidden
-        // service couldn't be created because Tor wasn't up yet at restart. Leave
-        // the on-disk state intact so the next restart retries them.
-        if (failed == 0) {
-            self.persist();
-        } else {
-            log.warn("restore: {d} transfer(s) didn't come back; leaving saved state intact for retry", .{failed});
-        }
+        // Persisting here is safe even after failures: every failed spec was just
+        // retained, and `persist` re-includes `retained_specs` alongside the live
+        // set, so nothing is erased.
+        self.persist();
         if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
+        if (retained > 0) log.info("kept {d} saved transfer(s) that could not be re-added", .{retained});
+    }
+
+    /// Remove every retained spec whose source matches (the spec became live
+    /// again, or the caller is discarding it). Caller must hold `mutex` when the
+    /// manager is serving (restore runs single-threaded before that).
+    fn dropRetained(self: *Manager, source: []const u8) void {
+        var i: usize = 0;
+        while (i < self.retained_specs.items.len) {
+            if (std.mem.eql(u8, self.retained_specs.items[i].source, source)) {
+                self.allocator.free(self.retained_specs.items[i].source);
+                _ = self.retained_specs.swapRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Copy a persisted spec into `retained_specs` so `persist` re-includes it.
+    /// Returns false if the (owned) source copy can't be allocated, in which case
+    /// the caller drops the spec — there's no safe way to retain it.
+    fn retainSpec(self: *Manager, t: state_mod.TransferSpec) bool {
+        const src = self.allocator.dupe(u8, t.source) catch return false;
+        self.retained_specs.append(self.allocator, .{
+            .kind = t.kind,
+            .source = src,
+            .route = t.route,
+            .nostr = t.nostr,
+        }) catch {
+            self.allocator.free(src);
+            return false;
+        };
+        return true;
     }
 
     /// Capture any download whose (magnet) metadata has resolved: write the real
@@ -682,34 +810,39 @@ pub const Manager = struct {
         name: []const u8, // borrows from meta
     };
 
-    fn buildSession(self: *Manager, source: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
-        if (std.mem.startsWith(u8, source, "magnet:")) return self.buildMagnet(source, proxy);
+    fn buildSession(self: *Manager, source: []const u8, proxy: ?proxy_mod.Proxy, i2p: ?*i2p_sam.Session) Error!Built {
+        if (std.mem.startsWith(u8, source, "magnet:")) return self.buildMagnet(source, proxy, i2p);
         if (std.mem.startsWith(u8, source, "http://") or std.mem.startsWith(u8, source, "https://"))
-            return self.buildHttp(source, proxy);
-        return self.buildFile(source, proxy);
+            return self.buildHttp(source, proxy, i2p);
+        return self.buildFile(source, proxy, i2p);
     }
 
-    fn buildFile(self: *Manager, path: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+    fn buildFile(self: *Manager, path: []const u8, proxy: ?proxy_mod.Proxy, i2p: ?*i2p_sam.Session) Error!Built {
         const data = std.fs.cwd().readFileAlloc(self.allocator, path, 10 * 1024 * 1024) catch return error.InvalidTorrent;
         defer self.allocator.free(data);
         const mi = metainfo.parse(self.allocator, data) catch return error.InvalidTorrent;
-        return self.fromMetainfo(mi, proxy);
+        return self.fromMetainfo(mi, proxy, i2p);
     }
 
-    fn buildHttp(self: *Manager, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+    fn buildHttp(self: *Manager, url: []const u8, proxy: ?proxy_mod.Proxy, i2p: ?*i2p_sam.Session) Error!Built {
+        // The i2p route has no clearnet-tunneled fetch path: `fetchUrl` would
+        // dial the `.torrent` host directly (proxy is null on this route),
+        // leaking the real IP despite the route being documented as fail-closed.
+        // HTTP-over-SAM is P3 follow-up work (#35); until then, reject.
+        if (i2p != null) return error.UnsupportedOnI2p;
         const data = fetchUrl(self.allocator, url, proxy) catch return error.HttpFailed;
         defer self.allocator.free(data);
         const mi = metainfo.parse(self.allocator, data) catch return error.InvalidTorrent;
-        return self.fromMetainfo(mi, proxy);
+        return self.fromMetainfo(mi, proxy, i2p);
     }
 
-    fn fromMetainfo(self: *Manager, mi: metainfo.Metainfo, proxy: ?proxy_mod.Proxy) Error!Built {
+    fn fromMetainfo(self: *Manager, mi: metainfo.Metainfo, proxy: ?proxy_mod.Proxy, i2p: ?*i2p_sam.Session) Error!Built {
         // On a failed Session.init the metainfo is ours to free (it only becomes
         // the session's on success); mirrors the magnet path's errdefer.
         errdefer mi.deinit(self.allocator);
         const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer self.allocator.destroy(session);
-        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {
+        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
             return error.SessionInitFailed;
         };
         // Daemon downloads keep seeding once complete — the GUI lists them
@@ -721,7 +854,7 @@ pub const Manager = struct {
 
     /// Build a metadata-only session from a magnet link (BEP 9 bootstrap),
     /// mirroring the CLI's magnet path minus the optional NIP-35 enrichment.
-    fn buildMagnet(self: *Manager, uri: []const u8, proxy: ?proxy_mod.Proxy) Error!Built {
+    fn buildMagnet(self: *Manager, uri: []const u8, proxy: ?proxy_mod.Proxy, i2p: ?*i2p_sam.Session) Error!Built {
         const ml = magnet_mod.parse(self.allocator, uri) catch return error.InvalidMagnet;
         defer ml.deinit(self.allocator);
         const a = self.allocator;
@@ -731,7 +864,7 @@ pub const Manager = struct {
 
         const session = a.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer a.destroy(session);
-        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {
+        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
             return error.SessionInitFailed;
         };
         session.info_hash = ml.info_hash; // use the magnet's hash, not SHA1("")
@@ -933,12 +1066,25 @@ pub fn deriveSources(
             }
         },
         .proxy, .tor => {
-            // Proxied: DHT and UDP trackers are disabled to avoid IP leaks.
+            // Tunneled via SOCKS: clearnet DHT and UDP trackers are disabled to
+            // avoid leaks, but HTTP-tracker announces are routed through the
+            // proxy, so peers come from HTTP trackers and Nostr.
             if (has_http_tracker) {
                 out[n] = .tracker;
                 n += 1;
             }
             if (want_nostr or n == 0) {
+                out[n] = .nostr;
+                n += 1;
+            }
+        },
+        .i2p => {
+            // I2P can't reach clearnet trackers/DHT and has no I2P-native
+            // trackers yet, so `Session.tryAnnounceUrl` skips every announce
+            // (even HTTP ones). Reporting `tracker` here would imply peer
+            // discovery that never happens — Nostr `.b32.i2p` announces are the
+            // only real source, and only when the user opted into Nostr.
+            if (want_nostr) {
                 out[n] = .nostr;
                 n += 1;
             }
@@ -1030,6 +1176,13 @@ fn collectNostrPeers(mt: *ManagedTransfer) void {
             if (added >= 50) break;
             switch (ann.endpoint) {
                 .ipv4 => |ep| {
+                    // On the I2P transport a clearnet IPv4 peer is unreachable
+                    // (connectDirectPeer skips it to avoid leaking the real IP).
+                    // Skip it here too so clearnet announces don't silently count
+                    // against the discovery budget and starve later `.b32.i2p`
+                    // announces. (proxy/Tor dial IPv4 through the proxy, so they
+                    // still count.)
+                    if (mt.session.i2p != null) continue;
                     const addr = std.net.Address.initIp4(ep.ip, ep.port);
                     mt.session.connectDirectPeer(addr) catch continue;
                     added += 1;
@@ -1037,6 +1190,11 @@ fn collectNostrPeers(mt: *ManagedTransfer) void {
                 .onion => |ep| {
                     if (mt.session.proxy == null) continue;
                     mt.session.connectOnionPeer(ep.host, ep.port) catch continue;
+                    added += 1;
+                },
+                .i2p => |ep| {
+                    if (mt.session.i2p == null) continue; // needs an I2P route
+                    mt.session.connectI2pPeer(ep.host, ep.port) catch continue;
                     added += 1;
                 },
             }
@@ -1132,6 +1290,20 @@ test "deriveSources: proxy with http tracker keeps tracker + nostr" {
     try testing.expectEqual(api.SourceKind.nostr, s[1]);
 }
 
+test "deriveSources: i2p reports nostr only when opted in (never tracker)" {
+    var buf: [3]api.SourceKind = undefined;
+    // HTTP tracker present but never contacted on i2p, and nostr opted in:
+    // report nostr only, not tracker.
+    const with_nostr = deriveSources(&buf, .i2p, true, true, true);
+    try testing.expectEqual(@as(usize, 1), with_nostr.len);
+    try testing.expectEqual(api.SourceKind.nostr, with_nostr[0]);
+
+    // Without nostr there is no peer discovery at all on i2p: report nothing
+    // rather than implying a tracker is being used.
+    const no_nostr = deriveSources(&buf, .i2p, true, true, false);
+    try testing.expectEqual(@as(usize, 0), no_nostr.len);
+}
+
 test "formatEta" {
     var buf: [24]u8 = undefined;
     try testing.expectEqualStrings("stalled", formatEta(&buf, .stalled, 100, 0));
@@ -1141,6 +1313,27 @@ test "formatEta" {
     try testing.expectEqualStrings("10s", formatEta(&buf, .downloading, 1000, 100));
     try testing.expectEqualStrings("1m 40s", formatEta(&buf, .downloading, 10000, 100));
     try testing.expectEqualStrings("2h 46m", formatEta(&buf, .downloading, 1_000_000, 100));
+}
+
+test "Manager: dropRetained removes a re-added source so persist can't duplicate it" {
+    const allocator = testing.allocator;
+    var m = try Manager.init(allocator, .{});
+    defer m.deinit();
+
+    try testing.expect(m.retainSpec(.{ .kind = .download, .source = "magnet:?xt=urn:btih:aa", .route = .i2p, .nostr = true }));
+    try testing.expect(m.retainSpec(.{ .kind = .seed, .source = "/data/file.bin", .route = .tor, .nostr = false }));
+    try testing.expectEqual(@as(usize, 2), m.retained_specs.items.len);
+
+    // The magnet came back (user re-added it / transport recovered): its
+    // retained copy must go away or persist() would write it twice and the
+    // next restart would run two sessions on the same files.
+    m.dropRetained("magnet:?xt=urn:btih:aa");
+    try testing.expectEqual(@as(usize, 1), m.retained_specs.items.len);
+    try testing.expectEqualStrings("/data/file.bin", m.retained_specs.items[0].source);
+
+    // Unrelated source is a no-op.
+    m.dropRetained("magnet:?xt=urn:btih:bb");
+    try testing.expectEqual(@as(usize, 1), m.retained_specs.items.len);
 }
 
 test "Manager: init/deinit with config defaults" {

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -5,6 +5,7 @@ const wire = @import("wire.zig");
 const piece_mod = @import("piece.zig");
 const extension = @import("extension.zig");
 const proxy_mod = @import("proxy.zig");
+const i2p_sam = @import("i2p_sam.zig");
 
 pub const PeerState = enum {
     connecting,
@@ -27,7 +28,12 @@ pub const PeerConnection = struct {
     proxy: ?proxy_mod.Proxy,
 
     /// When set with `proxy`, connect via SOCKS to this hostname (e.g. `.onion`).
+    /// Also carries the `.b32.i2p` destination when `i2p` is set.
     connect_host: ?[]const u8 = null,
+
+    /// Borrowed SAM session (owned by the manager). When set, dial `connect_host`
+    /// (a `.b32.i2p` destination) over native I2P instead of TCP/SOCKS.
+    i2p: ?*i2p_sam.Session = null,
 
     // Protocol state
     am_choking: bool,
@@ -122,6 +128,16 @@ pub const PeerConnection = struct {
         };
     }
 
+    /// Outbound connection to an I2P `.b32.i2p` destination over a SAM session
+    /// (owned by the caller). The session must outlive this connection. `port`
+    /// is the peer's advertised I2CP destination port (0 = default), stored in
+    /// `address` and passed to SAM as `TO_PORT` at connect time.
+    pub fn initI2p(allocator: Allocator, host: []const u8, port: u16, sam: *i2p_sam.Session) !PeerConnection {
+        var p = try PeerConnection.initOnion(allocator, host, port);
+        p.i2p = sam;
+        return p;
+    }
+
     pub fn deinit(self: *PeerConnection) void {
         if (self.stream) |s| s.close();
         if (self.connect_host) |h| self.allocator.free(h);
@@ -137,6 +153,21 @@ pub const PeerConnection = struct {
 
     /// Initiate TCP connection with a timeout.
     pub fn connect(self: *PeerConnection) !void {
+        // Native I2P: open a SAM stream to the destination. Synchronous, so on
+        // success the stream is ready for the BT handshake (like the proxy path).
+        if (self.i2p) |sam| {
+            const dest = self.connect_host orelse {
+                self.state = .disconnected;
+                return error.ConnectionFailed;
+            };
+            self.stream = sam.connect(dest, self.address.getPort()) catch {
+                self.state = .disconnected;
+                return error.ConnectionFailed;
+            };
+            self.state = .handshaking;
+            return;
+        }
+
         // When a proxy is configured, tunnel through it. The handshake is
         // synchronous, so on success the stream is ready for the BT handshake.
         if (self.proxy) |px| {

--- a/src/peer_announce.zig
+++ b/src/peer_announce.zig
@@ -24,6 +24,9 @@ pub const kind_peer_announce: u32 = 30078;
 /// Tor v3 onion hostname: 56 base32 chars + `.onion` (62 bytes total).
 pub const v3_onion_host_len: usize = 62;
 
+/// I2P base32 destination hostname: 52 base32 chars + `.b32.i2p` (60 bytes).
+pub const b32_i2p_host_len: usize = 60;
+
 pub const Error = error{
     InvalidEvent,
     MissingD,
@@ -42,6 +45,11 @@ pub const Endpoint = union(enum) {
     },
     /// `host` is borrowed from the event tag when parsed from the network.
     onion: struct {
+        host: []const u8,
+        port: u16,
+    },
+    /// I2P `*.b32.i2p` destination; `host` is borrowed from the event tag.
+    i2p: struct {
         host: []const u8,
         port: u16,
     },
@@ -80,6 +88,31 @@ pub fn build(
     return buildTagged(allocator, sk, pk, &tag_sets);
 }
 
+/// Shared builder for a host-based endpoint (Tor onion or I2P): identical
+/// `d`/`host`/`port`/`client` tag schema; the suffix in `host` distinguishes
+/// the network. Validation is the caller's responsibility.
+fn buildHostEndpoint(
+    allocator: Allocator,
+    sk: secp.SecretKey,
+    pk: secp.PublicKey,
+    info_hash: [20]u8,
+    host: []const u8,
+    port: u16,
+) !nostr.Event {
+    var infohash_hex: [40]u8 = undefined;
+    secp.toHex(&info_hash, &infohash_hex);
+
+    var port_buf: [6]u8 = undefined;
+    const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch unreachable;
+
+    const d_tag = [_][]const u8{ "d", &infohash_hex };
+    const host_tag = [_][]const u8{ "host", host };
+    const port_tag = [_][]const u8{ "port", port_str };
+    const client_tag = [_][]const u8{ "client", "carl/0.1" };
+    const tag_sets = [_][]const []const u8{ d_tag[0..], host_tag[0..], port_tag[0..], client_tag[0..] };
+    return buildTagged(allocator, sk, pk, &tag_sets);
+}
+
 /// Build and sign a kind-30078 event for a Tor v3 hidden service.
 pub fn buildOnion(
     allocator: Allocator,
@@ -90,23 +123,26 @@ pub fn buildOnion(
     port: u16,
 ) !nostr.Event {
     if (!isValidV3OnionHost(onion_host)) return error.BadHost;
+    return buildHostEndpoint(allocator, sk, pk, info_hash, onion_host, port);
+}
 
-    var infohash_hex: [40]u8 = undefined;
-    secp.toHex(&info_hash, &infohash_hex);
-
-    var port_buf: [6]u8 = undefined;
-    const port_str = std.fmt.bufPrint(&port_buf, "{d}", .{port}) catch unreachable;
-
-    const d_tag = [_][]const u8{ "d", &infohash_hex };
-    const host_tag = [_][]const u8{ "host", onion_host };
-    const port_tag = [_][]const u8{ "port", port_str };
-    const client_tag = [_][]const u8{ "client", "carl/0.1" };
-    const tag_sets = [_][]const []const u8{ d_tag[0..], host_tag[0..], port_tag[0..], client_tag[0..] };
-    return buildTagged(allocator, sk, pk, &tag_sets);
+/// Build and sign a kind-30078 event for an I2P `*.b32.i2p` destination. Same
+/// `host`-tag schema as the onion path; the suffix distinguishes the two.
+pub fn buildI2p(
+    allocator: Allocator,
+    sk: secp.SecretKey,
+    pk: secp.PublicKey,
+    info_hash: [20]u8,
+    i2p_host: []const u8,
+    port: u16,
+) !nostr.Event {
+    if (!isValidI2pB32Host(i2p_host)) return error.BadHost;
+    return buildHostEndpoint(allocator, sk, pk, info_hash, i2p_host, port);
 }
 
 /// Parse and validate a kind-30078 event. Supports legacy `ip` tags and `host`
-/// tags for `.onion` endpoints. Caller must have already verified the signature.
+/// tags for `.onion` and `.b32.i2p` endpoints. Caller must have already verified
+/// the signature.
 pub fn parse(event: nostr.Event) Error!PeerAnnounce {
     if (event.kind != kind_peer_announce) return error.InvalidEvent;
 
@@ -130,6 +166,14 @@ pub fn parse(event: nostr.Event) Error!PeerAnnounce {
                 .created_at = event.created_at,
             };
         }
+        if (isValidI2pB32Host(host)) {
+            return .{
+                .info_hash = info_hash,
+                .endpoint = .{ .i2p = .{ .host = host, .port = port } },
+                .pubkey = event.pubkey,
+                .created_at = event.created_at,
+            };
+        }
         return error.BadHost;
     }
 
@@ -149,6 +193,18 @@ pub fn isValidV3OnionHost(host: []const u8) bool {
     if (host.len != v3_onion_host_len) return false;
     if (!std.mem.endsWith(u8, host, ".onion")) return false;
     const label = host[0 .. host.len - 6];
+    for (label) |c| {
+        const ok = (c >= 'a' and c <= 'z') or (c >= '2' and c <= '7');
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// True for an I2P base32 destination hostname (52-char base32 label + `.b32.i2p`).
+pub fn isValidI2pB32Host(host: []const u8) bool {
+    if (host.len != b32_i2p_host_len) return false;
+    if (!std.mem.endsWith(u8, host, ".b32.i2p")) return false;
+    const label = host[0 .. host.len - ".b32.i2p".len];
     for (label) |c| {
         const ok = (c >= 'a' and c <= 'z') or (c >= '2' and c <= '7');
         if (!ok) return false;
@@ -298,6 +354,48 @@ test "build + parse onion round trip" {
     try std.testing.expect(ann.endpoint == .onion);
     try std.testing.expectEqualStrings(onion, ann.endpoint.onion.host);
     try std.testing.expectEqual(@as(u16, 80), ann.endpoint.onion.port);
+}
+
+test "build + parse i2p round trip" {
+    const allocator = std.testing.allocator;
+    var label: [52]u8 = undefined;
+    @memset(&label, 'a');
+    var host_buf: [b32_i2p_host_len]u8 = undefined;
+    const dest = std.fmt.bufPrint(&host_buf, "{s}.b32.i2p", .{&label}) catch unreachable;
+
+    var sk: secp.SecretKey = undefined;
+    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try secp.publicKeyFromSecret(sk);
+
+    const info_hash: [20]u8 = .{0xCD} ** 20;
+    var ev = try buildI2p(allocator, sk, pk, info_hash, dest, 6881);
+    defer ev.deinit(allocator);
+
+    const ann = try parse(ev);
+    try std.testing.expect(ann.endpoint == .i2p);
+    try std.testing.expectEqualStrings(dest, ann.endpoint.i2p.host);
+    try std.testing.expectEqual(@as(u16, 6881), ann.endpoint.i2p.port);
+}
+
+test "isValidI2pB32Host" {
+    var label: [52]u8 = undefined;
+    @memset(&label, 'a');
+    var host_buf: [b32_i2p_host_len]u8 = undefined;
+    const ok = std.fmt.bufPrint(&host_buf, "{s}.b32.i2p", .{&label}) catch unreachable;
+    try std.testing.expect(isValidI2pB32Host(ok));
+    try std.testing.expect(!isValidI2pB32Host("short.b32.i2p"));
+    try std.testing.expect(!isValidI2pB32Host("aaaa.onion"));
+    // i2p host must not validate as onion and vice-versa
+    try std.testing.expect(!isValidV3OnionHost(ok));
+}
+
+test "buildI2p rejects non-i2p host" {
+    const allocator = std.testing.allocator;
+    var sk: secp.SecretKey = undefined;
+    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try secp.publicKeyFromSecret(sk);
+    const info_hash: [20]u8 = .{0} ** 20;
+    try std.testing.expectError(error.BadHost, buildI2p(allocator, sk, pk, info_hash, "nope.i2p", 80));
 }
 
 test "parse rejects private IP" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -15,6 +15,7 @@ const extension = @import("extension.zig");
 const bencode = @import("bencode.zig");
 const dht_mod = @import("dht.zig");
 const proxy_mod = @import("proxy.zig");
+const i2p_sam = @import("i2p_sam.zig");
 
 const log = std.log.scoped(.session);
 
@@ -147,6 +148,11 @@ pub const Session = struct {
     // listener are disabled to avoid leaking the real IP.
     proxy: ?proxy_mod.Proxy,
 
+    /// Native I2P transport (SAM v3). Borrowed; owned by the manager and set
+    /// after init for the `i2p` route. When set, peers are dialed as `.b32.i2p`
+    /// destinations over SAM instead of TCP/SOCKS. Mutually exclusive with proxy.
+    i2p: ?*i2p_sam.Session = null,
+
     /// Where the inbound listener binds when active.
     listen_bind: ListenBind,
     /// Tor hidden-service seed: no tracker/DHT (would leak or bypass Tor).
@@ -166,6 +172,7 @@ pub const Session = struct {
         proxy: ?proxy_mod.Proxy,
         listen_bind: ListenBind,
         tor_hidden: bool,
+        i2p: ?*i2p_sam.Session,
     ) !Session {
         const total_length = piece_mod.totalLength(meta.files);
         const num_pieces = piece_mod.numPieces(total_length, meta.piece_length);
@@ -214,10 +221,12 @@ pub const Session = struct {
             }
         }
 
-        // Skip the inbound listener entirely when proxied: accepting incoming
-        // peers would reveal the real IP to whoever connects.
+        // Skip the inbound listener entirely on any anonymized transport
+        // (proxy/Tor/I2P): accepting incoming clearnet peers would reveal the
+        // real IP. (Anonymized inbound — Tor hidden service / I2P — is wired
+        // separately, not via this clearnet listener.)
         var listener: ?std.net.Server = null;
-        if (proxy == null and (mode == .seed or our_bitfield.count() > 0)) {
+        if (proxy == null and i2p == null and (mode == .seed or our_bitfield.count() > 0)) {
             const bind_ip: [4]u8 = switch (listen_bind) {
                 .any => .{ 0, 0, 0, 0 },
                 .loopback => .{ 127, 0, 0, 1 },
@@ -260,6 +269,7 @@ pub const Session = struct {
             .dht_instance = null,
             .dht_failed = false,
             .proxy = proxy,
+            .i2p = i2p,
             .listen_bind = listen_bind,
             .tor_hidden = tor_hidden,
             .start_time = now,
@@ -455,8 +465,9 @@ pub const Session = struct {
                     break;
                 }
 
-                // Don't open an inbound listener when proxied (would leak our IP).
-                if (self.listener == null and self.proxy == null) {
+                // Don't open an inbound clearnet listener on any anonymized
+                // transport (would leak our IP).
+                if (self.listener == null and !self.anonymized()) {
                     const bind_ip: [4]u8 = switch (self.listen_bind) {
                         .any => .{ 0, 0, 0, 0 },
                         .loopback => .{ 127, 0, 0, 1 },
@@ -468,10 +479,10 @@ pub const Session = struct {
                 // Seeding only reads — swap the write handles for read-only
                 // ones so the completed files are usable by other programs.
                 self.store.downgradeToReadOnly();
-                if (self.proxy == null) {
+                if (!self.anonymized()) {
                     stdout.print("now seeding on port {d}...\n", .{self.listen_port}) catch {};
                 } else {
-                    stdout.print("download complete; seeding to outbound peers only (proxied)\n", .{}) catch {};
+                    stdout.print("download complete; seeding to outbound peers only (anonymized)\n", .{}) catch {};
                 }
             }
 
@@ -1446,6 +1457,10 @@ pub const Session = struct {
     }
 
     fn tryAnnounceUrl(self: *Session, url: []const u8, req: tracker_mod.AnnounceRequest) ?tracker_mod.AnnounceResponse {
+        // I2P (anonymized with no SOCKS/HTTP proxy) can't reach clearnet
+        // trackers, and announcing over them directly would leak the real IP.
+        // (I2P-native trackers are a follow-up.) Skip all clearnet trackers.
+        if (self.anonymized() and self.proxy == null) return null;
         if (std.mem.startsWith(u8, url, "udp://")) {
             // UDP cannot be carried over an HTTP/SOCKS CONNECT tunnel; disable
             // when proxied so we never leak the real IP via a raw datagram.
@@ -1537,6 +1552,10 @@ pub const Session = struct {
     /// Useful for testing and for manual peer addition.
     pub fn connectDirectPeer(self: *Session, addr: std.net.Address) !void {
         if (self.peers.items.len >= max_peers) return;
+        // On the I2P transport there is no clearnet route (and no proxy to tunnel
+        // through), so a clearnet IPv4 peer is unreachable and dialing it would
+        // leak the real IP — skip it. I2P peers arrive via connectI2pPeer.
+        if (self.i2p != null) return;
 
         const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
         errdefer self.allocator.destroy(p);
@@ -1557,6 +1576,30 @@ pub const Session = struct {
         p.* = try peer_mod.PeerConnection.initOnion(self.allocator, host, port);
         errdefer p.deinit();
         p.proxy = px;
+        try self.finishPeerConnect(p);
+    }
+
+    /// True when this transfer must not touch the clearnet — a proxy/Tor proxy
+    /// is set, or it's on the native I2P transport. All clearnet peer-discovery
+    /// and seeding machinery (inbound listener, DHT, UDP/HTTP trackers, web
+    /// seeds, direct dials) is disabled when this is true, so the real IP never
+    /// leaks regardless of which anonymity network is selected.
+    pub fn anonymized(self: *const Session) bool {
+        return self.proxy != null or self.i2p != null;
+    }
+
+    /// Connect to an I2P peer by `.b32.i2p` destination over the session's SAM
+    /// transport. `port` is the peer's advertised I2CP destination port (passed
+    /// to SAM as `TO_PORT`; 0 = default). Requires the `i2p` route (a live SAM
+    /// session).
+    pub fn connectI2pPeer(self: *Session, dest: []const u8, port: u16) !void {
+        if (self.peers.items.len >= max_peers) return;
+        const sam = self.i2p orelse return error.ConnectionFailed;
+
+        const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(p);
+        p.* = try peer_mod.PeerConnection.initI2p(self.allocator, dest, port, sam);
+        errdefer p.deinit();
         try self.finishPeerConnect(p);
     }
 
@@ -1604,9 +1647,9 @@ pub const Session = struct {
     // --- BEP 5: DHT peer discovery ---
 
     fn tryDhtPeerDiscovery(self: *Session) !void {
-        // DHT runs over UDP, which cannot be tunneled through an HTTP/SOCKS
-        // CONNECT proxy. Disable it when proxied to avoid leaking the real IP.
-        if (self.proxy != null) return;
+        // DHT runs over clearnet UDP, which can't be tunneled. Disable it on any
+        // anonymized transport (proxy/Tor/I2P) to avoid leaking the real IP.
+        if (self.anonymized()) return;
 
         // Don't retry if DHT previously failed to start (e.g. port busy)
         if (self.dht_failed) return;
@@ -1636,9 +1679,9 @@ pub const Session = struct {
     // --- BEP 19: Web seed downloads ---
 
     fn tryWebSeedDownload(self: *Session) !void {
-        // Web seeds use std.http.Client directly; disable when proxied (a
-        // proxied + Range-aware path is a follow-up).
-        if (self.proxy != null) return;
+        // Web seeds use std.http.Client directly (clearnet); disable on any
+        // anonymized transport (a tunneled, Range-aware path is a follow-up).
+        if (self.anonymized()) return;
 
         const urls = self.meta.url_list orelse return;
         if (urls.len == 0) return;


### PR DESCRIPTION
Implements the first slice of **I2P transport** for [#35](https://github.com/vincenzopalazzo/carl/issues/35): carl dials BitTorrent peers as `.b32.i2p` destinations over a native **SAM v3** bridge — the I2P analog of the Tor/onion path — while keeping carl's Nostr discovery layer.

Brainstorm: `docs/brainstorms/2026-06-08-i2p-transport-sam.md` (Approach A: phased native SAM; this is P1).

## What's here (P1: outbound / leech)
- **`src/i2p_sam.zig`** — native SAM v3 client: `Bridge` + `parseUrl`; `Session` (HELLO + SESSION CREATE; the control connection holds our destination open) and per-stream `connect` (HELLO + STREAM CONNECT → a transparent peer stream, the same "connected stream" contract as `proxy.zig`). Tested with pure reply-parser tests **and an in-process mock-SAM-bridge integration test** (success + error path).
- **`Route.i2p`** (`src/api.zig`), selectable via `carl daemon --route i2p --i2p-sam host:port` (default `127.0.0.1:7656`).
- **`Endpoint.i2p`** (`src/peer_announce.zig`) — `.b32.i2p` carried in the `host` tag (distinguished from `.onion` by suffix); `buildI2p` + `isValidI2pB32Host`, with tests.
- **Dial wiring** — `peer.zig` I2P connect branch (`initI2p`); `session.zig` `connectI2pPeer` + borrowed `i2p` session; `manager.zig` owns a per-transfer SAM session for the i2p route (created/torn down like the proxy) and feeds Nostr `.b32.i2p` peers to it.
- **Docs** — `docs/i2p.md` (router/SAM setup, usage, Tor-vs-I2P, manual E2E procedure) + `docs/proxy.md` Tor-vs-I2P section (the issue's documentation checkbox).

## Behavior
- The i2p route **fails closed** like proxy/Tor (clearnet DHT, UDP trackers, web seeds, inbound listener disabled).
- A missing/unreachable SAM bridge **fails fast with a clear error** (`SessionInitFailed` → HTTP 400); the daemon stays up (verified).

## Verification
- `zig build`, `zig build test` (incl. SAM mock-bridge + i2p endpoint tests), `zig fmt --check` — all green.
- Daemon starts on `--route i2p`; adding an i2p transfer with no router fails cleanly without crashing (verified locally).
- ⚠️ **Live swarm interop requires a running I2P router**, which isn't available in CI/on the dev host. The SAM protocol layer is unit-tested against a mock that speaks the real wire format; end-to-end is a documented manual procedure (`docs/i2p.md`).

## Follow-ups (tracked in #35)
- **P2**: inbound/seeding (`STREAM FORWARD` + stable persisted destination + announce our `.b32.i2p`).
- **P3**: I2P trackers (HTTP-over-SAM announce).
- **P4**: I2P DHT — recommend a separate issue (largest/riskiest piece).
- Note: Nostr relay traffic on the i2p route currently follows the existing relay-proxy logic; routing Nostr itself over I2P is orthogonal and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)