### PR TITLE
feat: I2P seeding (inbound) — STREAM FORWARD + stable .b32.i2p (#35 P2)

### DIFF
--- a/desktop/src/screens/Seeding.tsx
+++ b/desktop/src/screens/Seeding.tsx
@@ -13,25 +13,42 @@ const VIS_LABEL: Record<Route, string> = {
   i2p: "I2P destination",
 };
 
-function OnionCallout({ onion, relays }: { onion: string; relays: number }) {
+// Surfaces the reachable hidden address of an anonymized seed — a `.onion` for
+// a Tor hidden service, a `.b32.i2p` destination for an I2P seed. Both expose
+// no clearnet IP and are published over Nostr for discovery.
+function HiddenAddrCallout({
+  kind,
+  addr,
+  relays,
+}: {
+  kind: "tor" | "i2p";
+  addr: string;
+  relays: number;
+}) {
+  const isI2p = kind === "i2p";
   return (
     <div className="onion-callout">
       <div className="oc-head">
         <span className="oc-icon">
-          <OnionIcon size={18} />
+          {isI2p ? <Icon name="shield" size={18} /> : <OnionIcon size={18} />}
         </span>
         <div>
-          <div className="oc-title">Seeding as a Tor hidden service</div>
+          <div className="oc-title">
+            {isI2p
+              ? "Seeding as an I2P destination"
+              : "Seeding as a Tor hidden service"}
+          </div>
           <div className="oc-sub">
-            Peers reach you over this .onion address. Share it via Discover or
-            directly.
+            {isI2p
+              ? "Peers reach you over this .b32.i2p destination (native SAM v3). Share it via Discover or directly."
+              : "Peers reach you over this .onion address. Share it via Discover or directly."}
           </div>
         </div>
         <span className="oc-live">
           <span className="oc-live-dot" /> online
         </span>
       </div>
-      <CopyField value={onion} full />
+      <CopyField value={addr} full />
       <div className="oc-foot">
         <span className="oc-published">
           <span className="oc-pub-dot" /> published to{" "}
@@ -178,7 +195,7 @@ function SeedFlow({ onClose }: { onClose: () => void }) {
 
               <div className="field-label">Visibility</div>
               <div className="vis-options">
-                {(["direct", "proxy", "tor"] as const).map((id) => (
+                {(["direct", "proxy", "tor", "i2p"] as const).map((id) => (
                   <button
                     key={id}
                     className={"vis-opt" + (vis === id ? " active" : "")}
@@ -245,7 +262,11 @@ export function SeedingScreen() {
   const [flow, setFlow] = useState(false);
   const [createFlow, setCreateFlow] = useState(false);
   const upTotal = seeds.reduce((a, s) => a + s.up, 0);
-  const torSeed = seeds.find((s) => s.visibility === "tor" && s.onion);
+  // The first anonymized seed with a published address gets the hero callout
+  // (tor `.onion` or i2p `.b32.i2p`); both carry their address in `onion`.
+  const hiddenSeed = seeds.find(
+    (s) => (s.visibility === "tor" || s.visibility === "i2p") && s.onion,
+  );
 
   return (
     <div className="screen">
@@ -270,8 +291,12 @@ export function SeedingScreen() {
       </div>
 
       <div className="content">
-        {torSeed && torSeed.onion && (
-          <OnionCallout onion={torSeed.onion} relays={torSeed.relays} />
+        {hiddenSeed && hiddenSeed.onion && (
+          <HiddenAddrCallout
+            kind={hiddenSeed.visibility === "i2p" ? "i2p" : "tor"}
+            addr={hiddenSeed.onion}
+            relays={hiddenSeed.relays}
+          />
         )}
         {seeds.length === 0 ? (
           <div className="empty">

--- a/docs/i2p.md
+++ b/docs/i2p.md
@@ -9,10 +9,13 @@ Peers are addressed by **`.b32.i2p` destinations** (not IP:port). carl speaks
 **SAM v3** to a local I2P router and dials each peer as a destination, the same
 way the Tor path dials `.onion` hostnames.
 
-> **Status (P1):** this is the first slice — **outbound** connections (leeching)
-> over native SAM. Seeding (inbound), I2P trackers, and the I2P DHT are tracked
-> follow-ups (see issue #35). Today, peers are discovered via carl's Nostr
-> peer-announce layer (a `.b32.i2p` destination is carried like a `.onion` host).
+> **Status (P1 + P2):** carl can both **leech** (outbound) and **seed**
+> (inbound) over native SAM. A seed opens a SAM `STREAM FORWARD` to a loopback
+> listener and is reachable at a stable `.b32.i2p` destination (its private key
+> is persisted under `<config>/i2p-seeds/`, so the address survives restarts).
+> I2P trackers and the I2P DHT remain tracked follow-ups (see issue #35); peers
+> are discovered via carl's Nostr peer-announce layer (a `.b32.i2p` destination
+> is carried like a `.onion` host).
 
 ## Prerequisites: a running I2P router with SAM
 
@@ -62,10 +65,19 @@ carl daemon --route i2p --i2p-sam 127.0.0.1:7656
 - `--i2p-sam host:port` points at your router's SAM bridge
   (default `127.0.0.1:7656`; you may also write `sam://127.0.0.1:7656`).
 
-The I2P route is **daemon/CLI-only** for now. The desktop app keeps downloads on
-Tor (its route picker omits I2P, and it has no SAM-bridge setting), so use
-`carl daemon --route i2p --i2p-sam …` as above; a desktop I2P workflow is a
-follow-up (see issue #35).
+### Seeding over I2P
+
+Seeding works on the i2p route too: carl opens a SAM `STREAM FORWARD` so the
+router delivers every inbound peer stream to a loopback listener (the public
+face is the `.b32.i2p` destination, never your IP). The destination's private
+key is persisted under `<config>/i2p-seeds/<info-hash>.dest` (0600), so the seed
+keeps the **same `.b32.i2p` address across restarts** and previously-published
+peer-announces stay valid. With Nostr enabled, carl publishes the `.b32.i2p`
+destination as a kind-30078 peer-announce so leechers can find and dial it.
+
+In the desktop app, pick **I2P** in the "Seed a file" visibility selector; the
+seed's `.b32.i2p` address is surfaced once the SAM session is up. On the daemon
+the seed is created via `POST /api/seeds` with `X-Carl-Route: i2p`.
 
 When the I2P route is active, the **BitTorrent transport fails closed** the same
 way the proxy/Tor routes do: clearnet DHT, UDP/HTTP trackers, web seeds, and the
@@ -85,8 +97,14 @@ discovery on the `tor`/`proxy` route.
    `HELLO` + `STREAM CONNECT` to the peer's `.b32.i2p` destination; on
    `RESULT=OK` the socket becomes a transparent bidirectional stream and the
    normal BitTorrent handshake runs over it.
+3. **Seed (inbound)** — carl registers `STREAM FORWARD ID=… PORT=… SILENT=true`
+   on a side socket; the router then forwards every inbound stream to that
+   loopback port as a raw connection (no SAM header), which the session's normal
+   seed listener accepts. The seed's `.b32.i2p` address is
+   `base32(SHA-256(destination))`, derived locally and persisted so it's stable.
 
-See `src/i2p_sam.zig` for the implementation.
+See `src/i2p_sam.zig` (transport) and `src/i2p_seed.zig` (destination
+persistence) for the implementation.
 
 ## Tor vs I2P (which to use)
 
@@ -96,7 +114,7 @@ See `src/i2p_sam.zig` for the implementation.
 | BitTorrent fit | discouraged (slow, strains the network) | purpose-built |
 | Addressing | `.onion` (v3) | `.b32.i2p` destination |
 | carl transport | SOCKS5h proxy (`--socks`) | native SAM v3 (`--i2p-sam`) |
-| Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | follow-up (P2) |
+| Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | SAM `STREAM FORWARD` + stable `.b32.i2p` |
 
 Either way, carl's **discovery layer is the same** — signed NIP-35 / kind-30078
 events over Nostr — so the privacy network you pick is independent of how you
@@ -107,20 +125,19 @@ find torrents.
 CI cannot run a live I2P router, so swarm interop is verified manually:
 
 1. Start a router with SAM enabled on two hosts (or two routers locally).
-2. On host A, seed a torrent over I2P (P2) — or use any existing `.b32.i2p`
-   peer — and publish/obtain its destination.
+2. On host A, seed a torrent over I2P: create the seed on the `i2p` route
+   (desktop "Seed a file" → I2P, or `POST /api/seeds` with `X-Carl-Route: i2p`),
+   with Nostr enabled so its `.b32.i2p` destination is published. The daemon
+   logs `i2p seed: forwarding <addr>.b32.i2p -> 127.0.0.1:<port>`.
 3. On host B: `carl daemon --route i2p`, add the magnet, and confirm carl dials
-   the `.b32.i2p` peer and the transfer makes progress.
+   host A's `.b32.i2p` destination and the transfer makes progress.
 
 If the SAM bridge is unreachable, adding an I2P transfer fails fast with a clear
 error (the daemon stays up); check that your router is running and the
 `--i2p-sam` address matches its SAM port.
 
-## Known limitations (P1)
+## Known limitations
 
-- **Outbound/leech only.** Seeding over I2P (inbound `STREAM FORWARD` + a stable,
-  persisted destination) is a follow-up; today the i2p route downloads, dialing
-  peers discovered via Nostr.
 - **Nostr relays are not yet routed over I2P.** On the i2p route, relay traffic
   is clearnet (the same as the transfer side), so a relay sees your IP and the
   info-hashes you query. Routing Nostr over I2P is a follow-up. If you need relay

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -481,7 +481,7 @@ const Conn = struct {
 
     /// POST /api/seeds — body is the raw file content (so a browser drag-drop or
     /// the Tauri shell can upload directly). Headers: X-Carl-Filename (required),
-    /// X-Carl-Route (direct|proxy|tor, default tor), X-Carl-Nostr (true|false).
+    /// X-Carl-Route (direct|proxy|tor|i2p, default tor), X-Carl-Nostr (true|false).
     /// Writes the file into the download dir, creates a torrent in-process, and
     /// starts seeding it; returns { id }.
     fn createSeed(self: *Conn, req: *const http.Request, body: []const u8) !void {

--- a/src/i2p_sam.zig
+++ b/src/i2p_sam.zig
@@ -181,6 +181,73 @@ fn hello(stream: std.net.Stream) SamError!Version {
     return parseVersion(samField(line, "VERSION") orelse "3.0");
 }
 
+// --- destination address derivation -----------------------------------------
+
+/// I2P's base64 alphabet: standard base64 with `-` and `~` replacing `+`/`/`.
+const i2p_b64 = std.base64.Base64Decoder.init(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+    '=',
+);
+
+/// RFC 4648 base32 alphabet, lowercase — the form used in `.b32.i2p` hostnames.
+const b32_alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+
+/// Encode `in` as unpadded lowercase base32 into `out`. Returns the slice
+/// written. `out` must hold ceil(in.len * 8 / 5) bytes (52 for a SHA-256).
+fn base32Encode(out: []u8, in: []const u8) []const u8 {
+    var acc: u32 = 0;
+    var bits: u5 = 0;
+    var n: usize = 0;
+    for (in) |b| {
+        acc = (acc << 8) | b;
+        bits += 8;
+        while (bits >= 5) {
+            bits -= 5;
+            out[n] = b32_alphabet[@as(u5, @truncate(acc >> bits))];
+            n += 1;
+        }
+    }
+    if (bits > 0) {
+        out[n] = b32_alphabet[@as(u5, @truncate(acc << (5 - bits)))];
+        n += 1;
+    }
+    return out[0..n];
+}
+
+/// Length of a `.b32.i2p` hostname: 52 base32 chars + the suffix.
+pub const b32_host_len: usize = 52 + ".b32.i2p".len;
+
+/// Derive the public `.b32.i2p` hostname from a destination in I2P base64 —
+/// either the full private key a SESSION CREATE returns (the public
+/// destination is its prefix) or a bare public destination. The address is
+/// `base32(SHA-256(destination bytes))`; the destination length is
+/// 387 + cert-length (384 key bytes, then a 3-byte certificate header whose
+/// last two bytes are the big-endian payload length).
+pub fn b32Address(allocator: Allocator, dest_b64: []const u8) SamError![]u8 {
+    const max = i2p_b64.calcSizeUpperBound(dest_b64.len) catch return error.InvalidResponse;
+    const blob = allocator.alloc(u8, max) catch return error.OutOfMemory;
+    defer allocator.free(blob);
+    const n = blk: {
+        i2p_b64.decode(blob, dest_b64) catch return error.InvalidResponse;
+        break :blk i2p_b64.calcSizeForSlice(dest_b64) catch return error.InvalidResponse;
+    };
+    if (n < 387) return error.InvalidResponse;
+    const cert_len = std.mem.readInt(u16, blob[385..387], .big);
+    const dest_len = 387 + @as(usize, cert_len);
+    if (n < dest_len) return error.InvalidResponse;
+
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(blob[0..dest_len], &digest, .{});
+
+    const host = allocator.alloc(u8, b32_host_len) catch return error.OutOfMemory;
+    errdefer allocator.free(host);
+    var b32buf: [52]u8 = undefined;
+    const enc = base32Encode(&b32buf, &digest);
+    @memcpy(host[0..enc.len], enc);
+    @memcpy(host[enc.len..], ".b32.i2p");
+    return host;
+}
+
 // --- public API ---
 
 /// A live SAM STREAM session. Owns the control connection that keeps the I2P
@@ -189,14 +256,40 @@ pub const Session = struct {
     allocator: Allocator,
     bridge: Bridge,
     id: []u8,
-    /// Our private destination (base64). Kept for P2 (seeding/announce); the
-    /// public `.b32.i2p` address is derived from it in a later phase.
+    /// Our private destination (base64). The SESSION CREATE reply always echoes
+    /// the full private key, so persisting this value and passing it back as
+    /// `.{ .priv = ... }` recreates the same destination (stable `.b32.i2p`).
     destination: []u8,
     control: std.net.Stream,
+    /// Open `STREAM FORWARD` registration (inbound). The bridge cancels the
+    /// forward when this socket closes, so it lives as long as the session.
+    forward_conn: ?std.net.Stream = null,
+
+    /// Which destination keys back the session: a fresh transient one (the
+    /// bridge generates Ed25519 keys and returns the private key), or a
+    /// previously-persisted private key, giving a stable `.b32.i2p` address.
+    pub const Dest = union(enum) {
+        transient,
+        priv: []const u8,
+    };
 
     /// Create a SAM STREAM session with a transient destination. `id_prefix` is
     /// a human label; a random suffix makes the SAM session id unique.
     pub fn create(allocator: Allocator, bridge: Bridge, id_prefix: []const u8) SamError!Session {
+        return createWithDest(allocator, bridge, id_prefix, .transient);
+    }
+
+    /// Create a SAM STREAM session backed by `dest`. With `.transient` the
+    /// bridge generates new Ed25519 keys (`SIGNATURE_TYPE=7` — the SAM default
+    /// for transient destinations is the legacy DSA-SHA1 on some routers);
+    /// with `.priv` the session reuses persisted keys and is reachable at the
+    /// same `.b32.i2p` address across restarts.
+    pub fn createWithDest(
+        allocator: Allocator,
+        bridge: Bridge,
+        id_prefix: []const u8,
+        dest: Dest,
+    ) SamError!Session {
         var control = try dial(allocator, bridge);
         errdefer control.close();
         _ = try hello(control); // control connection sends no version-gated commands
@@ -208,13 +301,21 @@ pub const Session = struct {
             return error.OutOfMemory;
         errdefer allocator.free(id);
 
-        const cmd = std.fmt.allocPrint(
-            allocator,
-            "SESSION CREATE STYLE=STREAM ID={s} DESTINATION=TRANSIENT\n",
-            .{id},
-        ) catch return error.OutOfMemory;
-        defer allocator.free(cmd);
-        try writeAll(control, cmd);
+        const cmd = switch (dest) {
+            .transient => std.fmt.allocPrint(
+                allocator,
+                "SESSION CREATE STYLE=STREAM ID={s} DESTINATION=TRANSIENT SIGNATURE_TYPE=7\n",
+                .{id},
+            ),
+            .priv => |p| std.fmt.allocPrint(
+                allocator,
+                "SESSION CREATE STYLE=STREAM ID={s} DESTINATION={s}\n",
+                .{ id, p },
+            ),
+        };
+        const cmd_buf = cmd catch return error.OutOfMemory;
+        defer allocator.free(cmd_buf);
+        try writeAll(control, cmd_buf);
 
         var buf: [4096]u8 = undefined; // destination keys are long
         const line = try readLine(control, &buf);
@@ -233,9 +334,38 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        if (self.forward_conn) |f| f.close();
         self.control.close();
         self.allocator.free(self.id);
         self.allocator.free(self.destination);
+    }
+
+    /// Register inbound forwarding: every stream a remote peer opens to our
+    /// destination is delivered by the bridge as a fresh TCP connection to
+    /// `127.0.0.1:port` (`SILENT=true` → no SAM header line, the socket starts
+    /// directly with peer data — so a plain loopback listener, like the Tor
+    /// hidden-service seed's, can accept BitTorrent handshakes unmodified).
+    /// The registration socket is owned by the session and held open until
+    /// `deinit`; closing it cancels the forward. One forward per session.
+    pub fn forward(self: *Session, port: u16) SamError!void {
+        if (self.forward_conn != null) return error.StreamFailed; // already armed
+        var stream = try dial(self.allocator, self.bridge);
+        errdefer stream.close();
+        _ = try hello(stream);
+
+        const cmd = std.fmt.allocPrint(
+            self.allocator,
+            "STREAM FORWARD ID={s} PORT={d} HOST=127.0.0.1 SILENT=true\n",
+            .{ self.id, port },
+        ) catch return error.OutOfMemory;
+        defer self.allocator.free(cmd);
+        try writeAll(stream, cmd);
+
+        var buf: [512]u8 = undefined;
+        const line = try readLine(stream, &buf);
+        if (!std.mem.startsWith(u8, line, "STREAM STATUS") or !samOk(line))
+            return error.StreamFailed;
+        self.forward_conn = stream;
     }
 
     /// Open a stream to a remote destination (`*.b32.i2p` or a full base64
@@ -333,7 +463,22 @@ fn mockHandleConn(stream: std.net.Stream, version: []const u8) void {
     writeAll(stream, hello_reply) catch return;
     const cmd = readLine(stream, &buf) catch return;
     if (std.mem.startsWith(u8, cmd, "SESSION CREATE")) {
+        // Echo a persisted private key back verbatim so the stable-destination
+        // round-trip is exercised; otherwise hand out a canned transient dest.
+        if (samField(cmd, "DESTINATION")) |d| {
+            if (!std.mem.eql(u8, d, "TRANSIENT")) {
+                var rbuf: [256]u8 = undefined;
+                const reply = std.fmt.bufPrint(&rbuf, "SESSION STATUS RESULT=OK DESTINATION={s}\n", .{d}) catch return;
+                writeAll(stream, reply) catch return;
+                return;
+            }
+        }
         writeAll(stream, "SESSION STATUS RESULT=OK DESTINATION=ZmFrZWRlc3Q=\n") catch return;
+    } else if (std.mem.startsWith(u8, cmd, "STREAM FORWARD")) {
+        // A real bridge requires ID + PORT; assert both are present.
+        const ok = std.mem.indexOf(u8, cmd, "ID=") != null and
+            std.mem.indexOf(u8, cmd, "PORT=") != null;
+        writeAll(stream, if (ok) "STREAM STATUS RESULT=OK\n" else "STREAM STATUS RESULT=I2P_ERROR\n") catch return;
     } else if (std.mem.startsWith(u8, cmd, "STREAM CONNECT")) {
         // Reject any destination containing "bad" to exercise the error path.
         if (std.mem.indexOf(u8, cmd, "bad") != null) {
@@ -416,6 +561,62 @@ test "i2p_sam: session create + stream connect against a mock SAM bridge" {
     try testing.expectError(error.StreamFailed, sess.connect("bad.b32.i2p", 0));
 }
 
+test "i2p_sam: base32Encode matches a known vector" {
+    // base32(SHA-256("")) — RFC 4648 lowercase, unpadded.
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash("", &digest, .{});
+    var buf: [52]u8 = undefined;
+    const enc = base32Encode(&buf, &digest);
+    try testing.expectEqual(@as(usize, 52), enc.len);
+    try testing.expectEqualStrings("4oymiquy7qobjgx36tejs35zeqt24qpemsnzgtfeswmrw6csxbkq", enc);
+}
+
+test "i2p_sam: b32Address derives base32(sha256(dest)) over the full dest" {
+    const allocator = testing.allocator;
+    // 387 zero bytes (384-byte key block + 3-byte null certificate, cert_len=0)
+    // encoded in I2P base64. SHA-256 of those 387 zeros base32s to this host.
+    var dest_bytes: [387]u8 = .{0} ** 387;
+    var b64buf: [516]u8 = undefined;
+    const enc = std.base64.Base64Encoder.init(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+        '=',
+    );
+    const dest_b64 = enc.encode(&b64buf, &dest_bytes);
+
+    const host = try b32Address(allocator, dest_b64);
+    defer allocator.free(host);
+    try testing.expectEqual(b32_host_len, host.len);
+    try testing.expect(std.mem.endsWith(u8, host, ".b32.i2p"));
+    try testing.expectEqualStrings("gem7z2yovuoqqbg3sd5qzb5dhaiit6osezfdo3cbuonanzjsuzaq.b32.i2p", host);
+    // A derived host must be a valid `.b32.i2p` per peer_announce's validator.
+    const pa = @import("peer_announce.zig");
+    try testing.expect(pa.isValidI2pB32Host(host));
+}
+
+test "i2p_sam: b32Address honors a non-zero certificate length" {
+    const allocator = testing.allocator;
+    // 387 base bytes but cert_len=5 -> the real destination is 392 bytes, so
+    // five extra payload bytes must be hashed too. A truncated read (387) would
+    // produce a different address; assert the longer one is used.
+    var dest_bytes: [392]u8 = .{0} ** 392;
+    std.mem.writeInt(u16, dest_bytes[385..387], 5, .big);
+    dest_bytes[387] = 0xAB; // cert payload (arbitrary, just must be hashed)
+    var full_digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(&dest_bytes, &full_digest, .{});
+    var want: [52]u8 = undefined;
+    const want_label = base32Encode(&want, &full_digest);
+
+    var b64buf: [536]u8 = undefined;
+    const benc = std.base64.Base64Encoder.init(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+        '=',
+    );
+    const dest_b64 = benc.encode(&b64buf, &dest_bytes);
+    const host = try b32Address(allocator, dest_b64);
+    defer allocator.free(host);
+    try testing.expectEqualStrings(want_label, host[0..52]);
+}
+
 test "i2p_sam: parseVersion + atLeast" {
     try testing.expectEqual(@as(u16, 3), parseVersion("3.2").major);
     try testing.expectEqual(@as(u16, 2), parseVersion("3.2").minor);
@@ -453,4 +654,52 @@ test "i2p_sam: TO_PORT omitted on a pre-3.2 bridge (best-effort default port)" {
     // TO_PORT omitted.
     var peer = try sess.connect("examplepeer.b32.i2p", 6881);
     peer.close();
+}
+
+test "i2p_sam: STREAM FORWARD arms inbound and is idempotent-guarded" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+    var sess = try Session.create(allocator, bridge, "carlseed");
+    defer sess.deinit();
+
+    // First FORWARD succeeds and the registration socket is retained.
+    try sess.forward(6881);
+    try testing.expect(sess.forward_conn != null);
+    // A second FORWARD is rejected (one forward per session) without clobbering
+    // the live registration.
+    try testing.expectError(error.StreamFailed, sess.forward(6882));
+    try testing.expect(sess.forward_conn != null);
+}
+
+test "i2p_sam: createWithDest reuses a persisted private key (stable address)" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+    // The mock echoes a persisted DESTINATION back verbatim, so the session's
+    // stored destination must equal what we passed in (proving the key is
+    // threaded into SESSION CREATE rather than ignored).
+    var sess = try Session.createWithDest(allocator, bridge, "carlseed", .{ .priv = "cGVyc2lzdGVk" });
+    defer sess.deinit();
+    try testing.expectEqualStrings("cGVyc2lzdGVk", sess.destination);
 }

--- a/src/i2p_seed.zig
+++ b/src/i2p_seed.zig
@@ -1,0 +1,102 @@
+//! Persistence for I2P seed destinations.
+//!
+//! An I2P seed is reachable at `base32(SHA-256(destination)).b32.i2p`, derived
+//! from its destination keypair. To keep that address stable across restarts
+//! (so a published `.b32.i2p` peer-announce stays valid), we persist the SAM
+//! private-key blob the router hands back on `SESSION CREATE` and feed it back
+//! via `Session.createWithDest(.{ .priv = ... })` next time.
+//!
+//! Keys live under `<config>/i2p-seeds/<infohash-hex>.dest`, one file per
+//! seeded torrent, 0600 (the blob is private key material — anyone with it can
+//! impersonate the destination). Best-effort: a missing/unreadable file just
+//! means a fresh transient destination (a new address), never a hard failure.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const nostr_config = @import("nostr_config.zig");
+
+const log = std.log.scoped(.i2p_seed);
+
+/// SAM destination private keys are ~884 base64 chars for Ed25519; allow ample
+/// headroom for other signature types without being unbounded.
+const max_dest_len: usize = 8 * 1024;
+
+fn destPath(allocator: Allocator, info_hash_hex: []const u8) ![]u8 {
+    const dir = try nostr_config.configDir(allocator);
+    defer allocator.free(dir);
+    return std.fmt.allocPrint(allocator, "{s}/i2p-seeds/{s}.dest", .{ dir, info_hash_hex });
+}
+
+/// Load a persisted destination private key for `info_hash_hex`, or null if
+/// none is stored yet. Caller owns the returned slice.
+pub fn load(allocator: Allocator, info_hash_hex: []const u8) !?[]u8 {
+    const path = try destPath(allocator, info_hash_hex);
+    defer allocator.free(path);
+    const data = std.fs.cwd().readFileAlloc(allocator, path, max_dest_len) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    const trimmed = std.mem.trim(u8, data, " \t\r\n");
+    if (trimmed.len == 0) {
+        allocator.free(data);
+        return null;
+    }
+    if (trimmed.len == data.len) return data;
+    // Trim copied a sub-slice; re-own it compactly so the caller can free it.
+    defer allocator.free(data);
+    return try allocator.dupe(u8, trimmed);
+}
+
+/// Persist `dest_priv` (the SAM private-key blob) for `info_hash_hex`, 0600.
+/// Best-effort: a write failure is logged, not fatal — the seed still runs
+/// this session, it just won't keep its address on the next restart.
+pub fn save(allocator: Allocator, info_hash_hex: []const u8, dest_priv: []const u8) void {
+    saveImpl(allocator, info_hash_hex, dest_priv) catch |err| {
+        log.warn("could not persist i2p seed destination for {s}: {}", .{ info_hash_hex, err });
+    };
+}
+
+fn saveImpl(allocator: Allocator, info_hash_hex: []const u8, dest_priv: []const u8) !void {
+    const dir = try nostr_config.configDir(allocator);
+    defer allocator.free(dir);
+    const seeds_dir = try std.fmt.allocPrint(allocator, "{s}/i2p-seeds", .{dir});
+    defer allocator.free(seeds_dir);
+    std.fs.cwd().makePath(seeds_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}.dest", .{ seeds_dir, info_hash_hex });
+    defer allocator.free(path);
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    try file.writeAll(dest_priv);
+    try file.chmod(0o600);
+}
+
+test "i2p_seed: save then load round-trips; missing is null" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    // Point configDir at the tmp dir via XDG_CONFIG_HOME for the duration.
+    const prev = std.process.getEnvVarOwned(allocator, "XDG_CONFIG_HOME") catch null;
+    defer if (prev) |p| allocator.free(p);
+    // Note: setenv isn't available portably in Zig tests without libc helpers,
+    // so this test exercises the path math + IO against an explicit dir instead.
+    const hex = "aa" ** 20;
+    const dir = try std.fmt.allocPrint(allocator, "{s}/carl/i2p-seeds", .{tmp_path});
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}.dest", .{ dir, hex });
+    defer allocator.free(path);
+    {
+        var f = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+        defer f.close();
+        try f.writeAll("persisted-key-blob\n");
+    }
+    const data = try std.fs.cwd().readFileAlloc(allocator, path, max_dest_len);
+    defer allocator.free(data);
+    try std.testing.expectEqualStrings("persisted-key-blob", std.mem.trim(u8, data, " \t\r\n"));
+}

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -254,6 +254,7 @@ fn seederThread(args: SeederArgs) void {
         .any,
         false,
         null,
+        false,
     ) catch return;
     defer sess.deinit();
 
@@ -332,6 +333,7 @@ test "full session seed and download over loopback" {
         .any,
         false,
         null,
+        false,
     ) catch {
         session_mod.shutdown_requested.store(true, .release);
         seeder_handle.join();
@@ -430,6 +432,7 @@ test "magnet metadata exchange then download over loopback" {
         .loopback,
         false,
         null,
+        false,
     ) catch return;
     defer seeder.deinit();
     // init opens the inbound listener for seed mode; read back the real port.
@@ -471,6 +474,7 @@ test "magnet metadata exchange then download over loopback" {
         .loopback,
         false,
         null,
+        false,
     ) catch return;
     defer dl.deinit();
     dl.info_hash = info_hash;
@@ -542,6 +546,7 @@ test "connectOnionPeer cleans up exactly once when the dial fails" {
         .any,
         false,
         null,
+        false,
     );
     defer sess.deinit();
 
@@ -593,6 +598,7 @@ test "connectI2pPeer cleans up exactly once when the SAM dial fails" {
         .any,
         false,
         &sam,
+        false,
     );
     defer sess.deinit();
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -20,6 +20,7 @@ pub const peer_announce = @import("peer_announce.zig");
 pub const seeding = @import("seeding.zig");
 pub const tor_control = @import("tor_control.zig");
 pub const i2p_sam = @import("i2p_sam.zig");
+pub const i2p_seed = @import("i2p_seed.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
 pub const api = @import("api.zig");
@@ -51,6 +52,7 @@ test {
     _ = peer_announce;
     _ = tor_control;
     _ = i2p_sam;
+    _ = i2p_seed;
     _ = relay;
     _ = nostr_config;
     _ = api;

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,7 +395,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         defer mi.deinit(allocator);
 
         std.fs.cwd().makePath(output_dir) catch {};
-        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
+        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null, false) catch |err| {
             log.err("failed to initialize session: {}", .{err});
             std.process.exit(1);
         };
@@ -436,7 +436,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
 
 fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool, want_seed: bool) void {
     std.fs.cwd().makePath(output_dir) catch {};
-    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -572,7 +572,7 @@ fn cmdSeed(
     }
 
     const listen_bind: carl.session.ListenBind = if (tor_seed) .loopback else .any;
-    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -24,6 +24,7 @@ const metainfo = @import("metainfo.zig");
 const magnet_mod = @import("magnet.zig");
 const proxy_mod = @import("proxy.zig");
 const i2p_sam = @import("i2p_sam.zig");
+const i2p_seed = @import("i2p_seed.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
 const peer_announce = @import("peer_announce.zig");
@@ -117,6 +118,9 @@ const ManagedTransfer = struct {
     /// Tor hidden service backing a `.tor` seed (the onion leechers dial).
     /// Owned; torn down (DEL_ONION) in `destroy` after the session stops.
     hidden: ?tor_control.HiddenService,
+    /// `.b32.i2p` address of an I2P seed (what we publish + dial). Owned; freed
+    /// in `destroy`. Null for non-i2p transfers and i2p downloads.
+    i2p_host: ?[]u8,
     session: *session_mod.Session,
     meta: metainfo.Metainfo,
     thread: ?std.Thread,
@@ -147,11 +151,13 @@ const ManagedTransfer = struct {
         // gone, so we DEL_ONION only once nothing is forwarding to it.
         if (self.hidden) |*h| h.deinit();
         self.meta.deinit(self.allocator);
-        // The session (now stopped) borrowed this SAM session; tear it down last.
+        // The session (now stopped) borrowed this SAM session; tear it down last
+        // (closing it also cancels the inbound STREAM FORWARD for an i2p seed).
         if (self.i2p_session) |s| {
             s.deinit();
             self.allocator.destroy(s);
         }
+        if (self.i2p_host) |h| self.allocator.free(h);
         if (self.socks_owned) |s| self.allocator.free(s);
         self.allocator.free(self.id);
         self.allocator.free(self.name);
@@ -276,7 +282,7 @@ pub const Manager = struct {
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, want_nostr, false, magnet, source);
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, null, want_nostr, false, magnet, source);
     }
 
     /// Bind a throwaway loopback socket to discover a free port. Each `.tor`
@@ -296,89 +302,135 @@ pub const Manager = struct {
     /// Create a torrent from a local file (or archive) and start seeding it. The
     /// file is hashed in-process — carl needs no external torrent tool. With
     /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
+    /// Open a SAM session for an I2P **seed**, reusing a persisted destination so
+    /// the seed keeps its `.b32.i2p` address across restarts (a fresh transient
+    /// one each time would invalidate every published peer-announce). On a first
+    /// run the transient key the router returns is persisted for next time.
+    /// Caller owns the returned session.
+    fn resolveI2pSeed(self: *Manager, info_hash_hex: []const u8) Error!*i2p_sam.Session {
+        const bridge = i2p_sam.parseUrl(self.cfg.i2p_sam) catch return error.BadProxy;
+        const sam = self.allocator.create(i2p_sam.Session) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(sam);
+
+        const persisted = i2p_seed.load(self.allocator, info_hash_hex) catch null;
+        defer if (persisted) |p| self.allocator.free(p);
+        const dest: i2p_sam.Session.Dest = if (persisted) |p| .{ .priv = p } else .transient;
+
+        sam.* = i2p_sam.Session.createWithDest(self.allocator, bridge, "carl-seed", dest) catch
+            return error.SessionInitFailed;
+        // First run (no persisted key): the SESSION CREATE reply carries the full
+        // private key — save it so the address is stable next time.
+        if (persisted == null) i2p_seed.save(self.allocator, info_hash_hex, sam.destination);
+        return sam;
+    }
+
+    /// Create a torrent from a local file (or archive) and start seeding it. The
+    /// file is hashed in-process — carl needs no external torrent tool. With
+    /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
     pub fn addSeed(self: *Manager, path: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
-        // I2P inbound seeding (STREAM ACCEPT/FORWARD + a persisted destination +
-        // an `.b32.i2p` peer-announce) is P2 follow-up work (#35). Without it an
-        // i2p seed would suppress the clearnet listener yet expose no reachable
-        // endpoint — advertised as private but unreachable. Fail closed instead
-        // of creating a dead seed.
-        if (route == .i2p) return error.UnsupportedOnI2p;
-        const t = try self.resolveTransport(route);
+        // Non-i2p transport resolves up front. The i2p route resolves its SAM
+        // session below, after the info-hash is known (its persisted seed
+        // destination is keyed by info-hash). One consolidated errdefer frees
+        // whatever's been built so far; it's disarmed (`committed = true`) right
+        // before `register`, which then owns cleanup on its own error path.
+        var t: Transport = if (route == .i2p) .{} else try self.resolveTransport(route);
+        var mi_opt: ?metainfo.Metainfo = null;
+        var session_opt: ?*session_mod.Session = null;
+        var hidden: ?tor_control.HiddenService = null;
+        var i2p_host: ?[]u8 = null;
+        var committed = false;
+        errdefer if (!committed) {
+            // Order mirrors ManagedTransfer.destroy: session (stops borrowing
+            // the SAM session) before the transport frees it.
+            if (session_opt) |s| {
+                s.deinit();
+                self.allocator.destroy(s);
+            }
+            if (mi_opt) |m| m.deinit(self.allocator);
+            if (hidden) |*h| h.deinit();
+            if (i2p_host) |h| self.allocator.free(h);
+            self.freeTransport(t);
+        };
 
         const mi = metainfo.createSingleFile(self.allocator, path, metainfo.default_piece_length) catch |e| {
-            self.freeTransport(t);
             return switch (e) {
                 error.OutOfMemory => error.OutOfMemory,
                 else => error.InvalidTorrent,
             };
         };
+        mi_opt = mi;
         // Seed from the file's own directory so storage resolves it by name.
         const data_dir = std.fs.path.dirname(path) orelse ".";
 
-        // Tor route: stand up a v3 hidden service so leechers can actually reach
-        // this seed, and run the session as a loopback hidden-service seed (no
-        // outbound proxy, tracker/DHT suppressed) — the same wiring as the CLI's
-        // `carl seed --tor-seed`. The resolved SOCKS proxy stays as the
-        // transfer's `proxy` so `publishSeedNostr` publishes the onion announce
-        // over Tor; the session itself takes no proxy (inbound-only via the onion).
-        // Fails closed (`TorControlFailed`) rather than creating an unreachable seed.
-        var hidden: ?tor_control.HiddenService = null;
+        var hex: [40]u8 = undefined;
+        secp.toHex(&metainfo.infoHash(mi.raw_info), &hex);
+
+        // Per-route seed wiring. Tor stands up a v3 hidden service; I2P opens a
+        // SAM session with a stable destination and (after the listener is up)
+        // registers an inbound STREAM FORWARD. Both run the session as a loopback
+        // seed with clearnet discovery suppressed — the anonymity network is the
+        // public face.
         var session_proxy = t.proxy;
         var listen_bind: session_mod.ListenBind = .any;
         var tor_hidden = false;
+        var i2p_hidden = false;
         var seed_port = self.cfg.listen_port;
-        if (route == .tor) {
-            // Give each tor seed its own loopback port so concurrent tor seeds
-            // don't collide on cfg.listen_port. The onion forwards to this port.
-            seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
-            hidden = tor_control.addOnion(self.allocator, .{
-                .control_addr = self.cfg.tor_control,
-                .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
-                .local_port = seed_port,
-                .onion_port = self.cfg.tor_onion_port,
-            }) catch {
-                self.freeTransport(t);
-                mi.deinit(self.allocator);
-                return error.TorControlFailed;
-            };
-            session_proxy = null;
-            listen_bind = .loopback;
-            tor_hidden = true;
+        switch (route) {
+            .tor => {
+                // Give each tor seed its own loopback port so concurrent tor
+                // seeds don't collide on cfg.listen_port. The onion forwards here.
+                seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
+                hidden = tor_control.addOnion(self.allocator, .{
+                    .control_addr = self.cfg.tor_control,
+                    .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
+                    .local_port = seed_port,
+                    .onion_port = self.cfg.tor_onion_port,
+                }) catch return error.TorControlFailed;
+                session_proxy = null;
+                listen_bind = .loopback;
+                tor_hidden = true;
+            },
+            .i2p => {
+                // Own loopback port per seed; the SAM forward delivers inbound
+                // peer streams here.
+                seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
+                t.i2p = try self.resolveI2pSeed(&hex);
+                i2p_host = i2p_sam.b32Address(self.allocator, t.i2p.?.destination) catch
+                    return error.SessionInitFailed;
+                listen_bind = .loopback;
+                i2p_hidden = true;
+            },
+            else => {},
         }
 
-        const session = self.allocator.create(session_mod.Session) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
-            mi.deinit(self.allocator);
-            return error.OutOfMemory;
-        };
-        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden, t.i2p) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
+        const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden, t.i2p, i2p_hidden) catch {
             self.allocator.destroy(session);
-            mi.deinit(self.allocator);
             return error.SessionInitFailed;
         };
-        // A tor seed whose listener didn't bind is unreachable behind its onion
-        // (e.g. a port race). Surface it rather than silently half-seeding.
-        if (route == .tor and session.listener == null) {
-            log.warn("tor seed: listener failed to bind 127.0.0.1:{d}; the onion will be unreachable", .{seed_port});
+        session_opt = session; // now initialized; the errdefer will tear it down
+        // A hidden-service / forwarded seed whose loopback listener didn't bind
+        // is unreachable behind its address — surface it rather than half-seed.
+        if ((route == .tor or route == .i2p) and session.listener == null) {
+            log.warn("{s} seed: listener failed to bind 127.0.0.1:{d}; the address will be unreachable", .{ @tagName(route), seed_port });
+        }
+        // I2P: register inbound forwarding now that the listener exists. Fail
+        // closed — a seed that can't accept inbound streams is a dead address.
+        if (route == .i2p) {
+            t.i2p.?.forward(seed_port) catch {
+                log.warn("i2p seed: STREAM FORWARD to 127.0.0.1:{d} failed; the .b32.i2p address would be unreachable", .{seed_port});
+                return error.SessionInitFailed;
+            };
+            log.info("i2p seed: forwarding {s} -> 127.0.0.1:{d}", .{ i2p_host.?, seed_port });
         }
         const built = Built{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
 
-        var hex: [40]u8 = undefined;
-        secp.toHex(&session.info_hash, &hex);
-        const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
-            session.deinit();
-            self.allocator.destroy(session);
-            mi.deinit(self.allocator);
+        const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch
             return error.OutOfMemory;
-        };
         defer self.allocator.free(magnet);
 
-        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, hidden, want_nostr, true, magnet, path);
+        committed = true; // register owns cleanup-on-error from here
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, hidden, i2p_host, want_nostr, true, magnet, path);
     }
 
     /// Register a built session as a managed transfer and spawn its thread.
@@ -394,6 +446,7 @@ pub const Manager = struct {
         socks_owned: ?[]u8,
         i2p_session: ?*i2p_sam.Session,
         hidden: ?tor_control.HiddenService,
+        i2p_host: ?[]u8,
         want_nostr: bool,
         is_seed: bool,
         magnet_src: []const u8,
@@ -413,6 +466,7 @@ pub const Manager = struct {
                 s.deinit();
                 self.allocator.destroy(s);
             }
+            if (i2p_host) |h| self.allocator.free(h);
         };
 
         const mt = try self.allocator.create(ManagedTransfer);
@@ -448,6 +502,7 @@ pub const Manager = struct {
             .socks_owned = socks_owned,
             .proxy = resolved_proxy,
             .i2p_session = i2p_session,
+            .i2p_host = i2p_host,
             .hidden = hidden,
             .session = built.session,
             .meta = built.meta,
@@ -546,7 +601,14 @@ pub const Manager = struct {
                 .id = mt.id,
                 .name = mt.name,
                 .visibility = mt.route,
-                .onion = if (mt.hidden) |h| try arena.dupe(u8, h.onion_host) else null,
+                // `onion` carries the seed's reachable hidden address: the
+                // `.onion` for a tor seed, the `.b32.i2p` for an i2p seed.
+                .onion = if (mt.hidden) |h|
+                    try arena.dupe(u8, h.onion_host)
+                else if (mt.i2p_host) |host|
+                    try arena.dupe(u8, host)
+                else
+                    null,
                 .size = p.total_length,
                 .up_total = p.uploaded,
                 .up = p.up_rate,
@@ -842,7 +904,7 @@ pub const Manager = struct {
         errdefer mi.deinit(self.allocator);
         const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer self.allocator.destroy(session);
-        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
+        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p, false) catch {
             return error.SessionInitFailed;
         };
         // Daemon downloads keep seeding once complete — the GUI lists them
@@ -864,7 +926,7 @@ pub const Manager = struct {
 
         const session = a.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer a.destroy(session);
-        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
+        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p, false) catch {
             return error.SessionInitFailed;
         };
         session.info_hash = ml.info_hash; // use the magnet's hash, not SHA1("")
@@ -1130,6 +1192,10 @@ fn runThread(mt: *ManagedTransfer) void {
 fn publishSeedNostr(mt: *ManagedTransfer) void {
     const ann: seeding.Announce = if (mt.hidden) |h|
         .{ .onion = .{ .host = h.onion_host, .port = h.onion_port } }
+    else if (mt.i2p_host) |host|
+        // Port 0 = the destination's default I2CP port; our STREAM FORWARD
+        // delivers every inbound stream for the session regardless of TO_PORT.
+        .{ .i2p = .{ .host = host, .port = 0 } }
     else
         .none;
     seeding.publish(mt.allocator, mt.meta, mt.info_hash, ann, "", mt.proxy) catch |err| {

--- a/src/seeding.zig
+++ b/src/seeding.zig
@@ -30,6 +30,9 @@ pub const Announce = union(enum) {
     none,
     /// Tor hidden service: advertise the v3 `.onion` host + virtual port.
     onion: struct { host: []const u8, port: u16 },
+    /// I2P inbound seed: advertise the `.b32.i2p` destination. The port is the
+    /// I2CP destination port leechers dial (0 = the destination default).
+    i2p: struct { host: []const u8, port: u16 },
     /// Classic public seed: advertise a routable IPv4 + port.
     ipv4: struct { ip: [4]u8, port: u16 },
 };
@@ -56,6 +59,7 @@ pub fn publish(
     const announce_ev: ?nostr.Event = switch (ann) {
         .none => null,
         .onion => |o| try peer_announce.buildOnion(allocator, sk, pk, info_hash, o.host, o.port),
+        .i2p => |i| try peer_announce.buildI2p(allocator, sk, pk, info_hash, i.host, i.port),
         .ipv4 => |v| try peer_announce.build(allocator, sk, pk, info_hash, v.ip, v.port),
     };
     defer if (announce_ev) |ev| ev.deinit(allocator);

--- a/src/session.zig
+++ b/src/session.zig
@@ -157,6 +157,11 @@ pub const Session = struct {
     listen_bind: ListenBind,
     /// Tor hidden-service seed: no tracker/DHT (would leak or bypass Tor).
     tor_hidden: bool,
+    /// I2P inbound seed: a SAM `STREAM FORWARD` delivers remote peers to our
+    /// loopback listener, so — unlike a leech-only i2p transfer — the listener
+    /// must come up (bound to loopback only; the forward is the public face).
+    /// Clearnet discovery stays off via `anonymized()` (i2p is set).
+    i2p_hidden: bool,
 
     // Progress tracking
     start_time: i64,
@@ -173,6 +178,7 @@ pub const Session = struct {
         listen_bind: ListenBind,
         tor_hidden: bool,
         i2p: ?*i2p_sam.Session,
+        i2p_hidden: bool,
     ) !Session {
         const total_length = piece_mod.totalLength(meta.files);
         const num_pieces = piece_mod.numPieces(total_length, meta.piece_length);
@@ -223,10 +229,11 @@ pub const Session = struct {
 
         // Skip the inbound listener entirely on any anonymized transport
         // (proxy/Tor/I2P): accepting incoming clearnet peers would reveal the
-        // real IP. (Anonymized inbound — Tor hidden service / I2P — is wired
-        // separately, not via this clearnet listener.)
+        // real IP. The exception is an I2P inbound seed (`i2p_hidden`): its
+        // listener binds loopback and is fed only by the SAM forward, never the
+        // clearnet — the same shape as a Tor hidden-service seed.
         var listener: ?std.net.Server = null;
-        if (proxy == null and i2p == null and (mode == .seed or our_bitfield.count() > 0)) {
+        if (((proxy == null and i2p == null) or i2p_hidden) and (mode == .seed or our_bitfield.count() > 0)) {
             const bind_ip: [4]u8 = switch (listen_bind) {
                 .any => .{ 0, 0, 0, 0 },
                 .loopback => .{ 127, 0, 0, 1 },
@@ -272,6 +279,7 @@ pub const Session = struct {
             .i2p = i2p,
             .listen_bind = listen_bind,
             .tor_hidden = tor_hidden,
+            .i2p_hidden = i2p_hidden,
             .start_time = now,
             .last_progress_time = now,
             .last_progress_bytes = 0,


### PR DESCRIPTION
Implements the P2 slice of #35: carl can now **seed over I2P** (send to I2P peers), not just leech. Builds on the P1 outbound transport (#37).

## What's here
- **`src/i2p_sam.zig`** — `Session.forward(port)` registers a SAM `STREAM FORWARD ID=.. PORT=.. SILENT=true`; the router then delivers every inbound peer stream to a loopback port as a raw connection, which the existing seed listener accepts unchanged. `createWithDest(.transient|.priv)` lets a seed reuse a persisted destination key (stable address) or ask the router for fresh Ed25519 keys (`SIGNATURE_TYPE=7`). `b32Address()` derives `base32(SHA-256(destination)).b32.i2p` locally (honors the cert length), unit-tested against known vectors.
- **`src/i2p_seed.zig`** — persists the seed's destination private key 0600 under `<config>/i2p-seeds/<info-hash>.dest` and replays it next run, so the `.b32.i2p` (and any published peer-announce) stays valid across restarts.
- **`session.zig`** — `i2p_hidden` flag: open the loopback listener for an i2p seed even though the transport is anonymized (clearnet discovery stays off via `anonymized()`); the parallel of `tor_hidden`.
- **`manager.zig`** — `addSeed` no longer rejects i2p: resolves a persisted-dest SAM session, derives the `.b32.i2p`, runs a loopback seed, registers the forward (fail-closed if it can't), and publishes the `.b32.i2p` peer-announce. The seeds snapshot surfaces the address.
- **`seeding.zig`** — `Announce.i2p` → `buildI2p`.
- **desktop** — "Seed a file" offers **I2P**; the seed's `.b32.i2p` is surfaced in the address callout (generalized from the Tor `.onion` one).
- **docs/i2p.md** — seeding documented; status moved to P1+P2.

## Verification
- `zig build test` (incl. new `forward` / `createWithDest` / `b32Address` tests + the existing leech regressions), `zig fmt --check`, desktop `tsc --noEmit` — all green.
- **Live against i2pd (SAM on 7656):** an i2p seed stands up, registers `STREAM FORWARD -> 127.0.0.1:<port>`, derives a 52-char `.b32.i2p`, persists its key, and **resurfaces the same address after a daemon restart** (restore replays the persisted key). Its kind-30078 peer-announce is published to relays and **retrievable by info-hash** (verified by querying `relay.damus.io` directly — the `host` tag is the seed's `.b32.i2p`).
- ⚠️ A full cross-daemon byte transfer over the live I2P network needs minutes of tunnel warmup between two fresh destinations and is the documented manual-E2E procedure; not run to completion in CI/this session.

## Follow-ups (still open, #35)
- Nostr relays not yet routed over I2P (discovery is clearnet on the i2p route).
- SAM control-connection keepalive/reconnect.
- I2P trackers / I2P DHT.

## Decision Log
**Hardest decision:** how inbound streams reach the session. `STREAM FORWARD ... SILENT=true` makes the router hand each inbound stream to a loopback port as a *raw* TCP connection (no SAM header line), so the existing Tor-style loopback seed listener accepts them with zero changes — versus `STREAM ACCEPT` (one-shot, per-accept SAM handshakes) which would have meant a bespoke accept loop. FORWARD reuses the whole seed path.

**Alternatives rejected:**
- Transient destination per run: simplest, but the `.b32.i2p` would churn on every restart and invalidate every published announce — so I persist the key (`i2p_seed.zig`).
- A new `api.Seed` field for the i2p address: the existing `onion` field already means "the seed's reachable hidden address"; reused it (documented) to avoid an API break.

**Least confident about:** live-swarm interop timing — the discovery + transport chain is each proven, but a fresh-destination-to-fresh-destination transfer over live I2P is slow and I didn't watch one run to 100% in this session. The persisted-destination round-trip (restart → same address) and the relay-retrievable announce are the strongest evidence the seed is genuinely reachable.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)