### PR TITLE
feat(desktop): I2P route for downloads (Add modal, Discover, Settings)

### DIFF
--- a/desktop/src/components/atoms.tsx
+++ b/desktop/src/components/atoms.tsx
@@ -7,7 +7,7 @@ const ROUTE_META: Record<Route, { label: string; cls: string; icon: string }> = 
   direct: { label: "clearnet", cls: "rt-clearnet", icon: "globe" },
   proxy: { label: "proxied", cls: "rt-proxy", icon: "shield" },
   tor: { label: "tor", cls: "rt-tor", icon: "onion" },
-  i2p: { label: "i2p", cls: "rt-tor", icon: "onion" },
+  i2p: { label: "i2p", cls: "rt-i2p", icon: "shield" },
 };
 
 export function RouteBadge({

--- a/desktop/src/modals/AddModal.tsx
+++ b/desktop/src/modals/AddModal.tsx
@@ -18,17 +18,28 @@ const HINT: Record<Tab, string> = {
   url: "carl fetches the .torrent over your selected route.",
 };
 
+// Hints per anonymized download route. Downloads never run clearnet — the
+// choice is which anonymity network dials the peers.
+const ROUTE_HINT: Record<"tor" | "i2p", string> = {
+  tor: "Downloads are routed over Tor — your IP is never exposed. Trackers & DHT off · peers via Nostr. Requires a running Tor SOCKS proxy (127.0.0.1:9050).",
+  i2p: "Peers are dialed as .b32.i2p destinations over native I2P (SAM v3) — your IP is never exposed. Trackers & DHT off · peers via Nostr. Requires a running I2P router with SAM (127.0.0.1:7656).",
+};
+
 export function AddModal({ onClose }: { onClose: () => void }) {
   const { addTransfer } = useCarl();
   const [tab, setTab] = useState<Tab>("magnet");
   const [val, setVal] = useState("");
   const [nostr, setNostr] = useState(true);
-  // Downloads are Tor-only — privacy by default; the IP is never exposed.
-  const route: Route = "tor";
+  // Downloads are anonymized-only — Tor by default, native I2P as the
+  // alternative. Direct/proxy are deliberately not offered for downloads.
+  const [route, setRoute] = useState<Route>("tor");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const canAdd = val.trim().length > 0 && !busy;
+  // The daemon has no I2P-tunneled HTTP fetch yet (P3, #35): an HTTP .torrent
+  // source on the i2p route is rejected (fail-closed), so block it up front.
+  const urlUnsupported = tab === "url" && route === "i2p";
+  const canAdd = val.trim().length > 0 && !busy && !urlUnsupported;
 
   async function submit() {
     if (!canAdd) return;
@@ -90,16 +101,31 @@ export function AddModal({ onClose }: { onClose: () => void }) {
             <div className="field">
               <label className="field-label">Route</label>
               <div className="route-select route-select-lg">
-                <button className="rsl-btn active rt-tor" disabled>
+                <button
+                  className={"rsl-btn" + (route === "tor" ? " active rt-tor" : "")}
+                  onClick={() => setRoute("tor")}
+                >
                   <OnionIcon size={12} />
                   Tor
                 </button>
+                <button
+                  className={"rsl-btn" + (route === "i2p" ? " active rt-i2p" : "")}
+                  onClick={() => setRoute("i2p")}
+                >
+                  <Icon name="shield" size={12} />
+                  I2P
+                </button>
               </div>
               <span className="field-hint">
-                Downloads are routed over Tor only — your IP is never exposed.
-                Trackers &amp; DHT off · peers via Nostr. Requires a running Tor
-                SOCKS proxy (127.0.0.1:9050).
+                {ROUTE_HINT[route as "tor" | "i2p"]}
               </span>
+              {urlUnsupported && (
+                <span className="field-hint" style={{ color: "var(--warn)" }}>
+                  HTTP .torrent sources aren't supported on I2P yet (no
+                  I2P-tunneled fetch — it would leak). Use a magnet/file, or
+                  Tor for URL sources.
+                </span>
+              )}
             </div>
 
             <label

--- a/desktop/src/screens/Discover.tsx
+++ b/desktop/src/screens/Discover.tsx
@@ -120,7 +120,7 @@ function DiscoverCard({
 }
 
 export function DiscoverScreen() {
-  const { search, addTransfer } = useCarl();
+  const { search, addTransfer, state } = useCarl();
   const [q, setQ] = useState("");
   const [added, setAdded] = useState<Record<string, boolean>>({});
   const [all, setAll] = useState<DiscoverResult[]>([]);
@@ -163,11 +163,13 @@ export function DiscoverScreen() {
 
   async function download(d: DiscoverResult) {
     try {
-      // Downloads are Tor-only (same guarantee as the manual Add flow) so a
-      // download never exposes your IP to peers.
+      // Downloads are anonymized-only (same guarantee as the manual Add flow)
+      // so a download never exposes your IP to peers: I2P when it's the global
+      // route, Tor otherwise (incl. direct/proxy — one-click stays private).
+      const route = state.settings.route === "i2p" ? "i2p" : "tor";
       await addTransfer(
         `magnet:?xt=urn:btih:${d.hash}&dn=${encodeURIComponent(d.title)}`,
-        "tor",
+        route,
         true,
       );
       setAdded((s) => ({ ...s, [d.id]: true }));

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -164,6 +164,24 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
     );
   }
 
+  // I2P doesn't use the SOCKS proxy (the daemon talks to the SAM bridge per
+  // transfer), so the SOCKS health probe is reported "disabled" — show the
+  // route's own contract instead of a bogus proxy status.
+  if (route === "i2p") {
+    return (
+      <div className="leak-check lc-safe">
+        <span className="lc-dot" />
+        <div className="lc-body">
+          <div className="lc-title">I2P route — peers dialed via SAM</div>
+          <div className="lc-detail mono">
+            transport fail-closed (no clearnet peers/trackers/DHT) · SAM bridge
+            127.0.0.1:7656 · Nostr relay discovery is clearnet
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const ep = proxy.endpoint || "the proxy";
   const TITLE: Record<ProxyHealth["state"], string> = {
     ok: "Proxy reachable — leak check passed",
@@ -193,16 +211,16 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
   );
 }
 
-// Routes the GUI can select as its global anonymity setting. I2P is deliberately
-// absent: desktop downloads are Tor-only (see AddModal/Discover) and i2p seeding
-// is rejected by the daemon, so selecting i2p here would have no usable effect.
-// I2P is a daemon/CLI route (`carl daemon --route i2p`, see docs/i2p.md); the
-// Route type, ROUTE_META, badges and VIS_LABEL still carry i2p so a transfer
-// surfaced by a CLI-run daemon renders correctly.
+// Routes the GUI can select as its global anonymity setting. Selecting I2P
+// makes Discover one-click downloads dial peers as `.b32.i2p` destinations
+// over the SAM bridge (default 127.0.0.1:7656); the Add modal also offers
+// Tor/I2P per transfer. I2P seeding is not supported yet (rejected by the
+// daemon — #35 P2), so tor seeds remain the private seeding path.
 const ROUTES: [Route, string, string, string][] = [
   ["direct", "Direct", "Connect straight to peers. Fastest, no privacy.", "globe"],
   ["proxy", "SOCKS5 proxy", "Tunnel all traffic through a SOCKS5 proxy.", "shield"],
   ["tor", "Tor", "Route through the Tor network. Seed as a hidden service.", "onion"],
+  ["i2p", "I2P", "Native I2P (SAM v3). Downloads dial .b32.i2p peers; seeding not yet supported.", "shield"],
 ];
 
 export function SettingsScreen() {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3,7 +3,7 @@
   --border:#262b36; --border-soft:#1c212b;
   --fg:#e8eaf0; --fg-dim:#9aa1b1; --fg-faint:#666e7e;
   --accent:#8b7cf6; --accent-soft:rgba(139,124,246,0.14); --accent-border:rgba(139,124,246,0.4); --accent-dim:#a99ff8;
-  --clearnet:#d6a44e; --proxy:#5aa6db; --tor:#46c08a;
+  --clearnet:#d6a44e; --proxy:#5aa6db; --tor:#46c08a; --i2p:#b08ff0;
   --ok:#46c08a; --info:#5aa6db; --warn:#d6a44e; --danger:#d9726b;
   --dl:#5aa6db; --ul:#46c08a;
   --serif:"Newsreader",Georgia,serif;
@@ -111,6 +111,7 @@ input,textarea{ font-family:inherit; }
 .rt-clearnet{ color:var(--clearnet); background:rgba(214,164,78,0.1); border-color:rgba(214,164,78,0.25); }
 .rt-proxy{ color:var(--proxy); background:rgba(90,166,219,0.1); border-color:rgba(90,166,219,0.25); }
 .rt-tor{ color:var(--tor); background:rgba(70,192,138,0.1); border-color:rgba(70,192,138,0.28); }
+.rt-i2p{ color:var(--i2p); background:rgba(176,143,240,0.1); border-color:rgba(176,143,240,0.28); }
 html[data-show-routes="0"] .trow-line1 .route-badge span:last-child{ display:none; }
 html[data-show-routes="0"] .trow-line1 .route-badge{ padding:3px; }
 
@@ -239,6 +240,7 @@ html[data-density="compact"] .trow-stat{ width:74px; flex-basis:74px; }
 .rsl-btn:hover{ color:var(--fg); }
 .rsl-btn.active{ background:var(--bg-3); color:var(--fg); }
 .rsl-btn.active.rt-tor{ color:var(--tor); }
+.rsl-btn.active.rt-i2p{ color:var(--i2p); }
 .rsl-btn.active.rt-proxy{ color:var(--proxy); }
 .rsl-btn.active.rt-direct{ color:var(--clearnet); }
 .route-select-lg .rsl-btn{ padding:7px 14px; font-size:12.5px; }
@@ -412,6 +414,9 @@ html[data-density="compact"] .trow-stat{ width:74px; flex-basis:74px; }
 .route-radio.active.rt-tor .rr-ic{ color:var(--tor); }
 .route-radio.active.rt-tor .rr-radio{ border-color:var(--tor); }
 .route-radio.active.rt-tor .rr-radio::after{ background:var(--tor); }
+.route-radio.active.rt-i2p .rr-ic{ color:var(--i2p); }
+.route-radio.active.rt-i2p .rr-radio{ border-color:var(--i2p); }
+.route-radio.active.rt-i2p .rr-radio::after{ background:var(--i2p); }
 .rr-txt{ display:flex; flex-direction:column; gap:1px; }
 .rr-label{ font-size:13px; font-weight:500; }
 .rr-desc{ font-size:11.5px; color:var(--fg-dim); }


### PR DESCRIPTION
Follow-up to #37 (tracked in #35): the I2P transport existed daemon-side but the GUI couldn't reach it — AddModal/Discover hardcoded `tor` and Settings deliberately omitted i2p. This wires the desktop through the per-transfer i2p route.

## Summary
- **AddModal**: the fixed "Tor" button becomes a **Tor / I2P picker** (downloads remain anonymized-only; direct/proxy still not offered). HTTP `.torrent` sources on i2p are blocked client-side with a hint — the daemon fail-closes them anyway (`UnsupportedOnI2p`, no I2P-tunneled fetch until #35 P3).
- **Discover**: one-click downloads follow the global route when it's `i2p`, `tor` otherwise — never clearnet.
- **Settings**: i2p joins the route picker with honest copy (downloads only; seeding rejected by the daemon until #35 P2). LeakCheck shows the i2p route's own contract (SAM bridge endpoint, transport fail-closed, Nostr-relay clearnet caveat) instead of the SOCKS probe, which correctly reports `disabled` on this route.
- **Styling**: dedicated `--i2p` color + `rt-i2p` classes; the i2p RouteBadge no longer masquerades as tor.

No daemon changes: `POST /api/transfers` already accepts `route: "i2p"` and resolves a per-transfer SAM session (default `127.0.0.1:7656`).

## Review Notes
- The url-tab block in AddModal is belt-and-braces: the daemon already 400s HTTP sources on i2p; the UI just explains it instead of surfacing a bare error.
- Seeding deliberately untouched — `SeedFlow` keeps direct/proxy/tor, matching the daemon's `UnsupportedOnI2p` rejection.

## Test plan
- [x] `tsc --noEmit` clean, `tauri build` ok
- [x] Live E2E on this machine: i2pd (brew service) with SAM on 7656; GUI-spawned-style daemon (no `--route` flag) + `POST /api/transfers {route:"i2p"}` → SAM `SESSION CREATE` succeeded (~30s tunnel build), transfer reports `route: i2p`, `sources: []` with Nostr off
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)