### PR TITLE
Detect and report SOCKS proxy / Tor health

### DIFF
--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -52,6 +52,19 @@ export interface Identity {
   npub: string;
 }
 
+/** Health of the configured SOCKS proxy on the proxy/tor route. */
+export interface ProxyHealth {
+  state:
+    | "disabled"
+    | "checking"
+    | "ok"
+    | "not_running"
+    | "timeout"
+    | "rejected";
+  endpoint: string;
+  detail: string;
+}
+
 export interface Settings {
   route: Route;
   socks: string;
@@ -92,6 +105,7 @@ export interface AppState {
   transfers: Transfer[];
   seeds: Seed[];
   relays: Relay[];
+  proxy: ProxyHealth;
   identity: Identity;
   settings: Settings;
 }
@@ -100,6 +114,7 @@ export const emptyState: AppState = {
   transfers: [],
   seeds: [],
   relays: [],
+  proxy: { state: "disabled", endpoint: "", detail: "" },
   identity: { npub: "" },
   settings: {
     route: "direct",

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -3,7 +3,7 @@ import { Icon, OnionIcon } from "../components/icons";
 import { CopyField } from "../components/atoms";
 import { trunc } from "../components/format";
 import { useCarl } from "../api/store";
-import type { Route } from "../api/types";
+import type { Route, ProxyHealth } from "../api/types";
 import {
   cliStatus,
   installCli,
@@ -146,20 +146,48 @@ function CliToolsSection() {
   );
 }
 
-function LeakCheck({ route, socks }: { route: Route; socks: string }) {
-  const safe = route !== "direct";
+// Live proxy/Tor health driven by the daemon's background probe (state.proxy),
+// so the panel says whether the SOCKS proxy is actually reachable instead of
+// assuming "any non-direct route is safe".
+function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
+  if (route === "direct") {
+    return (
+      <div className="leak-check lc-warn">
+        <span className="lc-dot" />
+        <div className="lc-body">
+          <div className="lc-title">Direct connection — IP exposed</div>
+          <div className="lc-detail mono">
+            your IP is visible to trackers, DHT &amp; peers
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const ep = proxy.endpoint || "the proxy";
+  const TITLE: Record<ProxyHealth["state"], string> = {
+    ok: "Proxy reachable — leak check passed",
+    checking: "Checking proxy…",
+    not_running: "Proxy not running",
+    timeout: "Proxy connection timed out",
+    rejected: "Proxy rejected the connection",
+    disabled: "",
+  };
+  const DETAIL: Record<ProxyHealth["state"], string> = {
+    ok: `routed via ${ep} · DNS over the proxy`,
+    checking: `probing ${ep}…`,
+    not_running: `${ep} refused the connection — is Tor / your proxy running?`,
+    timeout: `${ep} timed out — check the address and port`,
+    rejected: `${ep} rejected SOCKS5${proxy.detail ? ` · ${proxy.detail}` : ""} — check it's a SOCKS5 proxy (auth may be required)`,
+    disabled: "",
+  };
+  const safe = proxy.state === "ok";
   return (
     <div className={"leak-check " + (safe ? "lc-safe" : "lc-warn")}>
       <span className="lc-dot" />
       <div className="lc-body">
-        <div className="lc-title">
-          {safe ? "Leak check passed" : "Direct connection — IP exposed"}
-        </div>
-        <div className="lc-detail mono">
-          {route === "tor" && `routed via ${socks} · DNS over the proxy`}
-          {route === "proxy" && `all traffic via ${socks} · DNS proxied`}
-          {route === "direct" && "your IP is visible to trackers, DHT & peers"}
-        </div>
+        <div className="lc-title">{TITLE[proxy.state]}</div>
+        <div className="lc-detail mono">{DETAIL[proxy.state]}</div>
       </div>
     </div>
   );
@@ -274,7 +302,7 @@ export function SettingsScreen() {
               </div>
             )}
 
-            <LeakCheck route={s.route} socks={s.socks} />
+            <LeakCheck route={s.route} proxy={state.proxy} />
 
             <div className="callout-note">
               <Icon name="shield" size={15} stroke={1.8} />

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -80,8 +80,25 @@ The combined initial-load payload (and the per-tick WebSocket push). Object:
   "transfers": [Transfer],
   "seeds":     [Seed],
   "relays":    [Relay],
+  "proxy":     ProxyHealth,
   "identity":  Identity,
   "settings":  Settings
+}
+```
+
+`ProxyHealth` reports the SOCKS proxy's reachability on the proxy/tor route:
+
+```jsonc
+{
+  // "disabled"  — direct route, no proxy configured
+  // "checking"  — before the first probe lands
+  // "ok"        — reachable and speaks SOCKS5
+  // "not_running" — connection refused (e.g. Tor isn't running)
+  // "timeout"   — connect/greeting timed out
+  // "rejected"  — reachable but not SOCKS5 / no acceptable auth method
+  "state": "ok",
+  "endpoint": "socks5h://127.0.0.1:9050",
+  "detail": ""   // e.g. "SOCKS5 replied 0xff" when state == "rejected"
 }
 ```
 
@@ -92,7 +109,9 @@ The combined initial-load payload (and the per-tick WebSocket push). Object:
 A background prober refreshes relay reachability every ~30s (open + close a
 connection per relay, through the configured route), so `state` reflects real
 `connected` / `unreachable` status rather than just `configured`. The same
-status rides in `GET /api/state` and the WebSocket push.
+prober classifies the SOCKS proxy each cycle (a SOCKS5 method-negotiation
+greeting only — no CONNECT, so it opens no upstream connection) and publishes
+`proxy`. All of this rides in `GET /api/state` and the WebSocket push.
 ### `GET /api/identity` → `Identity`
 ### `GET /api/settings` → `Settings`
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -144,6 +144,25 @@ carl download debian-12.iso.torrent --output-dir ~/Downloads \
 > block BitTorrent peer ports, so a full download may stall. Use `ssh -D` or
 > `microsocks` for a complete download.
 
+## Is the proxy actually reachable? (health detection)
+
+On a proxy/tor route, carl tells you *why* the route isn't working instead of
+silently failing:
+
+- **At startup**, `carl daemon --route tor` (or `proxy`) probes the SOCKS port
+  and logs one of: `reachable`, `unreachable (connection refused) -- is Tor
+  running?`, `timed out`, or `rejected the SOCKS5 handshake`.
+- **Continuously**, the daemon re-probes every ~30s and publishes the result as
+  `proxy` in `GET /api/state` + the WebSocket push (see `docs/daemon-api.md`).
+  The desktop **Settings → Anonymity** panel shows it live: reachable / not
+  running / timed out / rejected.
+
+The probe only performs the SOCKS5 **method-negotiation greeting** — it never
+issues a `CONNECT`, so it opens no upstream connection and leaks no traffic. It
+distinguishes "nothing listening" (Tor down) from "timed out" from "rejected"
+(not a SOCKS5 proxy, or auth required). Full SOCKS5 `CONNECT` reply codes only
+arise on real peer dials; surfacing those per-transfer is a follow-up.
+
 ## Verifying there are no leaks
 
 This is the test that matters for a privacy feature -- prove that **nothing**

--- a/src/api.zig
+++ b/src/api.zig
@@ -137,6 +137,19 @@ pub const Relay = struct {
     events: u64 = 0,
 };
 
+/// Health of the configured SOCKS proxy on the proxy/tor route, so the UI and
+/// logs can say *why* the route isn't working (Tor down / timeout / rejected)
+/// instead of silently failing. Probed by the daemon's background prober.
+pub const ProxyHealth = struct {
+    /// "disabled" (direct route) | "checking" (before first probe) |
+    /// "ok" | "not_running" | "timeout" | "rejected"
+    state: []const u8,
+    /// The SOCKS endpoint being probed (e.g. "socks5h://127.0.0.1:9050").
+    endpoint: []const u8,
+    /// Human-readable detail, e.g. the SOCKS5 reply byte for "rejected"; "" otherwise.
+    detail: []const u8 = "",
+};
+
 /// A file being seeded.
 pub const Seed = struct {
     id: []const u8,
@@ -410,6 +423,14 @@ pub fn writeRelay(j: *Json, r: Relay) Allocator.Error!void {
     try j.keyString("state", r.state);
     try j.keyString("net", r.net);
     try j.keyNumber("events", r.events);
+    try j.endObject();
+}
+
+pub fn writeProxyHealth(j: *Json, h: ProxyHealth) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("state", h.state);
+    try j.keyString("endpoint", h.endpoint);
+    try j.keyString("detail", h.detail);
     try j.endObject();
 }
 

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -180,7 +180,13 @@ pub const Daemon = struct {
     /// Never opens an upstream connection (greeting only) — see classifySocks5.
     fn probeProxy(self: *Daemon) void {
         if (self.manager.cfg.route == .direct) {
-            self.publishProxy(.ok, null); // unused for direct; snapshot maps to "disabled"
+            // Don't fabricate an "ok": mark unprobed so that if the route later
+            // switches to proxy/tor, the snapshot shows an honest "checking"
+            // until a real probe lands (rather than a stale/false "ok"). The
+            // direct route is reported as "disabled" by the snapshot regardless.
+            self.health_mutex.lock();
+            self.proxy_probed = false;
+            self.health_mutex.unlock();
             return;
         }
         const proxy = proxy_mod.parseUrl(self.manager.cfg.socks) catch {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -57,6 +57,11 @@ pub const Daemon = struct {
     /// Last relay-health probe result (owned). Guarded by `health_mutex`.
     health_mutex: std.Thread.Mutex = .{},
     health: []api.Relay = &.{},
+    /// Last SOCKS-proxy-health probe (proxy/tor route), guarded by `health_mutex`.
+    /// `proxy_probed` is false until the first probe lands (UI shows "checking").
+    proxy_state: proxy_mod.ProxyState = .ok,
+    proxy_reply: ?u8 = null,
+    proxy_probed: bool = false,
 
     /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
     pub fn serve(self: *Daemon, port: u16) !void {
@@ -143,9 +148,63 @@ pub const Daemon = struct {
         return out;
     }
 
+    /// Snapshot proxy health for the API. `endpoint` is duped into `arena`.
+    /// Maps the direct route to "disabled" and the pre-first-probe window to
+    /// "checking"; otherwise reflects the last `classifySocks5` result.
+    fn proxyHealthSnapshot(self: *Daemon, arena: Allocator) !api.ProxyHealth {
+        // Mask any SOCKS auth credentials before exposing the endpoint.
+        const raw = self.manager.cfg.socks;
+        const rbuf = try arena.alloc(u8, raw.len + 4);
+        const endpoint = try arena.dupe(u8, proxy_mod.redactUrl(raw, rbuf));
+        if (self.manager.cfg.route == .direct)
+            return .{ .state = "disabled", .endpoint = endpoint };
+
+        self.health_mutex.lock();
+        const probed = self.proxy_probed;
+        const st = self.proxy_state;
+        const reply = self.proxy_reply;
+        self.health_mutex.unlock();
+
+        if (!probed) return .{ .state = "checking", .endpoint = endpoint };
+
+        var detail: []const u8 = "";
+        if (st == .rejected) {
+            if (reply) |b| {
+                detail = std.fmt.allocPrint(arena, "SOCKS5 replied 0x{x:0>2}", .{b}) catch "";
+            }
+        }
+        return .{ .state = st.jsonName(), .endpoint = endpoint, .detail = detail };
+    }
+
+    /// Probe the SOCKS proxy once (proxy/tor route only) and cache the result.
+    /// Never opens an upstream connection (greeting only) — see classifySocks5.
+    fn probeProxy(self: *Daemon) void {
+        if (self.manager.cfg.route == .direct) {
+            self.publishProxy(.ok, null); // unused for direct; snapshot maps to "disabled"
+            return;
+        }
+        const proxy = proxy_mod.parseUrl(self.manager.cfg.socks) catch {
+            // Malformed proxy URL is a config error the user must fix; surface it
+            // as "rejected" so the route doesn't silently look healthy.
+            self.publishProxy(.rejected, null);
+            return;
+        };
+        const probe = proxy_mod.classifySocks5(self.allocator, proxy, 5);
+        self.publishProxy(probe.state, probe.reply);
+    }
+
+    fn publishProxy(self: *Daemon, state: proxy_mod.ProxyState, reply: ?u8) void {
+        self.health_mutex.lock();
+        self.proxy_state = state;
+        self.proxy_reply = reply;
+        self.proxy_probed = true;
+        self.health_mutex.unlock();
+    }
+
     fn relayHealthLoop(self: *Daemon) void {
         while (self.running.load(.acquire) and !session_mod.shutdown_requested.load(.acquire)) {
             self.probeRelays();
+            self.probeProxy();
             // Persist any newly-resolved magnet torrents (headless coverage; the
             // WS push also does this ~1/s when the GUI is connected).
             self.manager.checkpoint();
@@ -794,6 +853,8 @@ fn buildStateJson(arena: Allocator, daemon: *Daemon, relays: []const api.Relay, 
     try j.beginArray();
     for (relays) |r| try api.writeRelay(&j, r);
     try j.endArray();
+    try j.key("proxy");
+    try api.writeProxyHealth(&j, try daemon.proxyHealthSnapshot(arena));
     try j.key("identity");
     try api.writeIdentity(&j, .{ .npub = npub });
     try j.key("settings");

--- a/src/main.zig
+++ b/src/main.zig
@@ -893,6 +893,25 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     try stdout.print("token: {s}\n", .{token});
     try stdout.print("route: {s}\n", .{route_str});
 
+    // On a proxy/tor route, check the SOCKS proxy up front and say clearly why
+    // it's unreachable (the daemon keeps running and the GUI shows live health).
+    if (route != .direct) {
+        // Mask any user:pass@ credentials before logging the proxy URL.
+        var rbuf: [512]u8 = undefined;
+        const safe_socks = carl.proxy.redactUrl(socks, &rbuf);
+        if (carl.proxy.parseUrl(socks)) |px| {
+            const probe = carl.proxy.classifySocks5(allocator, px, 5);
+            switch (probe.state) {
+                .ok => log.info("SOCKS proxy {s} reachable", .{safe_socks}),
+                .not_running => log.warn("SOCKS proxy {s} unreachable (connection refused) -- is Tor/your proxy running?", .{safe_socks}),
+                .timeout => log.warn("SOCKS proxy {s} timed out -- check the address/port and that the proxy is up", .{safe_socks}),
+                .rejected => log.warn("SOCKS proxy {s} rejected the SOCKS5 handshake -- check it's a SOCKS5 proxy (auth may be required)", .{safe_socks}),
+            }
+        } else |_| {
+            log.warn("invalid --socks URL '{s}' for the {s} route", .{ safe_socks, route_str });
+        }
+    }
+
     daemon.serve(port) catch |err| {
         log.err("daemon error: {}", .{err});
         std.process.exit(1);

--- a/src/main.zig
+++ b/src/main.zig
@@ -896,7 +896,9 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     // On a proxy/tor route, check the SOCKS proxy up front and say clearly why
     // it's unreachable (the daemon keeps running and the GUI shows live health).
     if (route != .direct) {
-        // Mask any user:pass@ credentials before logging the proxy URL.
+        // Mask any user:pass@ credentials before logging the proxy URL. redactUrl
+        // is credential-safe even if this buffer is too small (it then returns
+        // the bare host:port), so a fixed buffer can't leak the password.
         var rbuf: [512]u8 = undefined;
         const safe_socks = carl.proxy.redactUrl(socks, &rbuf);
         if (carl.proxy.parseUrl(socks)) |px| {

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -140,21 +140,24 @@ pub fn parseUrl(url: []const u8) ProxyError!Proxy {
 }
 
 /// Mask any `user:pass@` userinfo in a proxy URL so it is safe to log or show
-/// in the API/UI — SOCKS5 auth credentials must never leak. Writes the masked
-/// form into `out` and returns that slice; if there's no userinfo (or `out` is
-/// too small) returns the input `url` unchanged. `out` should be at least
-/// `url.len + 4` bytes to always fit the `***@` mask.
+/// in the API/UI — SOCKS5 auth credentials must never leak. Returns a slice that
+/// is guaranteed credential-free on every path:
+///   - no `://` or no userinfo → the input unchanged (already credential-free);
+///   - userinfo + room in `out` → the masked `scheme://***@host:port`;
+///   - userinfo but `out` too small → the bare `host:port` (still no creds).
+/// `out` should be `url.len + 4` bytes to fit the `***@` mask.
 pub fn redactUrl(url: []const u8, out: []u8) []const u8 {
     const sep = std.mem.indexOf(u8, url, "://") orelse return url;
     const after = sep + 3;
-    // Match parseUrl's delimiter choice (last '@', so a '@' inside a password
-    // doesn't truncate early). Search only the authority portion.
+    // Last '@' matches parseUrl's delimiter choice, so a '@' inside the password
+    // doesn't truncate early. (A stray '@' in a credential-free path would only
+    // cause harmless over-redaction, never a leak.)
     const rest = url[after..];
     const at_rel = std.mem.lastIndexOfScalar(u8, rest, '@') orelse return url;
     const prefix = url[0..after]; // "scheme://"
     const suffix = rest[at_rel + 1 ..]; // "host:port[/...]"
     const mask = "***@";
-    if (out.len < prefix.len + mask.len + suffix.len) return url;
+    if (out.len < prefix.len + mask.len + suffix.len) return suffix; // credential-free fallback
     @memcpy(out[0..prefix.len], prefix);
     @memcpy(out[prefix.len..][0..mask.len], mask);
     @memcpy(out[prefix.len + mask.len ..][0..suffix.len], suffix);
@@ -379,13 +382,18 @@ fn resolveIp4(allocator: Allocator, host: []const u8, port: u16) ProxyError!std.
 
 /// Health-check a SOCKS5 proxy using only the method-negotiation greeting — we
 /// never send a CONNECT, so the proxy is not asked to open any upstream
-/// connection and this probe leaks no traffic from the privacy tool. Bounded by
-/// `timeout_secs` end to end. Pure classification: never returns an error, it
-/// maps every failure into a `ProxyState`. (Full CONNECT reply codes only arise
-/// on real peer dials — surfacing those per-transfer is a documented follow-up.)
+/// connection and this probe leaks no traffic from the privacy tool. The connect
+/// and greeting phases are bounded by `timeout_secs`; the initial DNS resolve is
+/// not (typical SOCKS hosts are IP literals like 127.0.0.1, so no DNS happens).
+/// Pure classification: never returns an error, it maps every failure into a
+/// `ProxyState`. (Full CONNECT reply codes only arise on real peer dials —
+/// surfacing those per-transfer is a documented follow-up.)
 pub fn classifySocks5(allocator: Allocator, proxy: Proxy, timeout_secs: u32) ProxyProbe {
     const addr = resolveIp4(allocator, proxy.host, proxy.port) catch
         return .{ .state = .not_running }; // can't resolve → treat as unreachable
+    // poll() takes an i32 millisecond timeout; clamp so a pathological
+    // `timeout_secs` can't overflow the cast (callers pass small values).
+    const timeout_ms: i32 = if (timeout_secs > 600) 600_000 else @intCast(timeout_secs * 1000);
 
     const sock = std.posix.socket(
         std.posix.AF.INET,
@@ -405,7 +413,7 @@ pub fn classifySocks5(allocator: Allocator, proxy: Proxy, timeout_secs: u32) Pro
     std.posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
         error.WouldBlock => {
             var pfd = [_]std.posix.pollfd{.{ .fd = sock, .events = std.posix.POLL.OUT, .revents = 0 }};
-            const ready = std.posix.poll(&pfd, @intCast(@as(u64, timeout_secs) * 1000)) catch
+            const ready = std.posix.poll(&pfd, timeout_ms) catch
                 return .{ .state = .timeout };
             if (ready == 0) return .{ .state = .timeout };
             // Surface the async connect result: refused => not running, else timeout.
@@ -1012,5 +1020,12 @@ test "redactUrl masks SOCKS credentials" {
     try std.testing.expectEqualStrings(
         "socks5://***@host:1080",
         redactUrl("socks5://u:p@ss@host:1080", &buf),
+    );
+    // Buffer too small for the masked form falls back to the bare host:port —
+    // still credential-free (never the raw user:pass).
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "host:1080",
+        redactUrl("socks5://user:pass@host:1080", &tiny),
     );
 }

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -40,6 +40,33 @@ pub const ProxyError = error{
 
 pub const Scheme = enum { socks5, socks5h, http };
 
+/// Health classification of a SOCKS proxy, for the daemon's proxy-health probe.
+/// Distinguishes the failure modes a misconfigured Tor setup actually hits so
+/// the UI/log can say *why* the route isn't working instead of a generic fail.
+pub const ProxyState = enum {
+    /// Reachable and speaks SOCKS5 (accepted the no-auth method).
+    ok,
+    /// Nothing is listening on the SOCKS port (connection refused) — e.g. Tor
+    /// isn't running.
+    not_running,
+    /// The connect or the SOCKS5 greeting timed out.
+    timeout,
+    /// Reachable but rejected us: not SOCKS5, or no acceptable auth method
+    /// (`reply` carries the offending byte, e.g. 0xFF = auth required).
+    rejected,
+
+    pub fn jsonName(self: ProxyState) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// Result of `classifySocks5`. `reply` is the SOCKS5 method-selection / version
+/// byte when `state == .rejected` and the server spoke at all; null otherwise.
+pub const ProxyProbe = struct {
+    state: ProxyState,
+    reply: ?u8 = null,
+};
+
 /// A parsed proxy specification. String fields borrow from the URL passed to
 /// `parseUrl` -- that buffer (typically argv) must outlive the Proxy.
 pub const Proxy = struct {
@@ -110,6 +137,28 @@ pub fn parseUrl(url: []const u8) ProxyError!Proxy {
         .username = username,
         .password = password,
     };
+}
+
+/// Mask any `user:pass@` userinfo in a proxy URL so it is safe to log or show
+/// in the API/UI — SOCKS5 auth credentials must never leak. Writes the masked
+/// form into `out` and returns that slice; if there's no userinfo (or `out` is
+/// too small) returns the input `url` unchanged. `out` should be at least
+/// `url.len + 4` bytes to always fit the `***@` mask.
+pub fn redactUrl(url: []const u8, out: []u8) []const u8 {
+    const sep = std.mem.indexOf(u8, url, "://") orelse return url;
+    const after = sep + 3;
+    // Match parseUrl's delimiter choice (last '@', so a '@' inside a password
+    // doesn't truncate early). Search only the authority portion.
+    const rest = url[after..];
+    const at_rel = std.mem.lastIndexOfScalar(u8, rest, '@') orelse return url;
+    const prefix = url[0..after]; // "scheme://"
+    const suffix = rest[at_rel + 1 ..]; // "host:port[/...]"
+    const mask = "***@";
+    if (out.len < prefix.len + mask.len + suffix.len) return url;
+    @memcpy(out[0..prefix.len], prefix);
+    @memcpy(out[prefix.len..][0..mask.len], mask);
+    @memcpy(out[prefix.len + mask.len ..][0..suffix.len], suffix);
+    return out[0 .. prefix.len + mask.len + suffix.len];
 }
 
 // --- Public connect entry points ---
@@ -326,6 +375,64 @@ fn resolveIp4(allocator: Allocator, host: []const u8, port: u16) ProxyError!std.
         if (a.any.family == std.posix.AF.INET) return a;
     }
     return error.DnsResolveFailed;
+}
+
+/// Health-check a SOCKS5 proxy using only the method-negotiation greeting — we
+/// never send a CONNECT, so the proxy is not asked to open any upstream
+/// connection and this probe leaks no traffic from the privacy tool. Bounded by
+/// `timeout_secs` end to end. Pure classification: never returns an error, it
+/// maps every failure into a `ProxyState`. (Full CONNECT reply codes only arise
+/// on real peer dials — surfacing those per-transfer is a documented follow-up.)
+pub fn classifySocks5(allocator: Allocator, proxy: Proxy, timeout_secs: u32) ProxyProbe {
+    const addr = resolveIp4(allocator, proxy.host, proxy.port) catch
+        return .{ .state = .not_running }; // can't resolve → treat as unreachable
+
+    const sock = std.posix.socket(
+        std.posix.AF.INET,
+        std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
+        std.posix.IPPROTO.TCP,
+    ) catch return .{ .state = .timeout };
+    defer std.posix.close(sock);
+
+    // Non-blocking connect + poll so a filtered/dead host yields a real timeout
+    // (SO_SNDTIMEO does not bound connect() on macOS), and so we can tell
+    // "connection refused" (proxy not running) from "timed out".
+    const flags = std.posix.fcntl(sock, std.posix.F.GETFL, 0) catch return .{ .state = .timeout };
+    var o: std.posix.O = @bitCast(@as(u32, @truncate(flags)));
+    o.NONBLOCK = true;
+    _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+    std.posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        error.WouldBlock => {
+            var pfd = [_]std.posix.pollfd{.{ .fd = sock, .events = std.posix.POLL.OUT, .revents = 0 }};
+            const ready = std.posix.poll(&pfd, @intCast(@as(u64, timeout_secs) * 1000)) catch
+                return .{ .state = .timeout };
+            if (ready == 0) return .{ .state = .timeout };
+            // Surface the async connect result: refused => not running, else timeout.
+            std.posix.getsockoptError(sock) catch |e| return .{
+                .state = if (e == error.ConnectionRefused) .not_running else .timeout,
+            };
+        },
+        error.ConnectionRefused => return .{ .state = .not_running },
+        else => return .{ .state = .timeout },
+    };
+
+    // Connected. Back to blocking with bounded reads/writes for the greeting.
+    o.NONBLOCK = false;
+    _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+    const tv = std.posix.timeval{ .sec = @intCast(timeout_secs), .usec = 0 };
+    std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch {};
+    std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+
+    const stream = std.net.Stream{ .handle = sock };
+    // SOCKS5 greeting: VER=5, NMETHODS=1, METHOD=0x00 (no auth).
+    writeAll(stream, &[_]u8{ 0x05, 0x01, 0x00 }) catch return .{ .state = .timeout };
+    var reply: [2]u8 = undefined;
+    readN(stream, &reply) catch return .{ .state = .timeout };
+
+    if (reply[0] != 0x05) return .{ .state = .rejected, .reply = reply[0] }; // not SOCKS5
+    if (reply[1] == 0x00) return .{ .state = .ok }; // no-auth accepted
+    return .{ .state = .rejected, .reply = reply[1] }; // 0xFF = auth required / no method
 }
 
 // --- Blocking stream I/O helpers ---
@@ -781,4 +888,129 @@ test "responseComplete stops on full Content-Length body" {
     try std.testing.expect(!responseComplete("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n")); // no header terminator
     // chunked is read to EOF, not treated as complete by this check
     try std.testing.expect(!responseComplete("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"));
+}
+
+// --- classifySocks5 against a mock SOCKS5 endpoint ---
+
+const MockSocks = struct {
+    server: *std.net.Server,
+    stop: std.atomic.Value(bool),
+    reply: [2]u8,
+};
+
+fn mockSocksRun(ctx: *MockSocks) void {
+    // Poll-with-timeout accept so the thread can observe `stop` and exit (a bare
+    // accept() would park forever); mirrors the i2p_sam mock-bridge test.
+    var pfd = [_]std.posix.pollfd{.{ .fd = ctx.server.stream.handle, .events = std.posix.POLL.IN, .revents = 0 }};
+    while (!ctx.stop.load(.acquire)) {
+        const ready = std.posix.poll(&pfd, 200) catch 0;
+        if (ready == 0) continue;
+        const conn = ctx.server.accept() catch continue;
+        defer conn.stream.close();
+        var greeting: [3]u8 = undefined; // VER, NMETHODS, METHOD
+        var got: usize = 0;
+        while (got < greeting.len) {
+            const n = conn.stream.read(greeting[got..]) catch break;
+            if (n == 0) break;
+            got += n;
+        }
+        var sent: usize = 0;
+        while (sent < ctx.reply.len) {
+            const n = conn.stream.write(ctx.reply[sent..]) catch break;
+            if (n == 0) break;
+            sent += n;
+        }
+    }
+}
+
+fn startMockSocks(server: *std.net.Server, reply: [2]u8) !struct { ctx: *MockSocks, thread: std.Thread } {
+    const ctx = try std.testing.allocator.create(MockSocks);
+    ctx.* = .{ .server = server, .stop = std.atomic.Value(bool).init(false), .reply = reply };
+    const thread = try std.Thread.spawn(.{}, mockSocksRun, .{ctx});
+    return .{ .ctx = ctx, .thread = thread };
+}
+
+test "classifySocks5: connection refused => not_running" {
+    const a = std.testing.allocator;
+    // Bind to grab a free port, then close it so connects are refused.
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    server.deinit();
+
+    const probe = classifySocks5(a, .{ .scheme = .socks5, .host = "127.0.0.1", .port = port }, 2);
+    try std.testing.expectEqual(ProxyState.not_running, probe.state);
+}
+
+test "classifySocks5: no-auth accepted => ok" {
+    const a = std.testing.allocator;
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    const mock = try startMockSocks(&server, .{ 0x05, 0x00 });
+    defer {
+        mock.ctx.stop.store(true, .release);
+        mock.thread.join();
+        server.deinit();
+        a.destroy(mock.ctx);
+    }
+
+    const probe = classifySocks5(a, .{ .scheme = .socks5, .host = "127.0.0.1", .port = port }, 2);
+    try std.testing.expectEqual(ProxyState.ok, probe.state);
+}
+
+test "classifySocks5: no acceptable method => rejected with reply byte" {
+    const a = std.testing.allocator;
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    const mock = try startMockSocks(&server, .{ 0x05, 0xFF });
+    defer {
+        mock.ctx.stop.store(true, .release);
+        mock.thread.join();
+        server.deinit();
+        a.destroy(mock.ctx);
+    }
+
+    const probe = classifySocks5(a, .{ .scheme = .socks5, .host = "127.0.0.1", .port = port }, 2);
+    try std.testing.expectEqual(ProxyState.rejected, probe.state);
+    try std.testing.expectEqual(@as(?u8, 0xFF), probe.reply);
+}
+
+test "classifySocks5: non-SOCKS5 version => rejected" {
+    const a = std.testing.allocator;
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    const mock = try startMockSocks(&server, .{ 0x04, 0x00 }); // SOCKS4-ish version byte
+    defer {
+        mock.ctx.stop.store(true, .release);
+        mock.thread.join();
+        server.deinit();
+        a.destroy(mock.ctx);
+    }
+
+    const probe = classifySocks5(a, .{ .scheme = .socks5, .host = "127.0.0.1", .port = port }, 2);
+    try std.testing.expectEqual(ProxyState.rejected, probe.state);
+    try std.testing.expectEqual(@as(?u8, 0x04), probe.reply);
+}
+
+test "redactUrl masks SOCKS credentials" {
+    var buf: [128]u8 = undefined;
+    // With userinfo: password is masked.
+    try std.testing.expectEqualStrings(
+        "socks5h://***@127.0.0.1:9050",
+        redactUrl("socks5h://user:pass@127.0.0.1:9050", &buf),
+    );
+    // user-only (no password) is still masked.
+    try std.testing.expectEqualStrings(
+        "socks5://***@host:1080",
+        redactUrl("socks5://bob@host:1080", &buf),
+    );
+    // No userinfo: returned unchanged (no copy needed).
+    try std.testing.expectEqualStrings(
+        "socks5h://127.0.0.1:9050",
+        redactUrl("socks5h://127.0.0.1:9050", &buf),
+    );
+    // '@' inside the password doesn't truncate early (last '@' is the delimiter).
+    try std.testing.expectEqualStrings(
+        "socks5://***@host:1080",
+        redactUrl("socks5://u:p@ss@host:1080", &buf),
+    );
 }


### PR DESCRIPTION
## Summary
On a proxy/tor route there was no way to tell whether Tor is running, the connection timed out, or the SOCKS5 handshake was rejected — every failure looked the same (and the Settings "leak check" was static, claiming "passed" even with Tor down). This adds active detection (slice A from the brainstorm).

- **`proxy.classifySocks5`** — dials the SOCKS port (non-blocking connect + poll, so a dead host yields a real `timeout` distinct from connection-`refused`) and runs **only the SOCKS5 method-negotiation greeting** — no `CONNECT`, so the proxy is never asked to open an upstream connection and the probe leaks no traffic from the privacy tool. Classifies `ok` / `not_running` / `timeout` / `rejected` (non-SOCKS5 or no-acceptable-method, carrying the reply byte).
- **Background prober** — runs alongside the existing relay prober (startup + every ~30s, only off the direct route), publishing a `proxy` health object in `GET /api/state` + the WebSocket push.
- **Surfaces:** (1) daemon/CLI startup log — `SOCKS proxy ... unreachable -- is Tor running?`; (2) the `proxy` API field; (3) desktop **Settings → Anonymity** — the static `LeakCheck` is now driven by live health (reachable / not running / timed out / rejected).
- **Credentials:** any `user:pass@` userinfo in the SOCKS URL is masked (`redactUrl`) before it is logged or exposed in the API/UI.

Fail-closed semantics unchanged; Tor is never auto-started.

### Scope
Per-transfer failure-reason threading and full `CONNECT` reply codes are a documented follow-up (slice B) — the classifier already carries the reply byte for it.

## Test plan
- [x] `zig build`, `zig build test`, `zig fmt --check` — green. New tests: `classifySocks5` against a mock SOCKS listener (closed port → `not_running`; `0x05 0xFF` → `rejected` w/ reply byte; `0x05 0x00` → `ok`; non-`0x05` → `rejected`) + `redactUrl` credential masking.
- [x] Desktop `tsc --noEmit` + `vite build` — green.
- [x] `docs/proxy.md` + `docs/daemon-api.md` updated (new `proxy` state field + health section).
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)