### PR TITLE
Fix double-free on failed Tor/onion peer dial

### DIFF
--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -10,6 +10,7 @@ const piece_mod = @import("piece.zig");
 const storage_mod = @import("storage.zig");
 const session_mod = @import("session.zig");
 const extension = @import("extension.zig");
+const proxy_mod = @import("proxy.zig");
 
 /// Generate deterministic test data of a given size.
 fn generateTestData(allocator: std.mem.Allocator, size: usize) ![]u8 {
@@ -495,4 +496,52 @@ test "magnet metadata exchange then download over loopback" {
         const downloaded = dl.store.readPiece(da, idx, plen) catch continue;
         try std.testing.expectEqualSlices(u8, test_data[start .. start + plen], downloaded);
     }
+}
+
+// =============================================================================
+// Regression: a failed onion peer dial must not double-free the PeerConnection
+// =============================================================================
+
+// connectOnionPeer sets up a PeerConnection with `errdefer p.deinit()` and then
+// calls finishPeerConnect. finishPeerConnect used to *also* free `p` on a connect
+// failure, so when a Tor peer dial failed both freed it — a double free that
+// crashes the process (observed in the wild via collectNostrPeers). Here the
+// proxy points at a refused port so the dial fails fast; the test passes only if
+// the connect error surfaces cleanly with no double free (the GPA testing
+// allocator aborts on a double free, failing the test on the buggy code).
+test "connectOnionPeer cleans up exactly once when the dial fails" {
+    const allocator = std.testing.allocator;
+
+    const test_data = try generateTestData(allocator, 1024);
+    defer allocator.free(test_data);
+
+    var tm = try buildTestMetainfo(allocator, test_data, 1024, "onion_double_free.bin");
+    defer tm.deinit();
+
+    var dir = std.testing.tmpDir(.{});
+    defer dir.cleanup();
+    const dir_path = try dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(dir_path);
+
+    // SOCKS proxy at a port that refuses immediately, so the dial fails fast
+    // without touching the network. The Proxy borrows `host` from this literal.
+    const proxy = try proxy_mod.parseUrl("socks5://127.0.0.1:1");
+
+    var sess = try session_mod.Session.init(
+        allocator,
+        tm.meta,
+        dir_path,
+        .download,
+        0,
+        proxy,
+        .any,
+        false,
+    );
+    defer sess.deinit();
+
+    // The dial must fail (proxy refused), and crucially must free the peer
+    // exactly once. On the pre-fix code this double-frees and the test aborts.
+    try std.testing.expectError(error.ConnectionFailed, sess.connectOnionPeer("examplepeer.onion", 6881));
+    // The failed peer must not have been adopted into the peer set.
+    try std.testing.expectEqual(@as(usize, 0), sess.peers.items.len);
 }

--- a/src/session.zig
+++ b/src/session.zig
@@ -1419,7 +1419,9 @@ pub const Session = struct {
         if (self.peers.items.len >= max_peers) return;
 
         const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(p);
         p.* = peer_mod.PeerConnection.init(self.allocator, addr);
+        errdefer p.deinit();
         p.proxy = self.proxy;
 
         try self.finishPeerConnect(p);
@@ -1438,24 +1440,16 @@ pub const Session = struct {
         try self.finishPeerConnect(p);
     }
 
+    /// Connect, handshake, and adopt `p` into the peer set. Single-owner
+    /// contract: on any error `p` is left untouched (NOT freed) so the caller's
+    /// errdefer frees it exactly once; on success ownership transfers to
+    /// `self.peers`. Previously this freed `p` on error *and* the caller's
+    /// errdefer (in connectOnionPeer) freed it too — a double free that aborted
+    /// the daemon when a Tor peer dial failed.
     fn finishPeerConnect(self: *Session, p: *peer_mod.PeerConnection) !void {
-        p.connect() catch {
-            p.deinit();
-            self.allocator.destroy(p);
-            return error.ConnectionFailed;
-        };
-
-        p.sendHandshake(self.info_hash, self.peer_id) catch {
-            p.deinit();
-            self.allocator.destroy(p);
-            return error.OutOfMemory;
-        };
-
-        self.peers.append(self.allocator, p) catch {
-            p.deinit();
-            self.allocator.destroy(p);
-            return error.OutOfMemory;
-        };
+        p.connect() catch return error.ConnectionFailed;
+        p.sendHandshake(self.info_hash, self.peer_id) catch return error.OutOfMemory;
+        try self.peers.append(self.allocator, p);
     }
 
     /// Run a single iteration of the event loop (for testing).


### PR DESCRIPTION
## Summary
- **What was broken:** the daemon aborts with a GPA "Double free detected" (then a general protection fault) when a Tor/onion peer dial fails — e.g. dialing a `.b32`/`.onion` peer from a Nostr announce while the SOCKS proxy / relays are unreachable.
- **Root cause:** `connectOnionPeer` constructs a `PeerConnection` guarded by `errdefer p.deinit()` + `errdefer destroy(p)`, then calls `finishPeerConnect`. `finishPeerConnect` *also* freed `p` (deinit + destroy) on each error path, so on a failed dial both the function and the caller's errdefer freed the same allocation.
- **What the fix does:** gives `finishPeerConnect` a single-owner contract — it no longer frees `p` on error (just propagates the error); the caller's errdefer frees it exactly once, and on success ownership transfers to `self.peers`. `connectDirectPeer`, which had no errdefer and relied on the old in-function cleanup, gets the matching errdefers. `connectToPeers` was already self-contained (inline cleanup + `continue`) and is unaffected.

Observed via `collectNostrPeers` → `connectOnionPeer` → `finishPeerConnect` → `p.connect()` failure.

## Test plan
- [x] New regression test (`connectOnionPeer cleans up exactly once when the dial fails`) drives the dial through a refused proxy; verified it **aborts (signal 6) on the pre-fix code** and **passes** with the fix.
- [x] `zig build`, `zig build test`, `zig fmt --check` all green.
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)