### PR TITLE
Unify default work dir and release file locks on completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ carl download https://archlinux.org/releng/releases/2026.04.01/torrent/
 carl download file.torrent --output-dir ~/Downloads --port 6882
 ```
 
+Without `--output-dir`, downloads land in carl's **work dir** — the single
+download + seed directory shared by the CLI, the daemon, and the desktop app:
+`$CARL_DIR` if set, else the download folder picked in the app's Settings,
+else `~/Downloads/carl`. Anything in that directory can be reseeded directly:
+`carl seed <file.torrent>` (no data-dir needed) and the desktop app both read
+from it, and finished downloads keep seeding from it.
+
 ### Inspect a torrent file
 
 ```sh
@@ -102,6 +109,10 @@ carl announce file.torrent
 
 ```sh
 carl seed file.torrent /path/to/data --port 6881
+
+# data-dir omitted: seeds from the shared carl work dir (~/Downloads/carl),
+# where downloads land — drop a file there to reseed it
+carl seed file.torrent
 ```
 
 ### Anonymous mode (proxy)

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -223,40 +223,21 @@ fn uninstall_cli(system: bool) -> Result<(), String> {
     }
 }
 
-/// The default download folder for the desktop app — its own directory under
-/// the user's Downloads (like Telegram's "Telegram Desktop" folder), so
-/// downloads never land in the daemon's CWD (which is `/` for a Finder launch).
-/// The user can still change it in Settings.
-fn default_download_dir() -> Option<std::path::PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    Some(
-        std::path::Path::new(&home)
-            .join("Downloads")
-            .join("carl-download"),
-    )
-}
-
 /// Spawn `carl daemon` and block (with a timeout) until it reports its token.
 fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
     let bin = resolve_carl_bin();
     let port_s = port.to_string();
     let pid_s = std::process::id().to_string();
 
-    // Give the daemon a real download dir up front. The daemon defaults to `.`,
-    // which for a Finder-launched app is `/` (unwritable) — so without this,
-    // downloads fail to write. Created best-effort; the user can change it later.
-    let download_dir = default_download_dir();
-    if let Some(d) = &download_dir {
-        let _ = std::fs::create_dir_all(d);
-    }
-
+    // No --download-dir: the daemon resolves the unified carl work dir itself
+    // ($CARL_DIR > the persisted Settings value > ~/Downloads/carl), the same
+    // resolution the CLI uses — so GUI and CLI share one download + seed
+    // directory and never fall back to the Finder-launch CWD (`/`).
+    //
     // Pass our PID so the daemon's watchdog shuts it down if this shell dies
     // without a clean exit (crash / force-quit), instead of orphaning it.
     let mut cmd = Command::new(&bin);
     cmd.args(["daemon", "--port", &port_s, "--parent-pid", &pid_s]);
-    if let Some(d) = &download_dir {
-        cmd.args(["--download-dir", &d.to_string_lossy()]);
-    }
     let mut child = cmd
         .stdout(Stdio::piped())
         .spawn()

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -27,6 +27,7 @@ pub const http = @import("http.zig");
 pub const manager = @import("manager.zig");
 pub const daemon = @import("daemon.zig");
 pub const state = @import("state.zig");
+pub const workdir = @import("workdir.zig");
 
 test {
     _ = bencode;
@@ -56,5 +57,6 @@ test {
     _ = manager;
     _ = daemon;
     _ = state;
+    _ = workdir;
     _ = @import("integration_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,26 +64,44 @@ pub fn main() !void {
             break :blk @as([]const u8, allocator.dupe(u8, parts.items) catch @panic("OOM"));
         };
         defer if (source_owned) allocator.free(source);
-        const output_dir = parseFlag(args[3..], "--output-dir") orelse ".";
+        // Default to the unified carl work dir (shared with the daemon/GUI)
+        // so downloads from any frontend land in one reseedable place.
+        var output_dir_owned: ?[]u8 = null;
+        defer if (output_dir_owned) |d| allocator.free(d);
+        const output_dir = parseFlag(args[3..], "--output-dir") orelse blk: {
+            output_dir_owned = try carl.workdir.ensure(allocator);
+            break :blk @as([]const u8, output_dir_owned.?);
+        };
         const port = parsePort(args[3..]);
         const want_nostr = parseFlagPresent(args[3..], "--nostr");
         const want_seed = parseFlagPresent(args[3..], "--seed");
         try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr, want_seed);
     } else if (std.mem.eql(u8, command, "seed")) {
-        if (args.len < 4) {
-            log.err("usage: carl seed <file.torrent> <data-dir> [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--description \"...\"]", .{});
+        if (args.len < 3) {
+            log.err("usage: carl seed <file.torrent> [data-dir] [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--description \"...\"]", .{});
             std.process.exit(1);
         }
-        const port = parsePort(args[4..]);
-        const want_nostr = parseFlagPresent(args[4..], "--nostr");
-        const tor_seed = parseFlagPresent(args[4..], "--tor-seed");
-        const external_ip = parseFlag(args[4..], "--external-ip");
-        const description = parseFlag(args[4..], "--description") orelse "";
-        const tor_control = parseFlag(args[4..], "--tor-control") orelse "127.0.0.1:9051";
-        const tor_cookie = parseFlag(args[4..], "--tor-cookie");
-        const tor_onion_port: u16 = parsePortFlag(args[4..], "--tor-onion-port", 80);
-        const tor_socks_url = parseFlag(args[4..], "--tor-socks") orelse "socks5h://127.0.0.1:9050";
-        try cmdSeed(allocator, args[2], args[3], port, parseProxy(args[4..]), want_nostr, tor_seed, external_ip, description, .{
+        // data-dir is optional: when omitted (next arg is a flag or absent),
+        // seed from the unified carl work dir — the same directory downloads
+        // land in, so anything dropped there reseeds without extra arguments.
+        const has_data_dir = args.len >= 4 and !std.mem.startsWith(u8, args[3], "--");
+        const flag_args = if (has_data_dir) args[4..] else args[3..];
+        var data_dir_owned: ?[]u8 = null;
+        defer if (data_dir_owned) |d| allocator.free(d);
+        const data_dir: []const u8 = if (has_data_dir) args[3] else blk: {
+            data_dir_owned = try carl.workdir.ensure(allocator);
+            break :blk data_dir_owned.?;
+        };
+        const port = parsePort(flag_args);
+        const want_nostr = parseFlagPresent(flag_args, "--nostr");
+        const tor_seed = parseFlagPresent(flag_args, "--tor-seed");
+        const external_ip = parseFlag(flag_args, "--external-ip");
+        const description = parseFlag(flag_args, "--description") orelse "";
+        const tor_control = parseFlag(flag_args, "--tor-control") orelse "127.0.0.1:9051";
+        const tor_cookie = parseFlag(flag_args, "--tor-cookie");
+        const tor_onion_port: u16 = parsePortFlag(flag_args, "--tor-onion-port", 80);
+        const tor_socks_url = parseFlag(flag_args, "--tor-socks") orelse "socks5h://127.0.0.1:9050";
+        try cmdSeed(allocator, args[2], data_dir, port, parseProxy(flag_args), want_nostr, tor_seed, external_ip, description, .{
             .control_addr = tor_control,
             .cookie_path = tor_cookie,
             .onion_port = tor_onion_port,
@@ -123,12 +141,14 @@ fn printUsage() void {
         \\  announce <file.torrent> [--proxy url]            query tracker for peers
         \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr] [--seed]
         \\           source: file.torrent, magnet:?..., or http(s):// URL
+        \\           --output-dir: defaults to the carl work dir (see below)
         \\           --nostr: also subscribe to nostr peer-announce events
         \\           --seed: keep seeding after the download completes
         \\                   (default: exit once the download is done)
-        \\  seed <file.torrent> <data-dir> [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
+        \\  seed <file.torrent> [data-dir] [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
         \\           [--tor-seed] [--tor-control host:port] [--tor-cookie path]
         \\           [--tor-onion-port p] [--tor-socks url] [--description "..."]
+        \\           data-dir: defaults to the carl work dir (see below)
         \\           --nostr: publish NIP-35 torrent event + peer-announce
         \\           --external-ip: public IPv4 for peer-announce (classic seeding)
         \\           --tor-seed: hidden service via Tor ControlPort; requires --nostr
@@ -154,6 +174,12 @@ fn printUsage() void {
         \\                http://[user:pass@]host:port     (HTTP CONNECT)
         \\                When set, DHT, UDP trackers, web seeds, and incoming
         \\                peers are disabled for anonymity.
+        \\
+        \\  work dir      the shared download + seed directory used by the CLI,
+        \\                daemon, and desktop app when no directory is given:
+        \\                $CARL_DIR, else the GUI's persisted download folder
+        \\                setting, else ~/Downloads/carl. Drop a file there and
+        \\                `carl seed <file.torrent>` (or the app) can reseed it.
         \\
     , .{}) catch {};
 }
@@ -844,7 +870,15 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         std.process.exit(1);
     };
     const socks = parseFlag(extra, "--socks") orelse "";
-    const download_dir = parseFlag(extra, "--download-dir") orelse "";
+    // Default to the unified carl work dir (CARL_DIR > persisted Settings
+    // value > ~/Downloads/carl) so the daemon/GUI and the CLI share one
+    // download + seed directory.
+    var download_dir_owned: ?[]u8 = null;
+    defer if (download_dir_owned) |d| allocator.free(d);
+    const download_dir = parseFlag(extra, "--download-dir") orelse blk: {
+        download_dir_owned = try carl.workdir.resolve(allocator);
+        break :blk @as([]const u8, download_dir_owned.?);
+    };
     // Tor ControlPort config for reachable `.tor` seeds (hidden services). The
     // empty defaults let Manager.init fall back to 127.0.0.1:9051 + the default
     // cookie path, matching the CLI `carl seed --tor-seed` defaults.

--- a/src/main.zig
+++ b/src/main.zig
@@ -872,10 +872,19 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     const socks = parseFlag(extra, "--socks") orelse "";
     // Default to the unified carl work dir (CARL_DIR > persisted Settings
     // value > ~/Downloads/carl) so the daemon/GUI and the CLI share one
-    // download + seed directory.
+    // download + seed directory. An explicit flag or $CARL_DIR outranks the
+    // persisted setting, and `download_dir_pinned` tells the manager so its
+    // restore() doesn't clobber the dir with the stale DB value.
+    const download_dir_flag = parseFlag(extra, "--download-dir");
+    var download_dir_pinned = download_dir_flag != null;
     var download_dir_owned: ?[]u8 = null;
     defer if (download_dir_owned) |d| allocator.free(d);
-    const download_dir = parseFlag(extra, "--download-dir") orelse blk: {
+    const download_dir = download_dir_flag orelse blk: {
+        if (try carl.workdir.envOverride(allocator)) |d| {
+            download_dir_owned = d;
+            download_dir_pinned = true;
+            break :blk @as([]const u8, d);
+        }
         download_dir_owned = try carl.workdir.resolve(allocator);
         break :blk @as([]const u8, download_dir_owned.?);
     };
@@ -904,6 +913,7 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         .route = route,
         .socks = socks,
         .download_dir = download_dir,
+        .download_dir_pinned = download_dir_pinned,
         .listen_port = bt_port,
         .tor_control = tor_control,
         .tor_cookie = tor_cookie,

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -29,6 +29,7 @@ const peer_announce = @import("peer_announce.zig");
 const seeding = @import("seeding.zig");
 const tor_control = @import("tor_control.zig");
 const state_mod = @import("state.zig");
+const workdir = @import("workdir.zig");
 const nostr_config = @import("nostr_config.zig");
 const nostr_mod = @import("nostr.zig");
 const secp = @import("secp.zig");
@@ -561,10 +562,11 @@ pub const Manager = struct {
 
         self.mutex.lock();
         self.cfg.route = st.route;
-        // Treat "." (the bare placeholder default) as "unset" so a stale
-        // persisted "." doesn't clobber an explicit --download-dir passed on
-        // startup (e.g. the desktop shell's ~/Downloads/carl-download).
-        if (st.download_dir.len > 0 and !std.mem.eql(u8, st.download_dir, ".")) {
+        // Treat placeholder values ("", ".", and the retired desktop default
+        // ~/Downloads/carl-download) as "unset" so stale persisted state from
+        // before the unified work dir doesn't clobber the directory resolved
+        // at startup (--download-dir, or workdir's CARL_DIR/setting/default).
+        if (!workdir.isPlaceholder(self.allocator, st.download_dir)) {
             if (self.allocator.dupe(u8, st.download_dir)) |d| {
                 self.allocator.free(self.cfg.download_dir);
                 self.cfg.download_dir = d;
@@ -684,6 +686,10 @@ pub const Manager = struct {
         session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false) catch {
             return error.SessionInitFailed;
         };
+        // Daemon downloads keep seeding once complete — the GUI lists them
+        // under Seeds, and anything in the work dir stays reseedable. The
+        // session downgrades its file handles to read-only at that point.
+        session.seed_after_complete = true;
         return .{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
     }
 
@@ -705,6 +711,8 @@ pub const Manager = struct {
         session.info_hash = ml.info_hash; // use the magnet's hash, not SHA1("")
         session.metadata_download = extension.MetadataDownload.init(a, ml.info_hash);
         session.metadata_only = true;
+        // Same as the .torrent path: keep seeding after the download completes.
+        session.seed_after_complete = true;
         return .{ .session = session, .meta = mi, .info_hash = ml.info_hash, .name = session.meta.name };
     }
 };

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -56,6 +56,11 @@ pub const Config = struct {
     route: api.Route = .direct,
     socks: []const u8 = "",
     download_dir: []const u8 = "",
+    /// True when `download_dir` came from a source that outranks the persisted
+    /// setting (an explicit --download-dir flag or $CARL_DIR), so `restore`
+    /// must not replace it with the stale DB value — otherwise the daemon and
+    /// the CLI (which honors $CARL_DIR first) would diverge on the work dir.
+    download_dir_pinned: bool = false,
     listen_port: u16 = 6881,
     max_active: u32 = 8,
     peer_limit: u32 = 60,
@@ -144,6 +149,11 @@ pub const Manager = struct {
     /// While replaying persisted state on startup, suppress per-add persistence
     /// (we write once at the end of `restore`).
     restoring: bool = false,
+    /// The user's persisted downloadDir, kept aside while a pinned override
+    /// ($CARL_DIR / --download-dir) is active: `persist` re-saves this instead
+    /// of the override, so an ephemeral override never clobbers the setting on
+    /// disk. Cleared when the user picks a new dir via `setDownloadDir`. Owned.
+    saved_download_dir: ?[]u8 = null,
 
     pub fn init(allocator: Allocator, cfg: Config) Allocator.Error!Manager {
         return .{
@@ -152,6 +162,7 @@ pub const Manager = struct {
                 .route = cfg.route,
                 .socks = try allocator.dupe(u8, if (cfg.socks.len > 0) cfg.socks else "socks5h://127.0.0.1:9050"),
                 .download_dir = try allocator.dupe(u8, if (cfg.download_dir.len > 0) cfg.download_dir else "."),
+                .download_dir_pinned = cfg.download_dir_pinned,
                 .listen_port = cfg.listen_port,
                 .max_active = cfg.max_active,
                 .peer_limit = cfg.peer_limit,
@@ -169,6 +180,7 @@ pub const Manager = struct {
         self.transfers.deinit(self.allocator);
         self.allocator.free(self.cfg.socks);
         self.allocator.free(self.cfg.download_dir);
+        if (self.saved_download_dir) |d| self.allocator.free(d);
         self.allocator.free(self.cfg.tor_control);
         self.allocator.free(self.cfg.tor_cookie);
     }
@@ -508,6 +520,12 @@ pub const Manager = struct {
         self.mutex.lock();
         self.allocator.free(self.cfg.download_dir);
         self.cfg.download_dir = dup;
+        // An explicit user choice replaces any kept-aside persisted value:
+        // from here on `persist` saves the live dir again.
+        if (self.saved_download_dir) |old| {
+            self.allocator.free(old);
+            self.saved_download_dir = null;
+        }
         self.mutex.unlock();
         std.fs.cwd().makePath(dup) catch {};
         self.persist();
@@ -529,7 +547,7 @@ pub const Manager = struct {
 
         self.mutex.lock();
         const route = self.cfg.route;
-        const dir = aa.dupe(u8, self.cfg.download_dir) catch {
+        const dir = aa.dupe(u8, self.saved_download_dir orelse self.cfg.download_dir) catch {
             self.mutex.unlock();
             return;
         };
@@ -562,14 +580,22 @@ pub const Manager = struct {
 
         self.mutex.lock();
         self.cfg.route = st.route;
-        // Treat placeholder values ("", ".", and the retired desktop default
-        // ~/Downloads/carl-download) as "unset" so stale persisted state from
-        // before the unified work dir doesn't clobber the directory resolved
-        // at startup (--download-dir, or workdir's CARL_DIR/setting/default).
+        // Apply the persisted downloadDir only when it doesn't get outranked:
+        // a pinned dir (explicit --download-dir or $CARL_DIR) wins over the DB
+        // value so the daemon matches the CLI's `$CARL_DIR > setting > default`
+        // order, and placeholder values ("", ".", the retired desktop default
+        // ~/Downloads/carl-download) are stale pre-unification state, not a
+        // user choice. When pinned, keep the DB value aside so `persist`
+        // re-saves it — the override is ephemeral and must not clobber it.
         if (!workdir.isPlaceholder(self.allocator, st.download_dir)) {
             if (self.allocator.dupe(u8, st.download_dir)) |d| {
-                self.allocator.free(self.cfg.download_dir);
-                self.cfg.download_dir = d;
+                if (self.cfg.download_dir_pinned) {
+                    if (self.saved_download_dir) |old| self.allocator.free(old);
+                    self.saved_download_dir = d;
+                } else {
+                    self.allocator.free(self.cfg.download_dir);
+                    self.cfg.download_dir = d;
+                }
             } else |_| {}
         }
         self.mutex.unlock();

--- a/src/session.zig
+++ b/src/session.zig
@@ -446,6 +446,11 @@ pub const Session = struct {
                 // when proxied, can't even accept incoming peers). Opt back into
                 // seed-after-download with `--seed`.
                 if (!self.seed_after_complete) {
+                    // Release the files right away: the Session object can
+                    // outlive completion (the daemon keeps it registered until
+                    // removal), and a finished download must not hold its
+                    // files open — that blocks other programs from using them.
+                    self.store.closeFiles();
                     self.running = false;
                     break;
                 }
@@ -460,6 +465,9 @@ pub const Session = struct {
                     self.listener = addr.listen(.{ .reuse_address = true }) catch null;
                 }
                 self.mode = .seed;
+                // Seeding only reads — swap the write handles for read-only
+                // ones so the completed files are usable by other programs.
+                self.store.downgradeToReadOnly();
                 if (self.proxy == null) {
                     stdout.print("now seeding on port {d}...\n", .{self.listen_port}) catch {};
                 } else {

--- a/src/state.zig
+++ b/src/state.zig
@@ -194,6 +194,29 @@ fn loadFrom(a: Allocator, path: [:0]const u8) Error!State {
     return .{ .route = route, .download_dir = download_dir, .transfers = try list.toOwnedSlice(a) };
 }
 
+/// Read just the persisted `downloadDir` setting, or null when there is no
+/// database / no value / an empty value. Best-effort: any failure reads as
+/// "unset" so callers (workdir resolution) fall back to the built-in default.
+pub fn loadDownloadDir(a: Allocator) ?[]u8 {
+    const path = dbPath(a) catch return null;
+    defer a.free(path);
+    std.fs.cwd().access(path, .{}) catch return null; // no DB yet
+    const path_z = a.dupeZ(u8, path) catch return null;
+    defer a.free(path_z);
+    return loadDownloadDirFrom(a, path_z);
+}
+
+fn loadDownloadDirFrom(a: Allocator, path: [:0]const u8) ?[]u8 {
+    const db = open(path) catch return null;
+    defer _ = sqlite3_close(db);
+    const value = (getSetting(a, db, "downloadDir") catch return null) orelse return null;
+    if (value.len == 0) {
+        a.free(value);
+        return null;
+    }
+    return value;
+}
+
 fn upsertSetting(db: *Sqlite, key: []const u8, value: []const u8) Error!void {
     var stmt: ?*Stmt = null;
     const sql = "INSERT INTO settings(key,value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value";
@@ -277,4 +300,25 @@ test "sqlite save replaces prior transfers (no accumulation)" {
     try testing.expectEqual(@as(usize, 1), st.transfers.len);
     try testing.expectEqual(api.Route.tor, st.route);
     try testing.expectEqualStrings("/y", st.download_dir);
+}
+
+test "loadDownloadDirFrom reads the setting; empty/missing read as unset" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+    const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
+    defer a.free(path);
+
+    // Fresh DB (schema only): no setting yet.
+    try testing.expect(loadDownloadDirFrom(a, path) == null);
+
+    try saveTo(path, .direct, "/home/u/dl", &.{});
+    const got = loadDownloadDirFrom(a, path) orelse return error.TestUnexpectedResult;
+    defer a.free(got);
+    try testing.expectEqualStrings("/home/u/dl", got);
+
+    try saveTo(path, .direct, "", &.{});
+    try testing.expect(loadDownloadDirFrom(a, path) == null);
 }

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -88,6 +88,14 @@ pub const Storage = struct {
     file_map: FileMap,
     handles: []std.fs.File,
     piece_len: u64,
+    /// The output directory, kept open so handles can be reopened read-only.
+    dir: std.fs.Dir,
+    /// Relative path of each file inside `dir` (joined components), owned.
+    paths: [][]u8,
+    /// True when `handles` are read-only (seed mode, or after a downgrade).
+    read_only: bool,
+    /// True once `closeFiles` ran; guards double-close from `deinit`.
+    files_closed: bool = false,
 
     pub const IoError = error{
         FileOpenFailed,
@@ -109,14 +117,20 @@ pub const Storage = struct {
 
         const handles = allocator.alloc(std.fs.File, meta.files.len) catch return error.OutOfMemory;
         @memset(handles, undefined);
+        errdefer allocator.free(handles);
+
+        const paths = allocator.alloc([]u8, meta.files.len) catch return error.OutOfMemory;
+        errdefer allocator.free(paths);
 
         var opened: usize = 0;
+        var paths_set: usize = 0;
         errdefer {
             for (handles[0..opened]) |h| h.close();
-            allocator.free(handles);
+            for (paths[0..paths_set]) |p| allocator.free(p);
         }
 
-        const dir = std.fs.cwd().openDir(output_dir_path, .{}) catch return error.FileOpenFailed;
+        var dir = std.fs.cwd().openDir(output_dir_path, .{}) catch return error.FileOpenFailed;
+        errdefer dir.close();
 
         // Validate all path components before creating any files (path traversal defense)
         for (meta.files) |file_info| {
@@ -159,12 +173,20 @@ pub const Storage = struct {
 
             if (create) {
                 handles[i] = dir.createFile(path, .{ .read = true, .truncate = false }) catch return error.FileOpenFailed;
-                // Preallocate file size
+                // Count the handle as opened before preallocating, so a
+                // setEndPos failure (disk full) doesn't leak the descriptor
+                // on the error path — Session.init failures don't kill the
+                // daemon, so leaked fds would accumulate.
+                opened += 1;
                 handles[i].setEndPos(file_info.length) catch return error.WriteFailed;
             } else {
-                handles[i] = dir.openFile(path, .{ .mode = .read_write }) catch return error.FileOpenFailed;
+                // Seeding only reads: a read-only handle leaves the file free
+                // for other programs (no write lock on data we never modify).
+                handles[i] = dir.openFile(path, .{ .mode = .read_only }) catch return error.FileOpenFailed;
+                opened += 1;
             }
-            opened += 1;
+            paths[i] = allocator.dupe(u8, path) catch return error.OutOfMemory;
+            paths_set += 1;
         }
 
         return .{
@@ -172,13 +194,43 @@ pub const Storage = struct {
             .file_map = fm,
             .handles = handles,
             .piece_len = meta.piece_length,
+            .dir = dir,
+            .paths = paths,
+            .read_only = !create,
         };
     }
 
     pub fn deinit(self: *Storage) void {
-        for (self.handles) |h| h.close();
+        self.closeFiles();
         self.allocator.free(self.handles);
+        for (self.paths) |p| self.allocator.free(p);
+        self.allocator.free(self.paths);
+        self.dir.close();
         self.file_map.deinit(self.allocator);
+    }
+
+    /// Close every file handle (idempotent). Called when a download finishes
+    /// without continuing to seed: the session object can outlive completion
+    /// (the daemon keeps it registered), and a finished download must not
+    /// keep its files open. Reads/writes fail after this.
+    pub fn closeFiles(self: *Storage) void {
+        if (self.files_closed) return;
+        for (self.handles) |h| h.close();
+        self.files_closed = true;
+    }
+
+    /// Swap read-write handles for read-only ones, per file and best-effort
+    /// (a file whose reopen fails keeps its old handle). Called when a
+    /// finished download keeps seeding: serving pieces only reads, and
+    /// holding write access would keep other programs from using the files.
+    pub fn downgradeToReadOnly(self: *Storage) void {
+        if (self.files_closed or self.read_only) return;
+        for (self.handles, self.paths) |*h, p| {
+            const ro = self.dir.openFile(p, .{ .mode = .read_only }) catch continue;
+            h.close();
+            h.* = ro;
+        }
+        self.read_only = true;
     }
 
     /// Write a verified piece to disk.
@@ -347,4 +399,94 @@ test "storage write and read roundtrip" {
     const read1 = try store.readPiece(allocator, 1, 16384);
     defer allocator.free(read1);
     try std.testing.expectEqual(@as(u8, 0xBB), read1[0]);
+}
+
+fn testMeta(files: []const metainfo.FileInfo) metainfo.Metainfo {
+    return .{
+        .announce = "http://example.com",
+        .announce_list = null,
+        .name = "test",
+        .piece_length = 16384,
+        .pieces = &([_]u8{0} ** 20),
+        .files = files,
+        .comment = null,
+        .creation_date = null,
+        .created_by = null,
+        .raw_info = &.{},
+        .url_list = null,
+    };
+}
+
+test "downgradeToReadOnly: reads keep working, writes fail" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const tmp_path = tmp_dir.dir.realpathAlloc(allocator, ".") catch return;
+    defer allocator.free(tmp_path);
+
+    const files = [_]metainfo.FileInfo{
+        .{ .length = 16384, .path = &.{"dl.bin"} },
+    };
+    var store = Storage.init(allocator, testMeta(&files), tmp_path, true) catch return;
+    defer store.deinit();
+
+    const data = [_]u8{0xCC} ** 16384;
+    try store.writePiece(0, &data);
+
+    store.downgradeToReadOnly();
+    store.downgradeToReadOnly(); // idempotent
+
+    const back = try store.readPiece(allocator, 0, 16384);
+    defer allocator.free(back);
+    try std.testing.expectEqual(@as(u8, 0xCC), back[0]);
+    try std.testing.expectError(error.WriteFailed, store.writePiece(0, &data));
+}
+
+test "seed mode opens files read-only" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const tmp_path = tmp_dir.dir.realpathAlloc(allocator, ".") catch return;
+    defer allocator.free(tmp_path);
+
+    const files = [_]metainfo.FileInfo{
+        .{ .length = 16384, .path = &.{"seed.bin"} },
+    };
+
+    // Lay the file down via a create-mode store first.
+    {
+        var store = Storage.init(allocator, testMeta(&files), tmp_path, true) catch return;
+        defer store.deinit();
+        const data = [_]u8{0xDD} ** 16384;
+        try store.writePiece(0, &data);
+    }
+
+    var store = Storage.init(allocator, testMeta(&files), tmp_path, false) catch return;
+    defer store.deinit();
+    try std.testing.expect(store.read_only);
+
+    const back = try store.readPiece(allocator, 0, 16384);
+    defer allocator.free(back);
+    try std.testing.expectEqual(@as(u8, 0xDD), back[0]);
+    const data = [_]u8{0xEE} ** 16384;
+    try std.testing.expectError(error.WriteFailed, store.writePiece(0, &data));
+}
+
+test "closeFiles is idempotent and safe before deinit" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const tmp_path = tmp_dir.dir.realpathAlloc(allocator, ".") catch return;
+    defer allocator.free(tmp_path);
+
+    const files = [_]metainfo.FileInfo{
+        .{ .length = 16384, .path = &.{"done.bin"} },
+    };
+    var store = Storage.init(allocator, testMeta(&files), tmp_path, true) catch return;
+    defer store.deinit(); // closes again via the guard — must not double-close
+
+    const data = [_]u8{0xAB} ** 16384;
+    try store.writePiece(0, &data);
+    store.closeFiles();
+    store.closeFiles();
 }

--- a/src/workdir.zig
+++ b/src/workdir.zig
@@ -1,0 +1,96 @@
+//! The unified carl working directory: the default download *and* seed
+//! directory shared by the CLI, the daemon, and the desktop GUI. Downloads
+//! land here and seeds default to reading from here, so anything in the
+//! directory can be reseeded from any frontend — drop a file in, seed it.
+//!
+//! Resolution order:
+//!   1. `$CARL_DIR` — explicit override (tests, scripting)
+//!   2. the persisted `downloadDir` setting in `<config>/carl.db` (the GUI's
+//!      Settings screen writes it there via the daemon), so the CLI follows
+//!      whatever directory the user picked in the app and vice versa
+//!   3. `$HOME/Downloads/carl`
+//!
+//! Falls back to "." only when HOME is unavailable. Best-effort by design:
+//! the only error surfaced is OOM — a missing/corrupt DB just falls through
+//! to the built-in default.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const state = @import("state.zig");
+
+/// Old defaults that mean "the user never chose a directory": the CLI/daemon
+/// placeholder "." and the retired desktop default `~/Downloads/carl-download`.
+/// A persisted value matching these is ignored so stale state from before the
+/// unified work dir doesn't pin the old per-frontend behavior.
+pub fn isPlaceholder(a: Allocator, dir: []const u8) bool {
+    if (dir.len == 0 or std.mem.eql(u8, dir, ".")) return true;
+    const home = std.process.getEnvVarOwned(a, "HOME") catch return false;
+    defer a.free(home);
+    const legacy = std.fmt.allocPrint(a, "{s}/Downloads/carl-download", .{home}) catch return false;
+    defer a.free(legacy);
+    return std.mem.eql(u8, dir, legacy);
+}
+
+/// Built-in default: `$HOME/Downloads/carl` ("." without HOME). Caller owns
+/// the returned slice.
+pub fn defaultDir(a: Allocator) Allocator.Error![]u8 {
+    const home = std.process.getEnvVarOwned(a, "HOME") catch return a.dupe(u8, ".");
+    defer a.free(home);
+    return std.fmt.allocPrint(a, "{s}/Downloads/carl", .{home});
+}
+
+/// Resolve the working directory (override > persisted setting > default).
+/// Caller owns the returned slice.
+pub fn resolve(a: Allocator) Allocator.Error![]u8 {
+    if (std.process.getEnvVarOwned(a, "CARL_DIR")) |env| {
+        if (env.len > 0) return env;
+        a.free(env);
+    } else |_| {}
+    if (state.loadDownloadDir(a)) |dir| {
+        if (!isPlaceholder(a, dir)) return dir;
+        a.free(dir);
+    }
+    return defaultDir(a);
+}
+
+/// Resolve and create the directory (best-effort). Caller owns the slice.
+pub fn ensure(a: Allocator) Allocator.Error![]u8 {
+    const dir = try resolve(a);
+    std.fs.cwd().makePath(dir) catch {};
+    return dir;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+
+test "isPlaceholder: empty and dot are placeholders" {
+    try testing.expect(isPlaceholder(testing.allocator, ""));
+    try testing.expect(isPlaceholder(testing.allocator, "."));
+    try testing.expect(!isPlaceholder(testing.allocator, "/some/real/dir"));
+}
+
+test "isPlaceholder: legacy desktop default is a placeholder" {
+    const a = testing.allocator;
+    const home = std.process.getEnvVarOwned(a, "HOME") catch return; // no HOME: nothing to check
+    defer a.free(home);
+    const legacy = try std.fmt.allocPrint(a, "{s}/Downloads/carl-download", .{home});
+    defer a.free(legacy);
+    try testing.expect(isPlaceholder(a, legacy));
+}
+
+test "defaultDir: lands under HOME/Downloads/carl" {
+    const a = testing.allocator;
+    const dir = try defaultDir(a);
+    defer a.free(dir);
+    if (std.process.getEnvVarOwned(a, "HOME")) |home| {
+        defer a.free(home);
+        const expected = try std.fmt.allocPrint(a, "{s}/Downloads/carl", .{home});
+        defer a.free(expected);
+        try testing.expectEqualStrings(expected, dir);
+    } else |_| {
+        try testing.expectEqualStrings(".", dir);
+    }
+}

--- a/src/workdir.zig
+++ b/src/workdir.zig
@@ -39,13 +39,22 @@ pub fn defaultDir(a: Allocator) Allocator.Error![]u8 {
     return std.fmt.allocPrint(a, "{s}/Downloads/carl", .{home});
 }
 
-/// Resolve the working directory (override > persisted setting > default).
-/// Caller owns the returned slice.
-pub fn resolve(a: Allocator) Allocator.Error![]u8 {
+/// The `$CARL_DIR` override, or null when unset/empty. Callers that need to
+/// know whether the override is active (and not just the resolved result) use
+/// this directly — e.g. the daemon, which must keep the override outranking
+/// the persisted setting across `Manager.restore`. Caller owns the slice.
+pub fn envOverride(a: Allocator) Allocator.Error!?[]u8 {
     if (std.process.getEnvVarOwned(a, "CARL_DIR")) |env| {
         if (env.len > 0) return env;
         a.free(env);
     } else |_| {}
+    return null;
+}
+
+/// Resolve the working directory (override > persisted setting > default).
+/// Caller owns the returned slice.
+pub fn resolve(a: Allocator) Allocator.Error![]u8 {
+    if (try envOverride(a)) |dir| return dir;
     if (state.loadDownloadDir(a)) |dir| {
         if (!isPlaceholder(a, dir)) return dir;
         a.free(dir);


### PR DESCRIPTION
## Summary
- New `src/workdir.zig`: one shared download + seed directory for the CLI, daemon, and desktop GUI, resolved as `$CARL_DIR` > persisted `downloadDir` setting in `carl.db` > `~/Downloads/carl`. The CLI now follows the folder picked in the app's Settings and vice versa.
- `carl download` defaults `--output-dir` to the work dir (was `.`); `carl seed` makes `data-dir` optional, defaulting to the work dir — drop a file in `~/Downloads/carl` and `carl seed <file.torrent>` reseeds it with no extra args.
- The desktop shell no longer passes its own `~/Downloads/carl-download`; the daemon resolves the unified dir itself. Stale persisted values of the retired default migrate to the new one; genuinely custom dirs are respected.
- File locks released after download: seed-mode storage opens read-only, a download that exits closes its handles immediately, and a download that keeps seeding downgrades to read-only handles. Previously the daemon held completed files open read-write until shutdown.
- Daemon downloads now set `seed_after_complete`: before, the session thread exited at completion while the GUI listed the transfer under Seeds without actually serving anything.
- Fixes two fd leaks in `Storage`: the output-directory handle was never closed, and a `setEndPos` failure leaked the just-created file descriptor.

## Review Notes
- Production-safety review passed (3 rounds); `zig build test` and `zig fmt --check` green, `cargo check` green on the Tauri shell.
- Anonymity invariants checked: proxied/Tor downloads that now keep seeding still never open an inbound listener (outbound-only), so no IP leak path was added.
- Verified end-to-end with isolated `XDG_CONFIG_HOME`/`HOME`: CLI seed with no data-dir resolves `CARL_DIR` and holds the file read-only (`lsof` shows mode `r`); daemon seed upload lands in the work dir read-only; flagless CLI download follows the daemon-persisted dir; completed daemon download appears in `/api/seeds` with downgraded handles; legacy `carl-download` migrates while a custom persisted dir is kept.
- Pre-existing and non-blocking: in `onMetadataComplete` (`src/session.zig`), if the storage re-init fails after `store.deinit()`, the stale store gets deinit'd again on session teardown (double free on a rare error path). Predates this PR; the new `files_closed` guard narrows it slightly. Valid improvement for a follow-up.

## Decision Log
**Hardest decision:** making daemon downloads seed after completion (`src/manager.zig`, `seed_after_complete = true`). It changes daemon behavior — session threads now stay alive after a download finishes instead of exiting. I went with it because the GUI already presents completed downloads as Seeds (`Manager.seeds()` counts them), so the old behavior was arguably a lie, and the goal of a reseedable work dir needs completed downloads to actually serve. The lock concern that motivated exiting early is handled by the read-only downgrade instead.

**Alternatives rejected:**
- Auto-scanning the work dir and seeding everything in it: too aggressive (would hash/seed arbitrary files the user never asked to share — bad default for a privacy-focused client).
- Keeping the desktop's own `--download-dir` flag pointed at the new default: would work, but leaves two resolution code paths that can drift; letting the daemon resolve via `workdir` keeps exactly one.
- Closing handles entirely while seeding and reopening per read: releases even read handles, but adds an open/close syscall pair per served piece for marginal benefit — read-only handles already don't block other programs on POSIX.

**Least confident about:** `state.loadDownloadDir` reads `carl.db` without a busy timeout, so if the CLI resolves the work dir at the exact moment the daemon commits a `persist()`, the read could see SQLITE_BUSY and silently fall back to `~/Downloads/carl` for that one invocation. The window is tiny and the fallback is benign, but adding `sqlite3_busy_timeout` would close it — happy to do that here or in a follow-up. Let me know your thoughts.

## Test plan
- [ ] CI passes (build + test + fmt)
- [x] Unit tests: workdir placeholder/default resolution, `loadDownloadDir`, read-only seed mode, downgrade (reads ok / writes fail), `closeFiles` idempotency
- [x] e2e: CLI seed without data-dir, daemon seed upload, CLI following daemon-persisted dir, completed daemon download seeding read-only, legacy-dir migration, custom-dir respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)