### PR TITLE
Make UI-created Tor seeds reachable and discoverable

### DIFF
--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -55,7 +55,17 @@ export class DaemonClient {
 
   private async json<T>(res: Response): Promise<T> {
     if (!res.ok) {
-      throw new Error(`${res.status} ${res.statusText}`);
+      // Surface the daemon's `{ "error": "..." }` body when present, so the UI
+      // shows an actionable reason (e.g. Tor ControlPort not enabled) instead
+      // of a bare status code.
+      let detail = "";
+      try {
+        const body = (await res.json()) as { error?: unknown };
+        if (body && typeof body.error === "string") detail = `: ${body.error}`;
+      } catch {
+        /* non-JSON or empty body — fall back to the status line */
+      }
+      throw new Error(`${res.status} ${res.statusText}${detail}`);
     }
     return (await res.json()) as T;
   }

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -14,8 +14,15 @@ identity/relays/settings read the real config. See **Not yet wired** at the end.
 
 ```sh
 carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
-            [--download-dir d] [--token tok] [--parent-pid pid]
+            [--download-dir d] [--token tok] [--parent-pid pid] \
+            [--tor-control host:port] [--tor-cookie path] [--tor-onion-port p]
 ```
+
+- `--tor-control` (default `127.0.0.1:9051`) / `--tor-cookie` (default
+  `~/.tor/control_auth_cookie`) / `--tor-onion-port` (default `80`): Tor
+  ControlPort settings used to create the hidden service for a `tor`-route seed
+  (`POST /api/seeds` with `X-Carl-Route: tor`). Tor must have its ControlPort
+  enabled with cookie auth.
 
 - `--parent-pid`: when set (the desktop shell passes its own PID), a watchdog
   shuts the daemon down if that process dies — so a hard-killed app never leaves
@@ -119,8 +126,16 @@ directly); metadata rides in headers:
 
 The daemon writes the file into the download dir, hashes it into a torrent
 in-process (no external tool), and seeds it. Returns `{ "id": "t<N>" }`. Bodies
-are capped at 256 MiB. (The peer-announce for a clearnet/onion endpoint is still
-the CLI's `carl seed` job; this publishes the discoverable torrent metadata.)
+are capped at 256 MiB.
+
+On the **`tor` route** the daemon stands up a v3 Tor hidden service for the seed
+(via Tor's ControlPort, same as `carl seed --tor-seed`) and publishes a
+kind-30078 **onion peer-announce** alongside the NIP-35 metadata — so a Tor
+downloader can actually discover *and* dial the seeder. The seed's `.onion` is
+returned in the `Seed.onion` field. This requires Tor's ControlPort to be
+reachable; if it isn't, the request fails `400` with
+`{ "error": "Tor hidden service setup failed: …" }`. `direct`/`proxy` seeds
+publish only the discoverable NIP-35 metadata (no routable endpoint to announce).
 
 ### `POST /api/search`
 

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -438,6 +438,9 @@ const Conn = struct {
 
         const id = self.daemon.manager.addSeed(full, route_val, want_nostr) catch |err| {
             log.warn("addSeed failed: {}", .{err});
+            if (err == error.TorControlFailed) {
+                return self.sendError(.bad_request, "Tor hidden service setup failed: carl couldn't reach Tor's ControlPort. Enable it in your torrc (ControlPort 9051 + CookieAuthentication 1) and restart Tor, then retry the Tor seed.");
+            }
             return self.sendStatus(.bad_request);
         };
         defer a.free(id);
@@ -750,6 +753,18 @@ const Conn = struct {
     fn sendStatus(self: *Conn, status: http.Status) !void {
         // A tiny JSON body keeps clients that always parse JSON happy.
         try self.sendJson(status, "{}");
+    }
+
+    /// Like `sendStatus` but with an `{ "error": "<message>" }` body so the GUI
+    /// can show a specific, actionable reason instead of a bare status code.
+    fn sendError(self: *Conn, status: http.Status, message: []const u8) !void {
+        var arena = std.heap.ArenaAllocator.init(self.daemon.allocator);
+        defer arena.deinit();
+        var j = api.Json.init(arena.allocator());
+        j.beginObject() catch return self.sendStatus(status);
+        j.keyString("error", message) catch return self.sendStatus(status);
+        j.endObject() catch return self.sendStatus(status);
+        try self.sendJson(status, j.buf.items);
     }
 
     fn sendAll(self: *Conn, buf: []const u8) !void {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -17,6 +17,7 @@ pub const nip19 = @import("nip19.zig");
 pub const nostr = @import("nostr.zig");
 pub const nip35 = @import("nip35.zig");
 pub const peer_announce = @import("peer_announce.zig");
+pub const seeding = @import("seeding.zig");
 pub const tor_control = @import("tor_control.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -141,7 +141,10 @@ fn printUsage() void {
         \\  nostr-keygen                                     generate a fresh nostr key
         \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url]
         \\         [--download-dir d] [--token tok] [--parent-pid pid]
+        \\         [--tor-control host:port] [--tor-cookie path] [--tor-onion-port p]
         \\           run a localhost HTTP+WebSocket API for the desktop GUI.
+        \\           --tor-* configure the ControlPort used to create hidden
+        \\           services for tor-route seeds (default 127.0.0.1:9051).
         \\           binds 127.0.0.1 only; every request needs the printed token
         \\           (X-Carl-Token header, or ?token= for the /ws upgrade).
         \\
@@ -515,7 +518,9 @@ fn cmdSeed(
                 log.err("tor hidden service setup failed: {}", .{err});
                 std.process.exit(1);
             };
-            publishNostrOnion(allocator, mi, hidden.?.onion_host, hidden.?.onion_port, description, nostr_proxy) catch |err| {
+            carl.seeding.publish(allocator, mi, carl.metainfo.infoHash(mi.raw_info), .{
+                .onion = .{ .host = hidden.?.onion_host, .port = hidden.?.onion_port },
+            }, description, nostr_proxy) catch |err| {
                 log.warn("nostr publish failed: {} (continuing seed)", .{err});
             };
         } else {
@@ -530,7 +535,9 @@ fn cmdSeed(
                 );
                 std.process.exit(1);
             }
-            publishNostrIpv4(allocator, mi, ip, port, description, null) catch |err| {
+            carl.seeding.publish(allocator, mi, carl.metainfo.infoHash(mi.raw_info), .{
+                .ipv4 = .{ .ip = ip, .port = port },
+            }, description, null) catch |err| {
                 log.warn("nostr publish failed: {} (continuing seed)", .{err});
             };
         }
@@ -838,6 +845,12 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     };
     const socks = parseFlag(extra, "--socks") orelse "";
     const download_dir = parseFlag(extra, "--download-dir") orelse "";
+    // Tor ControlPort config for reachable `.tor` seeds (hidden services). The
+    // empty defaults let Manager.init fall back to 127.0.0.1:9051 + the default
+    // cookie path, matching the CLI `carl seed --tor-seed` defaults.
+    const tor_control = parseFlag(extra, "--tor-control") orelse "";
+    const tor_cookie = parseFlag(extra, "--tor-cookie") orelse "";
+    const tor_onion_port: u16 = parsePortFlag(extra, "--tor-onion-port", 80);
 
     // Token: use --token if given, else generate a random 32-hex secret. The
     // Tauri sidecar reads it off stdout and presents it on every request.
@@ -858,6 +871,9 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         .socks = socks,
         .download_dir = download_dir,
         .listen_port = bt_port,
+        .tor_control = tor_control,
+        .tor_cookie = tor_cookie,
+        .tor_onion_port = tor_onion_port,
     }) catch |err| {
         log.err("failed to init manager: {}", .{err});
         std.process.exit(1);
@@ -910,90 +926,6 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
 // -------------------------------------------------------------------------
 // Nostr helpers for seed/download
 // -------------------------------------------------------------------------
-
-fn publishNostrIpv4(
-    allocator: std.mem.Allocator,
-    mi: carl.metainfo.Metainfo,
-    external_ip: [4]u8,
-    port: u16,
-    description: []const u8,
-    proxy: ?carl.proxy.Proxy,
-) !void {
-    const sk = try readNostrSecretKey(allocator);
-    const pk = try carl.secp.publicKeyFromSecret(sk);
-    const info_hash = carl.metainfo.infoHash(mi.raw_info);
-
-    var torrent_ev = try carl.nip35.buildFromMetainfo(allocator, sk, pk, mi, info_hash, description);
-    defer torrent_ev.deinit(allocator);
-    var announce_ev = try carl.peer_announce.build(allocator, sk, pk, info_hash, external_ip, port);
-    defer announce_ev.deinit(allocator);
-
-    try publishNostrEvents(allocator, torrent_ev, announce_ev, proxy);
-}
-
-fn publishNostrOnion(
-    allocator: std.mem.Allocator,
-    mi: carl.metainfo.Metainfo,
-    onion_host: []const u8,
-    onion_port: u16,
-    description: []const u8,
-    proxy: ?carl.proxy.Proxy,
-) !void {
-    const sk = try readNostrSecretKey(allocator);
-    const pk = try carl.secp.publicKeyFromSecret(sk);
-    const info_hash = carl.metainfo.infoHash(mi.raw_info);
-
-    var torrent_ev = try carl.nip35.buildFromMetainfo(allocator, sk, pk, mi, info_hash, description);
-    defer torrent_ev.deinit(allocator);
-    var announce_ev = try carl.peer_announce.buildOnion(allocator, sk, pk, info_hash, onion_host, onion_port);
-    defer announce_ev.deinit(allocator);
-
-    try publishNostrEvents(allocator, torrent_ev, announce_ev, proxy);
-}
-
-fn readNostrSecretKey(allocator: std.mem.Allocator) !carl.secp.SecretKey {
-    return carl.nostr_config.readSecretKey(allocator) catch |err| {
-        switch (err) {
-            error.NoKey => {
-                log.err("no nostr key configured. run `carl nostr-keygen` first", .{});
-                return error.NoKey;
-            },
-            else => return err,
-        }
-    };
-}
-
-fn publishNostrEvents(
-    allocator: std.mem.Allocator,
-    torrent_ev: carl.nostr.Event,
-    announce_ev: carl.nostr.Event,
-    proxy: ?carl.proxy.Proxy,
-) !void {
-    const relay_urls = try carl.nostr_config.readRelays(allocator);
-    defer carl.nostr_config.freeRelays(allocator, relay_urls);
-
-    var torrent_acks: usize = 0;
-    var announce_acks: usize = 0;
-    for (relay_urls) |url| {
-        var r = carl.relay.Relay.connect(allocator, url, proxy) catch |err| {
-            log.warn("nostr publish: {s}: {}", .{ url, err });
-            continue;
-        };
-        defer r.deinit();
-        if (carl.relay.publishAndWait(allocator, &r, torrent_ev, 5_000)) {
-            log.info("published kind-2003 to {s}", .{url});
-            torrent_acks += 1;
-        }
-        if (carl.relay.publishAndWait(allocator, &r, announce_ev, 5_000)) {
-            log.info("published kind-30078 peer-announce to {s}", .{url});
-            announce_acks += 1;
-        }
-    }
-    log.info(
-        "nostr publish: kind-2003 {d}/{d} relays, kind-30078 {d}/{d} relays",
-        .{ torrent_acks, relay_urls.len, announce_acks, relay_urls.len },
-    );
-}
 
 /// Fetch the most recent kind-2003 (NIP-35) torrent event for `info_hash`,
 /// returning its parsed entry (title, trackers, files). Caller owns the result

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -25,8 +25,9 @@ const magnet_mod = @import("magnet.zig");
 const proxy_mod = @import("proxy.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
-const nip35 = @import("nip35.zig");
 const peer_announce = @import("peer_announce.zig");
+const seeding = @import("seeding.zig");
+const tor_control = @import("tor_control.zig");
 const state_mod = @import("state.zig");
 const nostr_config = @import("nostr_config.zig");
 const nostr_mod = @import("nostr.zig");
@@ -41,6 +42,10 @@ pub const Error = error{
     HttpFailed,
     BadProxy,
     SessionInitFailed,
+    /// Failed to stand up the Tor hidden service for a `.tor` seed (Tor
+    /// ControlPort unreachable, cookie auth failed, etc.). Fails closed rather
+    /// than creating a seed nobody can reach.
+    TorControlFailed,
     NotFound,
 } || Allocator.Error;
 
@@ -54,6 +59,13 @@ pub const Config = struct {
     max_active: u32 = 8,
     peer_limit: u32 = 60,
     publish_nip35: bool = true,
+    /// Tor ControlPort `host:port` for creating hidden services when seeding on
+    /// the `tor` route (so a UI-created Tor seed is reachable). Default 9051.
+    tor_control: []const u8 = "",
+    /// Path to the Tor control cookie; empty = default (`~/.tor/control_auth_cookie`).
+    tor_cookie: []const u8 = "",
+    /// Virtual port exposed on the seed's `.onion`.
+    tor_onion_port: u16 = 80,
 };
 
 /// One running transfer: its session, the thread driving it, and the metadata
@@ -80,6 +92,9 @@ const ManagedTransfer = struct {
     /// Owned copy of the socks URL the proxy slices borrow from.
     socks_owned: ?[]u8,
     proxy: ?proxy_mod.Proxy,
+    /// Tor hidden service backing a `.tor` seed (the onion leechers dial).
+    /// Owned; torn down (DEL_ONION) in `destroy` after the session stops.
+    hidden: ?tor_control.HiddenService,
     session: *session_mod.Session,
     meta: metainfo.Metainfo,
     thread: ?std.Thread,
@@ -112,6 +127,9 @@ const ManagedTransfer = struct {
         self.stop();
         self.session.deinit();
         self.allocator.destroy(self.session);
+        // Tear down the onion after the session (and its loopback listener) is
+        // gone, so we DEL_ONION only once nothing is forwarding to it.
+        if (self.hidden) |*h| h.deinit();
         self.meta.deinit(self.allocator);
         if (self.socks_owned) |s| self.allocator.free(s);
         self.allocator.free(self.id);
@@ -143,6 +161,9 @@ pub const Manager = struct {
                 .max_active = cfg.max_active,
                 .peer_limit = cfg.peer_limit,
                 .publish_nip35 = cfg.publish_nip35,
+                .tor_control = try allocator.dupe(u8, if (cfg.tor_control.len > 0) cfg.tor_control else "127.0.0.1:9051"),
+                .tor_cookie = try allocator.dupe(u8, cfg.tor_cookie),
+                .tor_onion_port = if (cfg.tor_onion_port > 0) cfg.tor_onion_port else 80,
             },
         };
     }
@@ -153,6 +174,8 @@ pub const Manager = struct {
         self.transfers.deinit(self.allocator);
         self.allocator.free(self.cfg.socks);
         self.allocator.free(self.cfg.download_dir);
+        self.allocator.free(self.cfg.tor_control);
+        self.allocator.free(self.cfg.tor_cookie);
     }
 
     // -----------------------------------------------------------------------
@@ -183,7 +206,7 @@ pub const Manager = struct {
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, false, magnet, source);
+        return self.register(built, route, resolved_proxy, socks_owned, null, want_nostr, false, magnet, source);
     }
 
     /// Create a torrent from a local file (or archive) and start seeding it. The
@@ -210,13 +233,43 @@ pub const Manager = struct {
         };
         // Seed from the file's own directory so storage resolves it by name.
         const data_dir = std.fs.path.dirname(path) orelse ".";
+
+        // Tor route: stand up a v3 hidden service so leechers can actually reach
+        // this seed, and run the session as a loopback hidden-service seed (no
+        // outbound proxy, tracker/DHT suppressed) — the same wiring as the CLI's
+        // `carl seed --tor-seed`. The resolved SOCKS proxy stays as the
+        // transfer's `proxy` so `publishSeedNostr` publishes the onion announce
+        // over Tor; the session itself takes no proxy (inbound-only via the onion).
+        // Fails closed (`TorControlFailed`) rather than creating an unreachable seed.
+        var hidden: ?tor_control.HiddenService = null;
+        var session_proxy = resolved_proxy;
+        var listen_bind: session_mod.ListenBind = .any;
+        var tor_hidden = false;
+        if (route == .tor) {
+            hidden = tor_control.addOnion(self.allocator, .{
+                .control_addr = self.cfg.tor_control,
+                .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
+                .local_port = self.cfg.listen_port,
+                .onion_port = self.cfg.tor_onion_port,
+            }) catch {
+                if (socks_owned) |s| self.allocator.free(s);
+                mi.deinit(self.allocator);
+                return error.TorControlFailed;
+            };
+            session_proxy = null;
+            listen_bind = .loopback;
+            tor_hidden = true;
+        }
+
         const session = self.allocator.create(session_mod.Session) catch {
             if (socks_owned) |s| self.allocator.free(s);
+            if (hidden) |*h| h.deinit();
             mi.deinit(self.allocator);
             return error.OutOfMemory;
         };
-        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, self.cfg.listen_port, resolved_proxy, .any, false) catch {
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, self.cfg.listen_port, session_proxy, listen_bind, tor_hidden) catch {
             if (socks_owned) |s| self.allocator.free(s);
+            if (hidden) |*h| h.deinit();
             self.allocator.destroy(session);
             mi.deinit(self.allocator);
             return error.SessionInitFailed;
@@ -227,6 +280,7 @@ pub const Manager = struct {
         secp.toHex(&session.info_hash, &hex);
         const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch {
             if (socks_owned) |s| self.allocator.free(s);
+            if (hidden) |*h| h.deinit();
             session.deinit();
             self.allocator.destroy(session);
             mi.deinit(self.allocator);
@@ -234,7 +288,7 @@ pub const Manager = struct {
         };
         defer self.allocator.free(magnet);
 
-        return self.register(built, route, resolved_proxy, socks_owned, want_nostr, true, magnet, path);
+        return self.register(built, route, resolved_proxy, socks_owned, hidden, want_nostr, true, magnet, path);
     }
 
     /// Register a built session as a managed transfer and spawn its thread.
@@ -248,6 +302,7 @@ pub const Manager = struct {
         route: api.Route,
         resolved_proxy: ?proxy_mod.Proxy,
         socks_owned: ?[]u8,
+        hidden: ?tor_control.HiddenService,
         want_nostr: bool,
         is_seed: bool,
         magnet_src: []const u8,
@@ -257,6 +312,10 @@ pub const Manager = struct {
         errdefer if (!mt_owned) {
             built.session.deinit();
             self.allocator.destroy(built.session);
+            if (hidden) |h| {
+                var hh = h;
+                hh.deinit();
+            }
             built.meta.deinit(self.allocator);
             if (socks_owned) |s| self.allocator.free(s);
         };
@@ -293,6 +352,7 @@ pub const Manager = struct {
             .has_http_tracker = std.mem.startsWith(u8, built.meta.announce, "http"),
             .socks_owned = socks_owned,
             .proxy = resolved_proxy,
+            .hidden = hidden,
             .session = built.session,
             .meta = built.meta,
             .thread = null,
@@ -381,7 +441,7 @@ pub const Manager = struct {
                 .id = mt.id,
                 .name = mt.name,
                 .visibility = mt.route,
-                .onion = null,
+                .onion = if (mt.hidden) |h| try arena.dupe(u8, h.onion_host) else null,
                 .size = p.total_length,
                 .up_total = p.uploaded,
                 .up = mt.rate_up,
@@ -828,28 +888,19 @@ fn runThread(mt: *ManagedTransfer) void {
     };
 }
 
-/// Publish a NIP-35 (kind-2003) torrent event for a seed so it's discoverable
-/// in Discover. Best-effort. The peer-announce (which needs a routable endpoint
-/// or an onion) is left to the CLI's `carl seed` for now; the torrent metadata
-/// event needs no reachable address and is enough to surface the torrent.
+/// Publish a seed's Nostr events via the shared `seeding.publish` (the same path
+/// the CLI `carl seed` uses). A `.tor` seed has a hidden service, so it also
+/// publishes a kind-30078 onion peer-announce — what a Tor leecher needs to dial
+/// it — over Tor (via `mt.proxy`). Other seeds publish only NIP-35 discovery
+/// metadata (no routable endpoint to announce). Best-effort.
 fn publishSeedNostr(mt: *ManagedTransfer) void {
-    const a = mt.allocator;
-    const sk = nostr_config.readSecretKey(a) catch return; // no key → skip
-    const pk = secp.publicKeyFromSecret(sk) catch return;
-    var ev = nip35.buildFromMetainfo(a, sk, pk, mt.meta, mt.info_hash, "") catch return;
-    defer ev.deinit(a);
-
-    const relay_urls = nostr_config.readRelays(a) catch return;
-    defer nostr_config.freeRelays(a, relay_urls);
-
-    var acks: usize = 0;
-    for (relay_urls) |url| {
-        if (!mt.session.running) return;
-        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
-        defer r.deinit();
-        if (relay_mod.publishAndWait(a, &r, ev, 5_000)) acks += 1;
-    }
-    if (acks > 0) log.info("seed {s}: published NIP-35 torrent event to {d} relay(s)", .{ mt.id, acks });
+    const ann: seeding.Announce = if (mt.hidden) |h|
+        .{ .onion = .{ .host = h.onion_host, .port = h.onion_port } }
+    else
+        .none;
+    seeding.publish(mt.allocator, mt.meta, mt.info_hash, ann, "", mt.proxy) catch |err| {
+        log.warn("seed {s}: nostr publish failed: {}", .{ mt.id, err });
+    };
 }
 
 /// Pull peer-announce (kind-30078) endpoints for this info-hash off the

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -210,6 +210,20 @@ pub const Manager = struct {
     }
 
     /// Create a torrent from a local file (or archive) and start seeding it. The
+    /// Bind a throwaway loopback socket to discover a free port. Each `.tor`
+    /// seed needs its own listener port: every seed otherwise reuses
+    /// `cfg.listen_port`, but only one Session can bind a given port, so a second
+    /// concurrent tor seed would silently fail to listen and be unreachable
+    /// behind its onion. There's a tiny TOCTOU window before the Session
+    /// re-binds; on the rare loss the Session's listener is null and `addSeed`
+    /// warns. Returns null if even the probe bind fails (caller falls back).
+    fn pickLoopbackPort(self: *Manager) ?u16 {
+        _ = self;
+        var server = (std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true })) catch return null;
+        defer server.deinit();
+        return server.listen_address.getPort();
+    }
+
     /// file is hashed in-process — carl needs no external torrent tool. With
     /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
     pub fn addSeed(self: *Manager, path: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
@@ -245,11 +259,15 @@ pub const Manager = struct {
         var session_proxy = resolved_proxy;
         var listen_bind: session_mod.ListenBind = .any;
         var tor_hidden = false;
+        var seed_port = self.cfg.listen_port;
         if (route == .tor) {
+            // Give each tor seed its own loopback port so concurrent tor seeds
+            // don't collide on cfg.listen_port. The onion forwards to this port.
+            seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
             hidden = tor_control.addOnion(self.allocator, .{
                 .control_addr = self.cfg.tor_control,
                 .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
-                .local_port = self.cfg.listen_port,
+                .local_port = seed_port,
                 .onion_port = self.cfg.tor_onion_port,
             }) catch {
                 if (socks_owned) |s| self.allocator.free(s);
@@ -267,13 +285,18 @@ pub const Manager = struct {
             mi.deinit(self.allocator);
             return error.OutOfMemory;
         };
-        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, self.cfg.listen_port, session_proxy, listen_bind, tor_hidden) catch {
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden) catch {
             if (socks_owned) |s| self.allocator.free(s);
             if (hidden) |*h| h.deinit();
             self.allocator.destroy(session);
             mi.deinit(self.allocator);
             return error.SessionInitFailed;
         };
+        // A tor seed whose listener didn't bind is unreachable behind its onion
+        // (e.g. a port race). Surface it rather than silently half-seeding.
+        if (route == .tor and session.listener == null) {
+            log.warn("tor seed: listener failed to bind 127.0.0.1:{d}; the onion will be unreachable", .{seed_port});
+        }
         const built = Built{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
 
         var hex: [40]u8 = undefined;
@@ -558,6 +581,7 @@ pub const Manager = struct {
 
         self.restoring = true;
         var restored: usize = 0;
+        var failed: usize = 0;
         for (st.transfers) |t| {
             const res = switch (t.kind) {
                 .download => self.addTransfer(t.source, t.route, t.nostr),
@@ -567,11 +591,21 @@ pub const Manager = struct {
                 self.allocator.free(id);
                 restored += 1;
             } else |e| {
-                log.warn("restore: could not re-add '{s}': {}", .{ t.source, e });
+                failed += 1;
+                log.warn("restore: could not re-add '{s}': {} (keeping it on disk)", .{ t.source, e });
             }
         }
         self.restoring = false;
-        self.persist();
+        // Only re-persist when every saved transfer came back. `persist` rewrites
+        // the DB purely from the live set, so persisting after a failure would
+        // permanently delete the dropped specs — e.g. a `tor` seed whose hidden
+        // service couldn't be created because Tor wasn't up yet at restart. Leave
+        // the on-disk state intact so the next restart retries them.
+        if (failed == 0) {
+            self.persist();
+        } else {
+            log.warn("restore: {d} transfer(s) didn't come back; leaving saved state intact for retry", .{failed});
+        }
         if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
     }
 

--- a/src/seeding.zig
+++ b/src/seeding.zig
@@ -1,0 +1,81 @@
+//! Shared seeding helpers used by BOTH the CLI (`carl seed`) and the daemon
+//! (`Manager.addSeed`), so a seed created from the desktop UI behaves exactly
+//! like one created on the command line — same Nostr events, same relays, same
+//! routing. Previously the CLI published a NIP-35 metadata event *and* a
+//! dialable peer-announce while the daemon published only the metadata, so a
+//! UI-created Tor seed was discoverable but unreachable (no peer to dial).
+//!
+//! `publish` emits the torrent's NIP-35 discovery event (kind 2003) and, when
+//! `ann` names a reachable endpoint, a peer-announce (kind 30078) carrying the
+//! `.onion` host or routable IPv4 a leecher needs to connect.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const metainfo = @import("metainfo.zig");
+const nip35 = @import("nip35.zig");
+const peer_announce = @import("peer_announce.zig");
+const nostr = @import("nostr.zig");
+const relay = @import("relay.zig");
+const nostr_config = @import("nostr_config.zig");
+const secp = @import("secp.zig");
+const proxy_mod = @import("proxy.zig");
+
+const log = std.log.scoped(.seeding);
+
+/// The reachable endpoint to advertise for a seed.
+pub const Announce = union(enum) {
+    /// Discovery metadata only (NIP-35); no dialable peer-announce. Used when
+    /// the seed has no routable endpoint (e.g. a plain direct/proxy seed).
+    none,
+    /// Tor hidden service: advertise the v3 `.onion` host + virtual port.
+    onion: struct { host: []const u8, port: u16 },
+    /// Classic public seed: advertise a routable IPv4 + port.
+    ipv4: struct { ip: [4]u8, port: u16 },
+};
+
+/// Publish a torrent's NIP-35 discovery event (kind 2003) and, when `ann` names
+/// a reachable endpoint, a peer-announce (kind 30078) so leechers can dial the
+/// seeder. `proxy` routes the relay connections (e.g. Tor SOCKS) so publishing
+/// doesn't leak. Returns `error.NoNostrKey` if no identity is configured.
+pub fn publish(
+    allocator: Allocator,
+    mi: metainfo.Metainfo,
+    info_hash: [20]u8,
+    ann: Announce,
+    description: []const u8,
+    proxy: ?proxy_mod.Proxy,
+) !void {
+    const sk = nostr_config.readSecretKey(allocator) catch return error.NoNostrKey;
+    const pk = try secp.publicKeyFromSecret(sk);
+
+    var torrent_ev = try nip35.buildFromMetainfo(allocator, sk, pk, mi, info_hash, description);
+    defer torrent_ev.deinit(allocator);
+
+    const announce_ev: ?nostr.Event = switch (ann) {
+        .none => null,
+        .onion => |o| try peer_announce.buildOnion(allocator, sk, pk, info_hash, o.host, o.port),
+        .ipv4 => |v| try peer_announce.build(allocator, sk, pk, info_hash, v.ip, v.port),
+    };
+    defer if (announce_ev) |ev| ev.deinit(allocator);
+
+    const relay_urls = try nostr_config.readRelays(allocator);
+    defer nostr_config.freeRelays(allocator, relay_urls);
+
+    var torrent_acks: usize = 0;
+    var announce_acks: usize = 0;
+    for (relay_urls) |url| {
+        var r = relay.Relay.connect(allocator, url, proxy) catch |err| {
+            log.warn("nostr publish: {s}: {}", .{ url, err });
+            continue;
+        };
+        defer r.deinit();
+        if (relay.publishAndWait(allocator, &r, torrent_ev, 5_000)) torrent_acks += 1;
+        if (announce_ev) |ev| {
+            if (relay.publishAndWait(allocator, &r, ev, 5_000)) announce_acks += 1;
+        }
+    }
+    log.info("nostr publish: kind-2003 {d}/{d} relays, kind-30078 {d}/{d} relays", .{
+        torrent_acks, relay_urls.len, announce_acks, relay_urls.len,
+    });
+}

--- a/src/seeding.zig
+++ b/src/seeding.zig
@@ -37,7 +37,8 @@ pub const Announce = union(enum) {
 /// Publish a torrent's NIP-35 discovery event (kind 2003) and, when `ann` names
 /// a reachable endpoint, a peer-announce (kind 30078) so leechers can dial the
 /// seeder. `proxy` routes the relay connections (e.g. Tor SOCKS) so publishing
-/// doesn't leak. Returns `error.NoNostrKey` if no identity is configured.
+/// doesn't leak. Propagates `readSecretKey`'s error (e.g. `error.NoKey` when no
+/// identity is configured) so callers can report the real reason.
 pub fn publish(
     allocator: Allocator,
     mi: metainfo.Metainfo,
@@ -46,7 +47,7 @@ pub fn publish(
     description: []const u8,
     proxy: ?proxy_mod.Proxy,
 ) !void {
-    const sk = nostr_config.readSecretKey(allocator) catch return error.NoNostrKey;
+    const sk = try nostr_config.readSecretKey(allocator);
     const pk = try secp.publicKeyFromSecret(sk);
 
     var torrent_ev = try nip35.buildFromMetainfo(allocator, sk, pk, mi, info_hash, description);

--- a/src/tor_control.zig
+++ b/src/tor_control.zig
@@ -10,6 +10,10 @@ const posix = std.posix;
 
 const log = std.log.scoped(.tor);
 
+/// Bound on control-connection reads/writes so a port that accepts but never
+/// replies (something other than Tor) can't wedge the caller indefinitely.
+const control_timeout_secs: i64 = 10;
+
 pub const Error = error{
     ConnectFailed,
     AuthFailed,
@@ -120,7 +124,15 @@ fn connectControl(allocator: Allocator, addr_str: []const u8) !std.net.Stream {
     defer list.deinit();
 
     for (list.addrs) |a| {
-        if (std.net.tcpConnectToAddress(a)) |s| return s else |_| {}
+        if (std.net.tcpConnectToAddress(a)) |s| {
+            // Bound control reads/writes: `authenticate`/`readReply` do blocking
+            // reads with no timeout, so without this a port that accepts but
+            // never replies (not Tor) would wedge the caller forever.
+            const tv = posix.timeval{ .sec = control_timeout_secs, .usec = 0 };
+            posix.setsockopt(s.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+            posix.setsockopt(s.handle, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch {};
+            return s;
+        } else |_| {}
     }
     return error.ConnectFailed;
 }


### PR DESCRIPTION
## Summary
A seed created from the desktop UI with **tor** visibility produced **no peers** for a Tor downloader. Deep research (full seed → announce → discover → dial trace) pinned the root cause entirely on the **seed side** — the download path was already correct:

`manager.addSeed(.tor)` (1) never created a Tor hidden service, (2) ran the session with a proxy set so the inbound listener was disabled (anonymized), and (3) published only NIP-35 metadata — **never a kind-30078 onion peer-announce**, which is exactly what a Tor downloader's `collectNostrPeers` filters for. So the seed was both unreachable *and* undiscoverable as a peer. The correct logic existed only in the CLI `carl seed --tor-seed`.

Per the directive to **share one code path** (so "if it works on CLI it works everywhere"):

- **`src/seeding.zig`** (new) — `publish(mi, info_hash, Announce, description, proxy)` builds the NIP-35 event and, for a reachable endpoint, a peer-announce (`onion` or `ipv4`), publishing both to relays over an optional proxy. The CLI and daemon now both call it; the CLI's duplicated `publishNostr{Onion,Ipv4,Events}`/`readNostrSecretKey` are removed.
- **`manager.addSeed`** — on the `tor` route, stands up a v3 hidden service (`tor_control.addOnion`) and runs the session as a loopback hidden-service seed (`proxy=null`, `tor_hidden=true`), the same wiring as `--tor-seed`. The resolved SOCKS proxy stays as the transfer's proxy so the announce publishes over Tor. Fails closed with `TorControlFailed` (clear `400` + message) if Tor's ControlPort isn't reachable.
- **`ManagedTransfer`** owns the `HiddenService` and tears it down (DEL_ONION) after the session stops; `seeds()` reports the live `.onion` so the UI's onion callout appears.
- **Daemon flags** `--tor-control` / `--tor-cookie` / `--tor-onion-port` (defaults match the CLI).
- **Client** surfaces the daemon's `{error}` body, so the UI shows the actionable "enable Tor ControlPort" message instead of a bare 400.

## Requirements / scope
- Needs Tor's ControlPort + cookie auth (documented in `daemon-api.md`).
- Ephemeral onion per session — a stable persisted destination across restarts is a follow-up.
- Per-transfer proxy-failure reasons and I2P seeding remain separate follow-ups.

## Test plan
- [x] `zig build`, `zig build test`, `zig fmt --check` — green. Desktop `tsc --noEmit` + `vite build` — green.
- [x] Shared `seeding.publish` used by both CLI and daemon (single path).
- [ ] CI passes
- [ ] Manual Tor E2E (documented): seed from UI on `tor` → onion appears; download on another host over Tor finds + dials it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)