### PR TITLE
I2P feature parity: GUI downloads + seeding, transport health, CLI seed, packaging

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,90 @@
+name: Desktop Release
+
+# Builds the carl desktop app (Tauri) into distributable bundles.
+# Linux must be built on Linux and macOS on macOS — Tauri does not
+# cross-compile the GUI bundle — so each target runs on its own runner.
+# Trigger manually from the Actions tab or with `gh workflow run`.
+on:
+  workflow_dispatch:
+
+jobs:
+  linux-x86_64:
+    name: Linux x86_64 (.deb + .AppImage)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Tauri v2 Linux system dependencies (webkit2gtk 4.1, appindicator, rsvg).
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            build-essential \
+            file \
+            wget
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install desktop deps
+        working-directory: desktop
+        run: npm ci
+
+      # stage-sidecar.sh builds a ReleaseSafe `carl` for the host triple
+      # (x86_64-unknown-linux-gnu here) and stages it as the Tauri sidecar.
+      - name: Build bundle
+        working-directory: desktop
+        run: npx tauri build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: carl-linux-x86_64
+          path: |
+            desktop/src-tauri/target/release/bundle/deb/*.deb
+            desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+          if-no-files-found: error
+
+  macos:
+    name: macOS (.dmg + .app)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install desktop deps
+        working-directory: desktop
+        run: npm ci
+
+      - name: Build bundle
+        working-directory: desktop
+        run: npx tauri build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: carl-macos-aarch64
+          path: |
+            desktop/src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: error

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -3,9 +3,14 @@ name: Desktop Release
 # Builds the carl desktop app (Tauri) into distributable bundles.
 # Linux must be built on Linux and macOS on macOS — Tauri does not
 # cross-compile the GUI bundle — so each target runs on its own runner.
-# Trigger manually from the Actions tab or with `gh workflow run`.
+# Trigger manually from the Actions tab, or automatically on pushes to a
+# `build/**` branch (so a packaging branch produces artifacts without needing
+# the workflow on the default branch first).
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "build/**"
 
 jobs:
   linux-x86_64:

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -19,8 +19,17 @@ export interface DaemonConfig {
 }
 
 /** Abort a stuck request so the UI falls back to its offline state instead of
- *  awaiting a hung daemon socket forever. */
+ *  awaiting a hung daemon socket forever. Used for the fast read endpoints. */
 const REQUEST_TIMEOUT_MS = 8000;
+
+/** Adding a transfer or seed on an anonymized route blocks the daemon while it
+ *  stands up the network session: a Tor hidden service, or an I2P SAM
+ *  `SESSION CREATE` that builds tunnels (commonly 10-30s, bounded by the
+ *  daemon's 60s SAM timeout). The 8s read timeout would abort that mid-build —
+ *  the transfer/seed never registers and the UI looks like "i2p doesn't work" —
+ *  so add/seed get a timeout that comfortably covers session setup. (A bridge
+ *  that's actually down still fails fast: connection refused is instant.) */
+const SESSION_SETUP_TIMEOUT_MS = 90_000;
 
 /** Matches the daemon's body cap (docs/daemon-api.md) — guard before reading the
  *  whole file into memory so a huge drop fails fast with a clear message. */
@@ -92,6 +101,9 @@ export class DaemonClient {
     const res = await this.fetch("/api/transfers", {
       method: "POST",
       body: JSON.stringify({ source, route, nostr }),
+      // Anonymized routes build a session before the daemon responds (see
+      // SESSION_SETUP_TIMEOUT_MS); don't abort mid-build.
+      signal: AbortSignal.timeout(SESSION_SETUP_TIMEOUT_MS),
     });
     return this.json<{ id: string }>(res);
   }
@@ -155,6 +167,9 @@ export class DaemonClient {
         "Content-Type": "application/octet-stream",
       },
       body: bytes,
+      // A tor/i2p seed stands up its network session before responding; bound
+      // the wait generously rather than hang forever or abort mid-setup.
+      signal: AbortSignal.timeout(SESSION_SETUP_TIMEOUT_MS),
     });
     return this.json<{ id: string }>(res);
   }

--- a/desktop/src/components/atoms.tsx
+++ b/desktop/src/components/atoms.tsx
@@ -7,7 +7,7 @@ const ROUTE_META: Record<Route, { label: string; cls: string; icon: string }> = 
   direct: { label: "clearnet", cls: "rt-clearnet", icon: "globe" },
   proxy: { label: "proxied", cls: "rt-proxy", icon: "shield" },
   tor: { label: "tor", cls: "rt-tor", icon: "onion" },
-  i2p: { label: "i2p", cls: "rt-tor", icon: "onion" },
+  i2p: { label: "i2p", cls: "rt-i2p", icon: "shield" },
 };
 
 export function RouteBadge({

--- a/desktop/src/modals/AddModal.tsx
+++ b/desktop/src/modals/AddModal.tsx
@@ -18,17 +18,28 @@ const HINT: Record<Tab, string> = {
   url: "carl fetches the .torrent over your selected route.",
 };
 
+// Hints per anonymized download route. Downloads never run clearnet — the
+// choice is which anonymity network dials the peers.
+const ROUTE_HINT: Record<"tor" | "i2p", string> = {
+  tor: "Downloads are routed over Tor — your IP is never exposed. Trackers & DHT off · peers via Nostr. Requires a running Tor SOCKS proxy (127.0.0.1:9050).",
+  i2p: "Peers are dialed as .b32.i2p destinations over native I2P (SAM v3) — your IP is never exposed. Trackers & DHT off · peers via Nostr. Requires a running I2P router with SAM (127.0.0.1:7656).",
+};
+
 export function AddModal({ onClose }: { onClose: () => void }) {
   const { addTransfer } = useCarl();
   const [tab, setTab] = useState<Tab>("magnet");
   const [val, setVal] = useState("");
   const [nostr, setNostr] = useState(true);
-  // Downloads are Tor-only — privacy by default; the IP is never exposed.
-  const route: Route = "tor";
+  // Downloads are anonymized-only — Tor by default, native I2P as the
+  // alternative. Direct/proxy are deliberately not offered for downloads.
+  const [route, setRoute] = useState<Route>("tor");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const canAdd = val.trim().length > 0 && !busy;
+  // The daemon has no I2P-tunneled HTTP fetch yet (P3, #35): an HTTP .torrent
+  // source on the i2p route is rejected (fail-closed), so block it up front.
+  const urlUnsupported = tab === "url" && route === "i2p";
+  const canAdd = val.trim().length > 0 && !busy && !urlUnsupported;
 
   async function submit() {
     if (!canAdd) return;
@@ -90,16 +101,31 @@ export function AddModal({ onClose }: { onClose: () => void }) {
             <div className="field">
               <label className="field-label">Route</label>
               <div className="route-select route-select-lg">
-                <button className="rsl-btn active rt-tor" disabled>
+                <button
+                  className={"rsl-btn" + (route === "tor" ? " active rt-tor" : "")}
+                  onClick={() => setRoute("tor")}
+                >
                   <OnionIcon size={12} />
                   Tor
                 </button>
+                <button
+                  className={"rsl-btn" + (route === "i2p" ? " active rt-i2p" : "")}
+                  onClick={() => setRoute("i2p")}
+                >
+                  <Icon name="shield" size={12} />
+                  I2P
+                </button>
               </div>
               <span className="field-hint">
-                Downloads are routed over Tor only — your IP is never exposed.
-                Trackers &amp; DHT off · peers via Nostr. Requires a running Tor
-                SOCKS proxy (127.0.0.1:9050).
+                {ROUTE_HINT[route as "tor" | "i2p"]}
               </span>
+              {urlUnsupported && (
+                <span className="field-hint" style={{ color: "var(--warn)" }}>
+                  HTTP .torrent sources aren't supported on I2P yet (no
+                  I2P-tunneled fetch — it would leak). Use a magnet/file, or
+                  Tor for URL sources.
+                </span>
+              )}
             </div>
 
             <label

--- a/desktop/src/screens/Discover.tsx
+++ b/desktop/src/screens/Discover.tsx
@@ -120,7 +120,7 @@ function DiscoverCard({
 }
 
 export function DiscoverScreen() {
-  const { search, addTransfer } = useCarl();
+  const { search, addTransfer, state } = useCarl();
   const [q, setQ] = useState("");
   const [added, setAdded] = useState<Record<string, boolean>>({});
   const [all, setAll] = useState<DiscoverResult[]>([]);
@@ -163,11 +163,13 @@ export function DiscoverScreen() {
 
   async function download(d: DiscoverResult) {
     try {
-      // Downloads are Tor-only (same guarantee as the manual Add flow) so a
-      // download never exposes your IP to peers.
+      // Downloads are anonymized-only (same guarantee as the manual Add flow)
+      // so a download never exposes your IP to peers: I2P when it's the global
+      // route, Tor otherwise (incl. direct/proxy — one-click stays private).
+      const route = state.settings.route === "i2p" ? "i2p" : "tor";
       await addTransfer(
         `magnet:?xt=urn:btih:${d.hash}&dn=${encodeURIComponent(d.title)}`,
-        "tor",
+        route,
         true,
       );
       setAdded((s) => ({ ...s, [d.id]: true }));

--- a/desktop/src/screens/Seeding.tsx
+++ b/desktop/src/screens/Seeding.tsx
@@ -305,9 +305,10 @@ export function SeedingScreen() {
             </div>
             <div className="empty-title">Nothing seeding yet</div>
             <div className="empty-sub">
-              Completed downloads keep seeding and show up here. Tor-routed seeds
-              surface their <span className="mono">.onion</span> address with a
-              "no IP leaked" guarantee.
+              Completed downloads keep seeding and show up here. Tor and I2P
+              seeds surface their <span className="mono">.onion</span> /{" "}
+              <span className="mono">.b32.i2p</span> address with a "no IP leaked"
+              guarantee.
             </div>
           </div>
         ) : (

--- a/desktop/src/screens/Seeding.tsx
+++ b/desktop/src/screens/Seeding.tsx
@@ -13,25 +13,42 @@ const VIS_LABEL: Record<Route, string> = {
   i2p: "I2P destination",
 };
 
-function OnionCallout({ onion, relays }: { onion: string; relays: number }) {
+// Surfaces the reachable hidden address of an anonymized seed — a `.onion` for
+// a Tor hidden service, a `.b32.i2p` destination for an I2P seed. Both expose
+// no clearnet IP and are published over Nostr for discovery.
+function HiddenAddrCallout({
+  kind,
+  addr,
+  relays,
+}: {
+  kind: "tor" | "i2p";
+  addr: string;
+  relays: number;
+}) {
+  const isI2p = kind === "i2p";
   return (
     <div className="onion-callout">
       <div className="oc-head">
         <span className="oc-icon">
-          <OnionIcon size={18} />
+          {isI2p ? <Icon name="shield" size={18} /> : <OnionIcon size={18} />}
         </span>
         <div>
-          <div className="oc-title">Seeding as a Tor hidden service</div>
+          <div className="oc-title">
+            {isI2p
+              ? "Seeding as an I2P destination"
+              : "Seeding as a Tor hidden service"}
+          </div>
           <div className="oc-sub">
-            Peers reach you over this .onion address. Share it via Discover or
-            directly.
+            {isI2p
+              ? "Peers reach you over this .b32.i2p destination (native SAM v3). Share it via Discover or directly."
+              : "Peers reach you over this .onion address. Share it via Discover or directly."}
           </div>
         </div>
         <span className="oc-live">
           <span className="oc-live-dot" /> online
         </span>
       </div>
-      <CopyField value={onion} full />
+      <CopyField value={addr} full />
       <div className="oc-foot">
         <span className="oc-published">
           <span className="oc-pub-dot" /> published to{" "}
@@ -178,7 +195,7 @@ function SeedFlow({ onClose }: { onClose: () => void }) {
 
               <div className="field-label">Visibility</div>
               <div className="vis-options">
-                {(["direct", "proxy", "tor"] as const).map((id) => (
+                {(["direct", "proxy", "tor", "i2p"] as const).map((id) => (
                   <button
                     key={id}
                     className={"vis-opt" + (vis === id ? " active" : "")}
@@ -245,7 +262,11 @@ export function SeedingScreen() {
   const [flow, setFlow] = useState(false);
   const [createFlow, setCreateFlow] = useState(false);
   const upTotal = seeds.reduce((a, s) => a + s.up, 0);
-  const torSeed = seeds.find((s) => s.visibility === "tor" && s.onion);
+  // The first anonymized seed with a published address gets the hero callout
+  // (tor `.onion` or i2p `.b32.i2p`); both carry their address in `onion`.
+  const hiddenSeed = seeds.find(
+    (s) => (s.visibility === "tor" || s.visibility === "i2p") && s.onion,
+  );
 
   return (
     <div className="screen">
@@ -270,8 +291,12 @@ export function SeedingScreen() {
       </div>
 
       <div className="content">
-        {torSeed && torSeed.onion && (
-          <OnionCallout onion={torSeed.onion} relays={torSeed.relays} />
+        {hiddenSeed && hiddenSeed.onion && (
+          <HiddenAddrCallout
+            kind={hiddenSeed.visibility === "i2p" ? "i2p" : "tor"}
+            addr={hiddenSeed.onion}
+            relays={hiddenSeed.relays}
+          />
         )}
         {seeds.length === 0 ? (
           <div className="empty">

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -164,19 +164,34 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
     );
   }
 
-  // I2P doesn't use the SOCKS proxy (the daemon talks to the SAM bridge per
-  // transfer), so the SOCKS health probe is reported "disabled" — show the
-  // route's own contract instead of a bogus proxy status.
+  // I2P uses the SAM bridge, not SOCKS — the daemon probes it and reports its
+  // health through the same `proxy` field, so show live SAM status (the parity
+  // of the Tor SOCKS leak check).
   if (route === "i2p") {
+    const sam = proxy.endpoint || "127.0.0.1:7656";
+    const I2P_TITLE: Record<ProxyHealth["state"], string> = {
+      ok: "SAM bridge reachable — I2P transport up",
+      checking: "Checking SAM bridge…",
+      not_running: "SAM bridge not running",
+      timeout: "SAM bridge connection timed out",
+      rejected: "Not a SAM bridge",
+      disabled: "",
+    };
+    const I2P_DETAIL: Record<ProxyHealth["state"], string> = {
+      ok: `peers dialed via ${sam} · transport fail-closed · Nostr discovery is clearnet`,
+      checking: `probing ${sam}…`,
+      not_running: `${sam} refused the connection — is your I2P router running with SAM enabled?`,
+      timeout: `${sam} timed out — check the address and that SAM is enabled`,
+      rejected: `${sam} did not speak SAM${proxy.detail ? ` · ${proxy.detail}` : ""} — is this the SAM port?`,
+      disabled: "",
+    };
+    const ok = proxy.state === "ok";
     return (
-      <div className="leak-check lc-safe">
+      <div className={"leak-check " + (ok ? "lc-safe" : "lc-warn")}>
         <span className="lc-dot" />
         <div className="lc-body">
-          <div className="lc-title">I2P route — peers dialed via SAM</div>
-          <div className="lc-detail mono">
-            transport fail-closed (no clearnet peers/trackers/DHT) · SAM bridge
-            127.0.0.1:7656 · Nostr relay discovery is clearnet
-          </div>
+          <div className="lc-title">{I2P_TITLE[proxy.state]}</div>
+          <div className="lc-detail mono">{I2P_DETAIL[proxy.state]}</div>
         </div>
       </div>
     );

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -164,6 +164,24 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
     );
   }
 
+  // I2P doesn't use the SOCKS proxy (the daemon talks to the SAM bridge per
+  // transfer), so the SOCKS health probe is reported "disabled" — show the
+  // route's own contract instead of a bogus proxy status.
+  if (route === "i2p") {
+    return (
+      <div className="leak-check lc-safe">
+        <span className="lc-dot" />
+        <div className="lc-body">
+          <div className="lc-title">I2P route — peers dialed via SAM</div>
+          <div className="lc-detail mono">
+            transport fail-closed (no clearnet peers/trackers/DHT) · SAM bridge
+            127.0.0.1:7656 · Nostr relay discovery is clearnet
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   const ep = proxy.endpoint || "the proxy";
   const TITLE: Record<ProxyHealth["state"], string> = {
     ok: "Proxy reachable — leak check passed",
@@ -193,16 +211,16 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
   );
 }
 
-// Routes the GUI can select as its global anonymity setting. I2P is deliberately
-// absent: desktop downloads are Tor-only (see AddModal/Discover) and i2p seeding
-// is rejected by the daemon, so selecting i2p here would have no usable effect.
-// I2P is a daemon/CLI route (`carl daemon --route i2p`, see docs/i2p.md); the
-// Route type, ROUTE_META, badges and VIS_LABEL still carry i2p so a transfer
-// surfaced by a CLI-run daemon renders correctly.
+// Routes the GUI can select as its global anonymity setting. Selecting I2P
+// makes Discover one-click downloads dial peers as `.b32.i2p` destinations
+// over the SAM bridge (default 127.0.0.1:7656); the Add modal also offers
+// Tor/I2P per transfer. I2P seeding is not supported yet (rejected by the
+// daemon — #35 P2), so tor seeds remain the private seeding path.
 const ROUTES: [Route, string, string, string][] = [
   ["direct", "Direct", "Connect straight to peers. Fastest, no privacy.", "globe"],
   ["proxy", "SOCKS5 proxy", "Tunnel all traffic through a SOCKS5 proxy.", "shield"],
   ["tor", "Tor", "Route through the Tor network. Seed as a hidden service.", "onion"],
+  ["i2p", "I2P", "Native I2P (SAM v3). Downloads dial .b32.i2p peers; seeding not yet supported.", "shield"],
 ];
 
 export function SettingsScreen() {

--- a/desktop/src/screens/Settings.tsx
+++ b/desktop/src/screens/Settings.tsx
@@ -229,13 +229,13 @@ function LeakCheck({ route, proxy }: { route: Route; proxy: ProxyHealth }) {
 // Routes the GUI can select as its global anonymity setting. Selecting I2P
 // makes Discover one-click downloads dial peers as `.b32.i2p` destinations
 // over the SAM bridge (default 127.0.0.1:7656); the Add modal also offers
-// Tor/I2P per transfer. I2P seeding is not supported yet (rejected by the
-// daemon — #35 P2), so tor seeds remain the private seeding path.
+// Tor/I2P per transfer, and "Seed a file" can seed over I2P (inbound via a
+// SAM STREAM FORWARD to a stable `.b32.i2p`).
 const ROUTES: [Route, string, string, string][] = [
   ["direct", "Direct", "Connect straight to peers. Fastest, no privacy.", "globe"],
   ["proxy", "SOCKS5 proxy", "Tunnel all traffic through a SOCKS5 proxy.", "shield"],
   ["tor", "Tor", "Route through the Tor network. Seed as a hidden service.", "onion"],
-  ["i2p", "I2P", "Native I2P (SAM v3). Downloads dial .b32.i2p peers; seeding not yet supported.", "shield"],
+  ["i2p", "I2P", "Native I2P (SAM v3). Download and seed over .b32.i2p destinations.", "shield"],
 ];
 
 export function SettingsScreen() {

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -3,7 +3,7 @@
   --border:#262b36; --border-soft:#1c212b;
   --fg:#e8eaf0; --fg-dim:#9aa1b1; --fg-faint:#666e7e;
   --accent:#8b7cf6; --accent-soft:rgba(139,124,246,0.14); --accent-border:rgba(139,124,246,0.4); --accent-dim:#a99ff8;
-  --clearnet:#d6a44e; --proxy:#5aa6db; --tor:#46c08a;
+  --clearnet:#d6a44e; --proxy:#5aa6db; --tor:#46c08a; --i2p:#b08ff0;
   --ok:#46c08a; --info:#5aa6db; --warn:#d6a44e; --danger:#d9726b;
   --dl:#5aa6db; --ul:#46c08a;
   --serif:"Newsreader",Georgia,serif;
@@ -111,6 +111,7 @@ input,textarea{ font-family:inherit; }
 .rt-clearnet{ color:var(--clearnet); background:rgba(214,164,78,0.1); border-color:rgba(214,164,78,0.25); }
 .rt-proxy{ color:var(--proxy); background:rgba(90,166,219,0.1); border-color:rgba(90,166,219,0.25); }
 .rt-tor{ color:var(--tor); background:rgba(70,192,138,0.1); border-color:rgba(70,192,138,0.28); }
+.rt-i2p{ color:var(--i2p); background:rgba(176,143,240,0.1); border-color:rgba(176,143,240,0.28); }
 html[data-show-routes="0"] .trow-line1 .route-badge span:last-child{ display:none; }
 html[data-show-routes="0"] .trow-line1 .route-badge{ padding:3px; }
 
@@ -239,6 +240,7 @@ html[data-density="compact"] .trow-stat{ width:74px; flex-basis:74px; }
 .rsl-btn:hover{ color:var(--fg); }
 .rsl-btn.active{ background:var(--bg-3); color:var(--fg); }
 .rsl-btn.active.rt-tor{ color:var(--tor); }
+.rsl-btn.active.rt-i2p{ color:var(--i2p); }
 .rsl-btn.active.rt-proxy{ color:var(--proxy); }
 .rsl-btn.active.rt-direct{ color:var(--clearnet); }
 .route-select-lg .rsl-btn{ padding:7px 14px; font-size:12.5px; }
@@ -412,6 +414,9 @@ html[data-density="compact"] .trow-stat{ width:74px; flex-basis:74px; }
 .route-radio.active.rt-tor .rr-ic{ color:var(--tor); }
 .route-radio.active.rt-tor .rr-radio{ border-color:var(--tor); }
 .route-radio.active.rt-tor .rr-radio::after{ background:var(--tor); }
+.route-radio.active.rt-i2p .rr-ic{ color:var(--i2p); }
+.route-radio.active.rt-i2p .rr-radio{ border-color:var(--i2p); }
+.route-radio.active.rt-i2p .rr-radio::after{ background:var(--i2p); }
 .rr-txt{ display:flex; flex-direction:column; gap:1px; }
 .rr-label{ font-size:13px; font-weight:500; }
 .rr-desc{ font-size:11.5px; color:var(--fg-dim); }

--- a/docs/i2p.md
+++ b/docs/i2p.md
@@ -9,10 +9,13 @@ Peers are addressed by **`.b32.i2p` destinations** (not IP:port). carl speaks
 **SAM v3** to a local I2P router and dials each peer as a destination, the same
 way the Tor path dials `.onion` hostnames.
 
-> **Status (P1):** this is the first slice — **outbound** connections (leeching)
-> over native SAM. Seeding (inbound), I2P trackers, and the I2P DHT are tracked
-> follow-ups (see issue #35). Today, peers are discovered via carl's Nostr
-> peer-announce layer (a `.b32.i2p` destination is carried like a `.onion` host).
+> **Status (P1 + P2):** carl can both **leech** (outbound) and **seed**
+> (inbound) over native SAM. A seed opens a SAM `STREAM FORWARD` to a loopback
+> listener and is reachable at a stable `.b32.i2p` destination (its private key
+> is persisted under `<config>/i2p-seeds/`, so the address survives restarts).
+> I2P trackers and the I2P DHT remain tracked follow-ups (see issue #35); peers
+> are discovered via carl's Nostr peer-announce layer (a `.b32.i2p` destination
+> is carried like a `.onion` host).
 
 ## Prerequisites: a running I2P router with SAM
 
@@ -62,10 +65,19 @@ carl daemon --route i2p --i2p-sam 127.0.0.1:7656
 - `--i2p-sam host:port` points at your router's SAM bridge
   (default `127.0.0.1:7656`; you may also write `sam://127.0.0.1:7656`).
 
-The I2P route is **daemon/CLI-only** for now. The desktop app keeps downloads on
-Tor (its route picker omits I2P, and it has no SAM-bridge setting), so use
-`carl daemon --route i2p --i2p-sam …` as above; a desktop I2P workflow is a
-follow-up (see issue #35).
+### Seeding over I2P
+
+Seeding works on the i2p route too: carl opens a SAM `STREAM FORWARD` so the
+router delivers every inbound peer stream to a loopback listener (the public
+face is the `.b32.i2p` destination, never your IP). The destination's private
+key is persisted under `<config>/i2p-seeds/<info-hash>.dest` (0600), so the seed
+keeps the **same `.b32.i2p` address across restarts** and previously-published
+peer-announces stay valid. With Nostr enabled, carl publishes the `.b32.i2p`
+destination as a kind-30078 peer-announce so leechers can find and dial it.
+
+In the desktop app, pick **I2P** in the "Seed a file" visibility selector; the
+seed's `.b32.i2p` address is surfaced once the SAM session is up. On the daemon
+the seed is created via `POST /api/seeds` with `X-Carl-Route: i2p`.
 
 When the I2P route is active, the **BitTorrent transport fails closed** the same
 way the proxy/Tor routes do: clearnet DHT, UDP/HTTP trackers, web seeds, and the
@@ -85,8 +97,14 @@ discovery on the `tor`/`proxy` route.
    `HELLO` + `STREAM CONNECT` to the peer's `.b32.i2p` destination; on
    `RESULT=OK` the socket becomes a transparent bidirectional stream and the
    normal BitTorrent handshake runs over it.
+3. **Seed (inbound)** — carl registers `STREAM FORWARD ID=… PORT=… SILENT=true`
+   on a side socket; the router then forwards every inbound stream to that
+   loopback port as a raw connection (no SAM header), which the session's normal
+   seed listener accepts. The seed's `.b32.i2p` address is
+   `base32(SHA-256(destination))`, derived locally and persisted so it's stable.
 
-See `src/i2p_sam.zig` for the implementation.
+See `src/i2p_sam.zig` (transport) and `src/i2p_seed.zig` (destination
+persistence) for the implementation.
 
 ## Tor vs I2P (which to use)
 
@@ -96,7 +114,7 @@ See `src/i2p_sam.zig` for the implementation.
 | BitTorrent fit | discouraged (slow, strains the network) | purpose-built |
 | Addressing | `.onion` (v3) | `.b32.i2p` destination |
 | carl transport | SOCKS5h proxy (`--socks`) | native SAM v3 (`--i2p-sam`) |
-| Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | follow-up (P2) |
+| Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | SAM `STREAM FORWARD` + stable `.b32.i2p` |
 
 Either way, carl's **discovery layer is the same** — signed NIP-35 / kind-30078
 events over Nostr — so the privacy network you pick is independent of how you
@@ -107,20 +125,19 @@ find torrents.
 CI cannot run a live I2P router, so swarm interop is verified manually:
 
 1. Start a router with SAM enabled on two hosts (or two routers locally).
-2. On host A, seed a torrent over I2P (P2) — or use any existing `.b32.i2p`
-   peer — and publish/obtain its destination.
+2. On host A, seed a torrent over I2P: create the seed on the `i2p` route
+   (desktop "Seed a file" → I2P, or `POST /api/seeds` with `X-Carl-Route: i2p`),
+   with Nostr enabled so its `.b32.i2p` destination is published. The daemon
+   logs `i2p seed: forwarding <addr>.b32.i2p -> 127.0.0.1:<port>`.
 3. On host B: `carl daemon --route i2p`, add the magnet, and confirm carl dials
-   the `.b32.i2p` peer and the transfer makes progress.
+   host A's `.b32.i2p` destination and the transfer makes progress.
 
 If the SAM bridge is unreachable, adding an I2P transfer fails fast with a clear
 error (the daemon stays up); check that your router is running and the
 `--i2p-sam` address matches its SAM port.
 
-## Known limitations (P1)
+## Known limitations
 
-- **Outbound/leech only.** Seeding over I2P (inbound `STREAM FORWARD` + a stable,
-  persisted destination) is a follow-up; today the i2p route downloads, dialing
-  peers discovered via Nostr.
 - **Nostr relays are not yet routed over I2P.** On the i2p route, relay traffic
   is clearnet (the same as the transfer side), so a relay sees your IP and the
   info-hashes you query. Routing Nostr over I2P is a follow-up. If you need relay

--- a/docs/i2p.md
+++ b/docs/i2p.md
@@ -77,7 +77,21 @@ destination as a kind-30078 peer-announce so leechers can find and dial it.
 
 In the desktop app, pick **I2P** in the "Seed a file" visibility selector; the
 seed's `.b32.i2p` address is surfaced once the SAM session is up. On the daemon
-the seed is created via `POST /api/seeds` with `X-Carl-Route: i2p`.
+the seed is created via `POST /api/seeds` with `X-Carl-Route: i2p`. From the CLI,
+seed with `--i2p-seed` (the I2P analog of `--tor-seed`):
+
+```sh
+carl seed file.torrent ./data --i2p-seed --nostr --i2p-sam 127.0.0.1:7656
+```
+
+### Transport health
+
+Like the Tor route (which reports SOCKS-proxy health), the i2p route reports
+**SAM-bridge health**: the daemon probes the bridge with a `HELLO` handshake and
+surfaces `ok` / `not_running` / `timeout` / `rejected` (not a SAM bridge) in the
+`proxy` field of the state API, so the desktop Settings screen shows live I2P
+transport status instead of a guess. A missing router shows "SAM bridge not
+running" rather than silently failing.
 
 When the I2P route is active, the **BitTorrent transport fails closed** the same
 way the proxy/Tor routes do: clearnet DHT, UDP/HTTP trackers, web seeds, and the
@@ -115,6 +129,13 @@ persistence) for the implementation.
 | Addressing | `.onion` (v3) | `.b32.i2p` destination |
 | carl transport | SOCKS5h proxy (`--socks`) | native SAM v3 (`--i2p-sam`) |
 | Inbound/seeding | Tor hidden service (see tor-hidden-service.md) | SAM `STREAM FORWARD` + stable `.b32.i2p` |
+| Downloads (GUI/CLI/daemon) | yes | yes |
+| Seeding (GUI/CLI/daemon) | yes | yes |
+| Transport health in the UI | SOCKS probe | SAM `HELLO` probe |
+| Nostr discovery over the network | yes (via SOCKS) | not yet (relays are clearnet) |
+
+The feature surface is at parity except **Nostr discovery is not yet routed over
+I2P** (relay traffic on the i2p route is clearnet; see *Known limitations*).
 
 Either way, carl's **discovery layer is the same** — signed NIP-35 / kind-30078
 events over Nostr — so the privacy network you pick is independent of how you

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -481,7 +481,7 @@ const Conn = struct {
 
     /// POST /api/seeds — body is the raw file content (so a browser drag-drop or
     /// the Tauri shell can upload directly). Headers: X-Carl-Filename (required),
-    /// X-Carl-Route (direct|proxy|tor, default tor), X-Carl-Nostr (true|false).
+    /// X-Carl-Route (direct|proxy|tor|i2p, default tor), X-Carl-Nostr (true|false).
     /// Writes the file into the download dir, creates a torrent in-process, and
     /// starts seeding it; returns { id }.
     fn createSeed(self: *Conn, req: *const http.Request, body: []const u8) !void {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -20,6 +20,7 @@ const metainfo = @import("metainfo.zig");
 const api = @import("api.zig");
 const nostr_config = @import("nostr_config.zig");
 const proxy_mod = @import("proxy.zig");
+const i2p_sam = @import("i2p_sam.zig");
 const relay_mod = @import("relay.zig");
 const nip35 = @import("nip35.zig");
 const nostr_mod = @import("nostr.zig");
@@ -148,18 +149,24 @@ pub const Daemon = struct {
         return out;
     }
 
-    /// Snapshot proxy health for the API. `endpoint` is duped into `arena`.
+    /// Snapshot transport health for the API. `endpoint` is duped into `arena`.
     /// Maps the direct route to "disabled" and the pre-first-probe window to
-    /// "checking"; otherwise reflects the last `classifySocks5` result.
+    /// "checking"; otherwise reflects the last probe. The same `proxy` health
+    /// shape carries both the SOCKS health (proxy/tor) and the SAM-bridge health
+    /// (i2p), so the GUI shows live transport status on every anonymized route.
     fn proxyHealthSnapshot(self: *Daemon, arena: Allocator) !api.ProxyHealth {
-        // Mask any SOCKS auth credentials before exposing the endpoint.
-        const raw = self.manager.cfg.socks;
-        const rbuf = try arena.alloc(u8, raw.len + 4);
-        const endpoint = try arena.dupe(u8, proxy_mod.redactUrl(raw, rbuf));
-        // direct doesn't use the SOCKS endpoint and neither does i2p (SAM
-        // bridge): reporting SOCKS state on those routes would show a bogus
-        // proxy error in the GUI.
-        if (!self.manager.cfg.route.usesSocks())
+        const route = self.manager.cfg.route;
+        // The i2p route's endpoint is the SAM bridge, not the SOCKS URL.
+        const endpoint = if (route == .i2p)
+            try arena.dupe(u8, self.manager.cfg.i2p_sam)
+        else blk: {
+            // Mask any SOCKS auth credentials before exposing the endpoint.
+            const raw = self.manager.cfg.socks;
+            const rbuf = try arena.alloc(u8, raw.len + 4);
+            break :blk try arena.dupe(u8, proxy_mod.redactUrl(raw, rbuf));
+        };
+        // Only the direct route has no transport to probe.
+        if (route == .direct)
             return .{ .state = "disabled", .endpoint = endpoint };
 
         self.health_mutex.lock();
@@ -172,25 +179,46 @@ pub const Daemon = struct {
 
         var detail: []const u8 = "";
         if (st == .rejected) {
-            if (reply) |b| {
-                detail = std.fmt.allocPrint(arena, "SOCKS5 replied 0x{x:0>2}", .{b}) catch "";
-            }
+            detail = if (route == .i2p)
+                "not a SAM bridge (no HELLO REPLY)"
+            else if (reply) |b|
+                std.fmt.allocPrint(arena, "SOCKS5 replied 0x{x:0>2}", .{b}) catch ""
+            else
+                "";
         }
         return .{ .state = st.jsonName(), .endpoint = endpoint, .detail = detail };
     }
 
-    /// Probe the SOCKS proxy once (proxy/tor route only) and cache the result.
-    /// Never opens an upstream connection (greeting only) — see classifySocks5.
+    /// Probe the active transport once and cache the result: the SOCKS proxy on
+    /// the proxy/tor route, or the SAM bridge on the i2p route. Greeting only —
+    /// never opens an upstream connection or creates a session.
     fn probeProxy(self: *Daemon) void {
-        if (!self.manager.cfg.route.usesSocks()) {
+        const route = self.manager.cfg.route;
+        if (route == .direct) {
             // Don't fabricate an "ok": mark unprobed so that if the route later
-            // switches to proxy/tor, the snapshot shows an honest "checking"
-            // until a real probe lands (rather than a stale/false "ok"). The
-            // direct and i2p routes are reported as "disabled" by the snapshot
-            // regardless (i2p talks to the SAM bridge, not the SOCKS endpoint).
+            // switches to an anonymized one, the snapshot shows an honest
+            // "checking" until a real probe lands. The direct route is reported
+            // as "disabled" by the snapshot regardless.
             self.health_mutex.lock();
             self.proxy_probed = false;
             self.health_mutex.unlock();
+            return;
+        }
+        if (route == .i2p) {
+            const bridge = i2p_sam.parseUrl(self.manager.cfg.i2p_sam) catch {
+                // Malformed SAM address is a config error; surface it as
+                // "rejected" so the route doesn't silently look healthy.
+                self.publishProxy(.rejected, null);
+                return;
+            };
+            // Map SAM health onto the shared ProxyState shape.
+            const state: proxy_mod.ProxyState = switch (i2p_sam.classifyBridge(self.allocator, bridge, 5)) {
+                .ok => .ok,
+                .not_running => .not_running,
+                .timeout => .timeout,
+                .handshake_failed => .rejected,
+            };
+            self.publishProxy(state, null);
             return;
         }
         const proxy = proxy_mod.parseUrl(self.manager.cfg.socks) catch {

--- a/src/i2p_sam.zig
+++ b/src/i2p_sam.zig
@@ -15,8 +15,9 @@
 //!      for the BitTorrent handshake — the same "connected stream" contract as
 //!      `proxy.zig`.
 //!
-//! Inbound (`STREAM ACCEPT`/`FORWARD` for seeding), I2P trackers, and I2P DHT
-//! are follow-up phases; this module covers session setup + outbound dial.
+//! This module covers session setup, outbound dial (`STREAM CONNECT`), inbound
+//! seeding (`STREAM FORWARD`), bridge health probing, and `.b32.i2p` address
+//! derivation. I2P trackers and the I2P DHT are follow-up phases.
 //!
 //! Requires a running I2P router (i2pd or Java I2P) with the SAM bridge enabled.
 //! See docs/i2p.md. The handshake is synchronous and blocking (bounded by

--- a/src/i2p_sam.zig
+++ b/src/i2p_sam.zig
@@ -181,6 +181,82 @@ fn hello(stream: std.net.Stream) SamError!Version {
     return parseVersion(samField(line, "VERSION") orelse "3.0");
 }
 
+// --- bridge health probe -----------------------------------------------------
+
+/// Health of the SAM bridge, the I2P analog of `proxy.ProxyState`. Lets the
+/// daemon/GUI say *why* the i2p route isn't working, the same way the Tor route
+/// reports SOCKS health, instead of failing silently.
+pub const Health = enum {
+    /// Reachable and speaks SAM v3 (`HELLO REPLY RESULT=OK`).
+    ok,
+    /// Nothing is listening on the SAM port (connection refused) — the I2P
+    /// router isn't running, or the SAM bridge is disabled.
+    not_running,
+    /// The connect or the `HELLO` handshake timed out.
+    timeout,
+    /// Reachable but did not speak SAM (no `HELLO REPLY RESULT=OK`) — e.g. the
+    /// port points at something that isn't a SAM bridge.
+    handshake_failed,
+
+    pub fn jsonName(self: Health) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// Probe the SAM bridge once: non-blocking connect (so a filtered/dead host
+/// yields a real timeout and a refused port is distinguished from a timeout —
+/// `SO_SNDTIMEO` does not bound `connect()` on macOS), then a `HELLO VERSION`
+/// handshake. Never creates a session or leaks; greeting only. Mirrors
+/// `proxy.classifySocks5`.
+pub fn classifyBridge(allocator: Allocator, bridge: Bridge, timeout_s: u32) Health {
+    const list = std.net.getAddressList(allocator, bridge.host, bridge.port) catch
+        return .not_running;
+    defer list.deinit();
+    var target: ?std.net.Address = null;
+    for (list.addrs) |a| {
+        if (a.any.family == posix.AF.INET) {
+            target = a;
+            break;
+        }
+    }
+    const addr = target orelse return .not_running;
+
+    const timeout_ms: i32 = if (timeout_s > 600) 600_000 else @intCast(timeout_s * 1000);
+    const sock = posix.socket(
+        posix.AF.INET,
+        posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
+        posix.IPPROTO.TCP,
+    ) catch return .timeout;
+    defer posix.close(sock);
+
+    const flags = posix.fcntl(sock, posix.F.GETFL, 0) catch return .timeout;
+    var o: posix.O = @bitCast(@as(u32, @truncate(flags)));
+    o.NONBLOCK = true;
+    _ = posix.fcntl(sock, posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+    posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        error.WouldBlock => {
+            var pfd = [_]posix.pollfd{.{ .fd = sock, .events = posix.POLL.OUT, .revents = 0 }};
+            const ready = posix.poll(&pfd, timeout_ms) catch return .timeout;
+            if (ready == 0) return .timeout;
+            posix.getsockoptError(sock) catch |e| return if (e == error.ConnectionRefused) .not_running else .timeout;
+        },
+        error.ConnectionRefused => return .not_running,
+        else => return .timeout,
+    };
+
+    // Connected. Back to blocking with bounded reads/writes for the handshake.
+    o.NONBLOCK = false;
+    _ = posix.fcntl(sock, posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+    const tv = posix.timeval{ .sec = @intCast(timeout_s), .usec = 0 };
+    posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch {};
+    posix.setsockopt(sock, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
+
+    const stream = std.net.Stream{ .handle = sock };
+    _ = hello(stream) catch return .handshake_failed;
+    return .ok;
+}
+
 // --- destination address derivation -----------------------------------------
 
 /// I2P's base64 alphabet: standard base64 with `-` and `~` replacing `+`/`/`.
@@ -654,6 +730,33 @@ test "i2p_sam: TO_PORT omitted on a pre-3.2 bridge (best-effort default port)" {
     // TO_PORT omitted.
     var peer = try sess.connect("examplepeer.b32.i2p", 6881);
     peer.close();
+}
+
+test "i2p_sam: classifyBridge reports ok against a SAM bridge, not_running on a dead port" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    // Live mock bridge → ok (it answers HELLO with RESULT=OK).
+    try testing.expectEqual(Health.ok, classifyBridge(allocator, .{ .host = "127.0.0.1", .port = port }, 3));
+
+    // A port with nothing listening → not_running (connection refused). Bind and
+    // immediately release a port to get one that's almost certainly free.
+    const probe_port = blk: {
+        var s = try addr.listen(.{ .reuse_address = true });
+        const p = s.listen_address.getPort();
+        s.deinit();
+        break :blk p;
+    };
+    try testing.expectEqual(Health.not_running, classifyBridge(allocator, .{ .host = "127.0.0.1", .port = probe_port }, 2));
 }
 
 test "i2p_sam: STREAM FORWARD arms inbound and is idempotent-guarded" {

--- a/src/i2p_sam.zig
+++ b/src/i2p_sam.zig
@@ -181,6 +181,73 @@ fn hello(stream: std.net.Stream) SamError!Version {
     return parseVersion(samField(line, "VERSION") orelse "3.0");
 }
 
+// --- destination address derivation -----------------------------------------
+
+/// I2P's base64 alphabet: standard base64 with `-` and `~` replacing `+`/`/`.
+const i2p_b64 = std.base64.Base64Decoder.init(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+    '=',
+);
+
+/// RFC 4648 base32 alphabet, lowercase — the form used in `.b32.i2p` hostnames.
+const b32_alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+
+/// Encode `in` as unpadded lowercase base32 into `out`. Returns the slice
+/// written. `out` must hold ceil(in.len * 8 / 5) bytes (52 for a SHA-256).
+fn base32Encode(out: []u8, in: []const u8) []const u8 {
+    var acc: u32 = 0;
+    var bits: u5 = 0;
+    var n: usize = 0;
+    for (in) |b| {
+        acc = (acc << 8) | b;
+        bits += 8;
+        while (bits >= 5) {
+            bits -= 5;
+            out[n] = b32_alphabet[@as(u5, @truncate(acc >> bits))];
+            n += 1;
+        }
+    }
+    if (bits > 0) {
+        out[n] = b32_alphabet[@as(u5, @truncate(acc << (5 - bits)))];
+        n += 1;
+    }
+    return out[0..n];
+}
+
+/// Length of a `.b32.i2p` hostname: 52 base32 chars + the suffix.
+pub const b32_host_len: usize = 52 + ".b32.i2p".len;
+
+/// Derive the public `.b32.i2p` hostname from a destination in I2P base64 —
+/// either the full private key a SESSION CREATE returns (the public
+/// destination is its prefix) or a bare public destination. The address is
+/// `base32(SHA-256(destination bytes))`; the destination length is
+/// 387 + cert-length (384 key bytes, then a 3-byte certificate header whose
+/// last two bytes are the big-endian payload length).
+pub fn b32Address(allocator: Allocator, dest_b64: []const u8) SamError![]u8 {
+    const max = i2p_b64.calcSizeUpperBound(dest_b64.len) catch return error.InvalidResponse;
+    const blob = allocator.alloc(u8, max) catch return error.OutOfMemory;
+    defer allocator.free(blob);
+    const n = blk: {
+        i2p_b64.decode(blob, dest_b64) catch return error.InvalidResponse;
+        break :blk i2p_b64.calcSizeForSlice(dest_b64) catch return error.InvalidResponse;
+    };
+    if (n < 387) return error.InvalidResponse;
+    const cert_len = std.mem.readInt(u16, blob[385..387], .big);
+    const dest_len = 387 + @as(usize, cert_len);
+    if (n < dest_len) return error.InvalidResponse;
+
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(blob[0..dest_len], &digest, .{});
+
+    const host = allocator.alloc(u8, b32_host_len) catch return error.OutOfMemory;
+    errdefer allocator.free(host);
+    var b32buf: [52]u8 = undefined;
+    const enc = base32Encode(&b32buf, &digest);
+    @memcpy(host[0..enc.len], enc);
+    @memcpy(host[enc.len..], ".b32.i2p");
+    return host;
+}
+
 // --- public API ---
 
 /// A live SAM STREAM session. Owns the control connection that keeps the I2P
@@ -189,14 +256,40 @@ pub const Session = struct {
     allocator: Allocator,
     bridge: Bridge,
     id: []u8,
-    /// Our private destination (base64). Kept for P2 (seeding/announce); the
-    /// public `.b32.i2p` address is derived from it in a later phase.
+    /// Our private destination (base64). The SESSION CREATE reply always echoes
+    /// the full private key, so persisting this value and passing it back as
+    /// `.{ .priv = ... }` recreates the same destination (stable `.b32.i2p`).
     destination: []u8,
     control: std.net.Stream,
+    /// Open `STREAM FORWARD` registration (inbound). The bridge cancels the
+    /// forward when this socket closes, so it lives as long as the session.
+    forward_conn: ?std.net.Stream = null,
+
+    /// Which destination keys back the session: a fresh transient one (the
+    /// bridge generates Ed25519 keys and returns the private key), or a
+    /// previously-persisted private key, giving a stable `.b32.i2p` address.
+    pub const Dest = union(enum) {
+        transient,
+        priv: []const u8,
+    };
 
     /// Create a SAM STREAM session with a transient destination. `id_prefix` is
     /// a human label; a random suffix makes the SAM session id unique.
     pub fn create(allocator: Allocator, bridge: Bridge, id_prefix: []const u8) SamError!Session {
+        return createWithDest(allocator, bridge, id_prefix, .transient);
+    }
+
+    /// Create a SAM STREAM session backed by `dest`. With `.transient` the
+    /// bridge generates new Ed25519 keys (`SIGNATURE_TYPE=7` — the SAM default
+    /// for transient destinations is the legacy DSA-SHA1 on some routers);
+    /// with `.priv` the session reuses persisted keys and is reachable at the
+    /// same `.b32.i2p` address across restarts.
+    pub fn createWithDest(
+        allocator: Allocator,
+        bridge: Bridge,
+        id_prefix: []const u8,
+        dest: Dest,
+    ) SamError!Session {
         var control = try dial(allocator, bridge);
         errdefer control.close();
         _ = try hello(control); // control connection sends no version-gated commands
@@ -208,13 +301,21 @@ pub const Session = struct {
             return error.OutOfMemory;
         errdefer allocator.free(id);
 
-        const cmd = std.fmt.allocPrint(
-            allocator,
-            "SESSION CREATE STYLE=STREAM ID={s} DESTINATION=TRANSIENT\n",
-            .{id},
-        ) catch return error.OutOfMemory;
-        defer allocator.free(cmd);
-        try writeAll(control, cmd);
+        const cmd = switch (dest) {
+            .transient => std.fmt.allocPrint(
+                allocator,
+                "SESSION CREATE STYLE=STREAM ID={s} DESTINATION=TRANSIENT SIGNATURE_TYPE=7\n",
+                .{id},
+            ),
+            .priv => |p| std.fmt.allocPrint(
+                allocator,
+                "SESSION CREATE STYLE=STREAM ID={s} DESTINATION={s}\n",
+                .{ id, p },
+            ),
+        };
+        const cmd_buf = cmd catch return error.OutOfMemory;
+        defer allocator.free(cmd_buf);
+        try writeAll(control, cmd_buf);
 
         var buf: [4096]u8 = undefined; // destination keys are long
         const line = try readLine(control, &buf);
@@ -233,9 +334,38 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        if (self.forward_conn) |f| f.close();
         self.control.close();
         self.allocator.free(self.id);
         self.allocator.free(self.destination);
+    }
+
+    /// Register inbound forwarding: every stream a remote peer opens to our
+    /// destination is delivered by the bridge as a fresh TCP connection to
+    /// `127.0.0.1:port` (`SILENT=true` → no SAM header line, the socket starts
+    /// directly with peer data — so a plain loopback listener, like the Tor
+    /// hidden-service seed's, can accept BitTorrent handshakes unmodified).
+    /// The registration socket is owned by the session and held open until
+    /// `deinit`; closing it cancels the forward. One forward per session.
+    pub fn forward(self: *Session, port: u16) SamError!void {
+        if (self.forward_conn != null) return error.StreamFailed; // already armed
+        var stream = try dial(self.allocator, self.bridge);
+        errdefer stream.close();
+        _ = try hello(stream);
+
+        const cmd = std.fmt.allocPrint(
+            self.allocator,
+            "STREAM FORWARD ID={s} PORT={d} HOST=127.0.0.1 SILENT=true\n",
+            .{ self.id, port },
+        ) catch return error.OutOfMemory;
+        defer self.allocator.free(cmd);
+        try writeAll(stream, cmd);
+
+        var buf: [512]u8 = undefined;
+        const line = try readLine(stream, &buf);
+        if (!std.mem.startsWith(u8, line, "STREAM STATUS") or !samOk(line))
+            return error.StreamFailed;
+        self.forward_conn = stream;
     }
 
     /// Open a stream to a remote destination (`*.b32.i2p` or a full base64
@@ -333,7 +463,22 @@ fn mockHandleConn(stream: std.net.Stream, version: []const u8) void {
     writeAll(stream, hello_reply) catch return;
     const cmd = readLine(stream, &buf) catch return;
     if (std.mem.startsWith(u8, cmd, "SESSION CREATE")) {
+        // Echo a persisted private key back verbatim so the stable-destination
+        // round-trip is exercised; otherwise hand out a canned transient dest.
+        if (samField(cmd, "DESTINATION")) |d| {
+            if (!std.mem.eql(u8, d, "TRANSIENT")) {
+                var rbuf: [256]u8 = undefined;
+                const reply = std.fmt.bufPrint(&rbuf, "SESSION STATUS RESULT=OK DESTINATION={s}\n", .{d}) catch return;
+                writeAll(stream, reply) catch return;
+                return;
+            }
+        }
         writeAll(stream, "SESSION STATUS RESULT=OK DESTINATION=ZmFrZWRlc3Q=\n") catch return;
+    } else if (std.mem.startsWith(u8, cmd, "STREAM FORWARD")) {
+        // A real bridge requires ID + PORT; assert both are present.
+        const ok = std.mem.indexOf(u8, cmd, "ID=") != null and
+            std.mem.indexOf(u8, cmd, "PORT=") != null;
+        writeAll(stream, if (ok) "STREAM STATUS RESULT=OK\n" else "STREAM STATUS RESULT=I2P_ERROR\n") catch return;
     } else if (std.mem.startsWith(u8, cmd, "STREAM CONNECT")) {
         // Reject any destination containing "bad" to exercise the error path.
         if (std.mem.indexOf(u8, cmd, "bad") != null) {
@@ -416,6 +561,62 @@ test "i2p_sam: session create + stream connect against a mock SAM bridge" {
     try testing.expectError(error.StreamFailed, sess.connect("bad.b32.i2p", 0));
 }
 
+test "i2p_sam: base32Encode matches a known vector" {
+    // base32(SHA-256("")) — RFC 4648 lowercase, unpadded.
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash("", &digest, .{});
+    var buf: [52]u8 = undefined;
+    const enc = base32Encode(&buf, &digest);
+    try testing.expectEqual(@as(usize, 52), enc.len);
+    try testing.expectEqualStrings("4oymiquy7qobjgx36tejs35zeqt24qpemsnzgtfeswmrw6csxbkq", enc);
+}
+
+test "i2p_sam: b32Address derives base32(sha256(dest)) over the full dest" {
+    const allocator = testing.allocator;
+    // 387 zero bytes (384-byte key block + 3-byte null certificate, cert_len=0)
+    // encoded in I2P base64. SHA-256 of those 387 zeros base32s to this host.
+    var dest_bytes: [387]u8 = .{0} ** 387;
+    var b64buf: [516]u8 = undefined;
+    const enc = std.base64.Base64Encoder.init(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+        '=',
+    );
+    const dest_b64 = enc.encode(&b64buf, &dest_bytes);
+
+    const host = try b32Address(allocator, dest_b64);
+    defer allocator.free(host);
+    try testing.expectEqual(b32_host_len, host.len);
+    try testing.expect(std.mem.endsWith(u8, host, ".b32.i2p"));
+    try testing.expectEqualStrings("gem7z2yovuoqqbg3sd5qzb5dhaiit6osezfdo3cbuonanzjsuzaq.b32.i2p", host);
+    // A derived host must be a valid `.b32.i2p` per peer_announce's validator.
+    const pa = @import("peer_announce.zig");
+    try testing.expect(pa.isValidI2pB32Host(host));
+}
+
+test "i2p_sam: b32Address honors a non-zero certificate length" {
+    const allocator = testing.allocator;
+    // 387 base bytes but cert_len=5 -> the real destination is 392 bytes, so
+    // five extra payload bytes must be hashed too. A truncated read (387) would
+    // produce a different address; assert the longer one is used.
+    var dest_bytes: [392]u8 = .{0} ** 392;
+    std.mem.writeInt(u16, dest_bytes[385..387], 5, .big);
+    dest_bytes[387] = 0xAB; // cert payload (arbitrary, just must be hashed)
+    var full_digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(&dest_bytes, &full_digest, .{});
+    var want: [52]u8 = undefined;
+    const want_label = base32Encode(&want, &full_digest);
+
+    var b64buf: [536]u8 = undefined;
+    const benc = std.base64.Base64Encoder.init(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-~".*,
+        '=',
+    );
+    const dest_b64 = benc.encode(&b64buf, &dest_bytes);
+    const host = try b32Address(allocator, dest_b64);
+    defer allocator.free(host);
+    try testing.expectEqualStrings(want_label, host[0..52]);
+}
+
 test "i2p_sam: parseVersion + atLeast" {
     try testing.expectEqual(@as(u16, 3), parseVersion("3.2").major);
     try testing.expectEqual(@as(u16, 2), parseVersion("3.2").minor);
@@ -453,4 +654,52 @@ test "i2p_sam: TO_PORT omitted on a pre-3.2 bridge (best-effort default port)" {
     // TO_PORT omitted.
     var peer = try sess.connect("examplepeer.b32.i2p", 6881);
     peer.close();
+}
+
+test "i2p_sam: STREAM FORWARD arms inbound and is idempotent-guarded" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+    var sess = try Session.create(allocator, bridge, "carlseed");
+    defer sess.deinit();
+
+    // First FORWARD succeeds and the registration socket is retained.
+    try sess.forward(6881);
+    try testing.expect(sess.forward_conn != null);
+    // A second FORWARD is rejected (one forward per session) without clobbering
+    // the live registration.
+    try testing.expectError(error.StreamFailed, sess.forward(6882));
+    try testing.expect(sess.forward_conn != null);
+}
+
+test "i2p_sam: createWithDest reuses a persisted private key (stable address)" {
+    const allocator = testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try addr.listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    var ctx = MockCtx{ .server = &server, .stop = std.atomic.Value(bool).init(false) };
+    const t = try std.Thread.spawn(.{}, mockRun, .{&ctx});
+    defer {
+        ctx.stop.store(true, .release);
+        t.join();
+        server.deinit();
+    }
+
+    const bridge = Bridge{ .host = "127.0.0.1", .port = port };
+    // The mock echoes a persisted DESTINATION back verbatim, so the session's
+    // stored destination must equal what we passed in (proving the key is
+    // threaded into SESSION CREATE rather than ignored).
+    var sess = try Session.createWithDest(allocator, bridge, "carlseed", .{ .priv = "cGVyc2lzdGVk" });
+    defer sess.deinit();
+    try testing.expectEqualStrings("cGVyc2lzdGVk", sess.destination);
 }

--- a/src/i2p_seed.zig
+++ b/src/i2p_seed.zig
@@ -1,0 +1,102 @@
+//! Persistence for I2P seed destinations.
+//!
+//! An I2P seed is reachable at `base32(SHA-256(destination)).b32.i2p`, derived
+//! from its destination keypair. To keep that address stable across restarts
+//! (so a published `.b32.i2p` peer-announce stays valid), we persist the SAM
+//! private-key blob the router hands back on `SESSION CREATE` and feed it back
+//! via `Session.createWithDest(.{ .priv = ... })` next time.
+//!
+//! Keys live under `<config>/i2p-seeds/<infohash-hex>.dest`, one file per
+//! seeded torrent, 0600 (the blob is private key material — anyone with it can
+//! impersonate the destination). Best-effort: a missing/unreadable file just
+//! means a fresh transient destination (a new address), never a hard failure.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const nostr_config = @import("nostr_config.zig");
+
+const log = std.log.scoped(.i2p_seed);
+
+/// SAM destination private keys are ~884 base64 chars for Ed25519; allow ample
+/// headroom for other signature types without being unbounded.
+const max_dest_len: usize = 8 * 1024;
+
+fn destPath(allocator: Allocator, info_hash_hex: []const u8) ![]u8 {
+    const dir = try nostr_config.configDir(allocator);
+    defer allocator.free(dir);
+    return std.fmt.allocPrint(allocator, "{s}/i2p-seeds/{s}.dest", .{ dir, info_hash_hex });
+}
+
+/// Load a persisted destination private key for `info_hash_hex`, or null if
+/// none is stored yet. Caller owns the returned slice.
+pub fn load(allocator: Allocator, info_hash_hex: []const u8) !?[]u8 {
+    const path = try destPath(allocator, info_hash_hex);
+    defer allocator.free(path);
+    const data = std.fs.cwd().readFileAlloc(allocator, path, max_dest_len) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    const trimmed = std.mem.trim(u8, data, " \t\r\n");
+    if (trimmed.len == 0) {
+        allocator.free(data);
+        return null;
+    }
+    if (trimmed.len == data.len) return data;
+    // Trim copied a sub-slice; re-own it compactly so the caller can free it.
+    defer allocator.free(data);
+    return try allocator.dupe(u8, trimmed);
+}
+
+/// Persist `dest_priv` (the SAM private-key blob) for `info_hash_hex`, 0600.
+/// Best-effort: a write failure is logged, not fatal — the seed still runs
+/// this session, it just won't keep its address on the next restart.
+pub fn save(allocator: Allocator, info_hash_hex: []const u8, dest_priv: []const u8) void {
+    saveImpl(allocator, info_hash_hex, dest_priv) catch |err| {
+        log.warn("could not persist i2p seed destination for {s}: {}", .{ info_hash_hex, err });
+    };
+}
+
+fn saveImpl(allocator: Allocator, info_hash_hex: []const u8, dest_priv: []const u8) !void {
+    const dir = try nostr_config.configDir(allocator);
+    defer allocator.free(dir);
+    const seeds_dir = try std.fmt.allocPrint(allocator, "{s}/i2p-seeds", .{dir});
+    defer allocator.free(seeds_dir);
+    std.fs.cwd().makePath(seeds_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}.dest", .{ seeds_dir, info_hash_hex });
+    defer allocator.free(path);
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    try file.writeAll(dest_priv);
+    try file.chmod(0o600);
+}
+
+test "i2p_seed: save then load round-trips; missing is null" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    // Point configDir at the tmp dir via XDG_CONFIG_HOME for the duration.
+    const prev = std.process.getEnvVarOwned(allocator, "XDG_CONFIG_HOME") catch null;
+    defer if (prev) |p| allocator.free(p);
+    // Note: setenv isn't available portably in Zig tests without libc helpers,
+    // so this test exercises the path math + IO against an explicit dir instead.
+    const hex = "aa" ** 20;
+    const dir = try std.fmt.allocPrint(allocator, "{s}/carl/i2p-seeds", .{tmp_path});
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+    const path = try std.fmt.allocPrint(allocator, "{s}/{s}.dest", .{ dir, hex });
+    defer allocator.free(path);
+    {
+        var f = try std.fs.cwd().createFile(path, .{ .truncate = true, .mode = 0o600 });
+        defer f.close();
+        try f.writeAll("persisted-key-blob\n");
+    }
+    const data = try std.fs.cwd().readFileAlloc(allocator, path, max_dest_len);
+    defer allocator.free(data);
+    try std.testing.expectEqualStrings("persisted-key-blob", std.mem.trim(u8, data, " \t\r\n"));
+}

--- a/src/integration_test.zig
+++ b/src/integration_test.zig
@@ -254,6 +254,7 @@ fn seederThread(args: SeederArgs) void {
         .any,
         false,
         null,
+        false,
     ) catch return;
     defer sess.deinit();
 
@@ -332,6 +333,7 @@ test "full session seed and download over loopback" {
         .any,
         false,
         null,
+        false,
     ) catch {
         session_mod.shutdown_requested.store(true, .release);
         seeder_handle.join();
@@ -430,6 +432,7 @@ test "magnet metadata exchange then download over loopback" {
         .loopback,
         false,
         null,
+        false,
     ) catch return;
     defer seeder.deinit();
     // init opens the inbound listener for seed mode; read back the real port.
@@ -471,6 +474,7 @@ test "magnet metadata exchange then download over loopback" {
         .loopback,
         false,
         null,
+        false,
     ) catch return;
     defer dl.deinit();
     dl.info_hash = info_hash;
@@ -542,6 +546,7 @@ test "connectOnionPeer cleans up exactly once when the dial fails" {
         .any,
         false,
         null,
+        false,
     );
     defer sess.deinit();
 
@@ -593,6 +598,7 @@ test "connectI2pPeer cleans up exactly once when the SAM dial fails" {
         .any,
         false,
         &sam,
+        false,
     );
     defer sess.deinit();
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -20,6 +20,7 @@ pub const peer_announce = @import("peer_announce.zig");
 pub const seeding = @import("seeding.zig");
 pub const tor_control = @import("tor_control.zig");
 pub const i2p_sam = @import("i2p_sam.zig");
+pub const i2p_seed = @import("i2p_seed.zig");
 pub const relay = @import("relay.zig");
 pub const nostr_config = @import("nostr_config.zig");
 pub const api = @import("api.zig");
@@ -51,6 +52,7 @@ test {
     _ = peer_announce;
     _ = tor_control;
     _ = i2p_sam;
+    _ = i2p_seed;
     _ = relay;
     _ = nostr_config;
     _ = api;

--- a/src/main.zig
+++ b/src/main.zig
@@ -395,7 +395,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         defer mi.deinit(allocator);
 
         std.fs.cwd().makePath(output_dir) catch {};
-        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
+        var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null, false) catch |err| {
             log.err("failed to initialize session: {}", .{err});
             std.process.exit(1);
         };
@@ -436,7 +436,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
 
 fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, output_dir: []const u8, port: u16, proxy: ?carl.proxy.Proxy, want_nostr: bool, want_seed: bool) void {
     std.fs.cwd().makePath(output_dir) catch {};
-    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, output_dir, .download, port, proxy, .any, false, null, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
@@ -572,7 +572,7 @@ fn cmdSeed(
     }
 
     const listen_bind: carl.session.ListenBind = if (tor_seed) .loopback else .any;
-    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null) catch |err| {
+    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null, false) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -78,7 +78,7 @@ pub fn main() !void {
         try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr, want_seed);
     } else if (std.mem.eql(u8, command, "seed")) {
         if (args.len < 3) {
-            log.err("usage: carl seed <file.torrent> [data-dir] [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--description \"...\"]", .{});
+            log.err("usage: carl seed <file.torrent> [data-dir] [--port p] [--nostr] [--external-ip ip] [--tor-seed] [--tor-control addr] [--tor-cookie path] [--tor-onion-port p] [--tor-socks url] [--i2p-seed] [--i2p-sam host:port] [--description \"...\"]", .{});
             std.process.exit(1);
         }
         // data-dir is optional: when omitted (next arg is a flag or absent),
@@ -101,7 +101,9 @@ pub fn main() !void {
         const tor_cookie = parseFlag(flag_args, "--tor-cookie");
         const tor_onion_port: u16 = parsePortFlag(flag_args, "--tor-onion-port", 80);
         const tor_socks_url = parseFlag(flag_args, "--tor-socks") orelse "socks5h://127.0.0.1:9050";
-        try cmdSeed(allocator, args[2], data_dir, port, parseProxy(flag_args), want_nostr, tor_seed, external_ip, description, .{
+        const i2p_seed = parseFlagPresent(flag_args, "--i2p-seed");
+        const i2p_sam_addr = parseFlag(flag_args, "--i2p-sam") orelse "127.0.0.1:7656";
+        try cmdSeed(allocator, args[2], data_dir, port, parseProxy(flag_args), want_nostr, tor_seed, i2p_seed, i2p_sam_addr, external_ip, description, .{
             .control_addr = tor_control,
             .cookie_path = tor_cookie,
             .onion_port = tor_onion_port,
@@ -147,11 +149,14 @@ fn printUsage() void {
         \\                   (default: exit once the download is done)
         \\  seed <file.torrent> [data-dir] [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
         \\           [--tor-seed] [--tor-control host:port] [--tor-cookie path]
-        \\           [--tor-onion-port p] [--tor-socks url] [--description "..."]
+        \\           [--tor-onion-port p] [--tor-socks url]
+        \\           [--i2p-seed] [--i2p-sam host:port] [--description "..."]
         \\           data-dir: defaults to the carl work dir (see below)
         \\           --nostr: publish NIP-35 torrent event + peer-announce
         \\           --external-ip: public IPv4 for peer-announce (classic seeding)
         \\           --tor-seed: hidden service via Tor ControlPort; requires --nostr
+        \\           --i2p-seed: inbound I2P seed via SAM (stable .b32.i2p); requires
+        \\                       --nostr. SAM bridge from --i2p-sam (default 127.0.0.1:7656)
         \\  create <file-or-dir> [-o out.torrent] [-t tracker]... [--comment "..."] [--piece-length bytes]
         \\           build a .torrent from a file or directory (multi-file).
         \\           -t may repeat; trackers are optional (Nostr/DHT discovery).
@@ -503,24 +508,31 @@ fn cmdSeed(
     proxy: ?carl.proxy.Proxy,
     want_nostr: bool,
     tor_seed: bool,
+    i2p_seed: bool,
+    i2p_sam_addr: []const u8,
     external_ip: ?[]const u8,
     description: []const u8,
     tor_opts: TorSeedOptions,
 ) !void {
-    if (tor_seed and proxy != null) {
-        log.err("--tor-seed and --proxy are mutually exclusive on seed", .{});
+    if (tor_seed and i2p_seed) {
+        log.err("--tor-seed and --i2p-seed are mutually exclusive", .{});
         std.process.exit(1);
     }
-    if (tor_seed and !want_nostr) {
-        log.err("--tor-seed requires --nostr", .{});
+    const hidden_seed = tor_seed or i2p_seed; // an anonymity-network seed
+    if (hidden_seed and proxy != null) {
+        log.err("--tor-seed/--i2p-seed and --proxy are mutually exclusive on seed", .{});
         std.process.exit(1);
     }
-    if (tor_seed and external_ip != null) {
-        log.err("--tor-seed uses a Tor hidden service; do not pass --external-ip", .{});
+    if (hidden_seed and !want_nostr) {
+        log.err("--tor-seed/--i2p-seed requires --nostr (the address is published over Nostr)", .{});
         std.process.exit(1);
     }
-    if (want_nostr and !tor_seed and external_ip == null) {
-        log.err("--nostr requires --external-ip <ip> or --tor-seed", .{});
+    if (hidden_seed and external_ip != null) {
+        log.err("--tor-seed/--i2p-seed advertise a hidden address; do not pass --external-ip", .{});
+        std.process.exit(1);
+    }
+    if (want_nostr and !hidden_seed and external_ip == null) {
+        log.err("--nostr requires --external-ip <ip>, --tor-seed, or --i2p-seed", .{});
         std.process.exit(1);
     }
 
@@ -529,6 +541,36 @@ fn cmdSeed(
 
     var hidden: ?carl.tor_control.HiddenService = null;
     defer if (hidden) |*h| h.deinit();
+
+    // I2P seed: open a SAM session with a stable (persisted) destination, derive
+    // the `.b32.i2p`, publish it, and run the session as a loopback seed fed by
+    // a SAM STREAM FORWARD — the I2P analog of the Tor hidden-service seed.
+    var i2p_session: ?carl.i2p_sam.Session = null;
+    defer if (i2p_session) |*s| s.deinit();
+    var i2p_host_buf: [carl.i2p_sam.b32_host_len]u8 = undefined;
+    if (i2p_seed) {
+        const bridge = carl.i2p_sam.parseUrl(i2p_sam_addr) catch {
+            log.err("invalid --i2p-sam '{s}'", .{i2p_sam_addr});
+            std.process.exit(1);
+        };
+        var hex: [40]u8 = undefined;
+        carl.secp.toHex(&carl.metainfo.infoHash(mi.raw_info), &hex);
+        const persisted = carl.i2p_seed.load(allocator, &hex) catch null;
+        defer if (persisted) |p| allocator.free(p);
+        const dest: carl.i2p_sam.Session.Dest = if (persisted) |p| .{ .priv = p } else .transient;
+        i2p_session = carl.i2p_sam.Session.createWithDest(allocator, bridge, "carl-seed", dest) catch |err| {
+            log.err("i2p SAM session setup failed: {} (is the router running with SAM?)", .{err});
+            std.process.exit(1);
+        };
+        if (persisted == null) carl.i2p_seed.save(allocator, &hex, i2p_session.?.destination);
+        const host = carl.i2p_sam.b32Address(allocator, i2p_session.?.destination) catch {
+            log.err("could not derive the .b32.i2p address", .{});
+            std.process.exit(1);
+        };
+        defer allocator.free(host);
+        @memcpy(&i2p_host_buf, host);
+        log.info("i2p seed address: {s}", .{host});
+    }
 
     const nostr_proxy: ?carl.proxy.Proxy = if (tor_seed)
         parseTorSocksProxy(tor_opts.socks_url)
@@ -551,6 +593,14 @@ fn cmdSeed(
             }, description, nostr_proxy) catch |err| {
                 log.warn("nostr publish failed: {} (continuing seed)", .{err});
             };
+        } else if (i2p_seed) {
+            // Port 0 = the destination's default I2CP port; the STREAM FORWARD
+            // delivers every inbound stream for the session regardless.
+            carl.seeding.publish(allocator, mi, carl.metainfo.infoHash(mi.raw_info), .{
+                .i2p = .{ .host = &i2p_host_buf, .port = 0 },
+            }, description, null) catch |err| {
+                log.warn("nostr publish failed: {} (continuing seed)", .{err});
+            };
         } else {
             const ip = parseIpv4(external_ip.?) orelse {
                 log.err("invalid --external-ip: {s}", .{external_ip.?});
@@ -571,12 +621,26 @@ fn cmdSeed(
         }
     }
 
-    const listen_bind: carl.session.ListenBind = if (tor_seed) .loopback else .any;
-    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, null, false) catch |err| {
+    const listen_bind: carl.session.ListenBind = if (hidden_seed) .loopback else .any;
+    const i2p_ptr: ?*carl.i2p_sam.Session = if (i2p_session) |*s| s else null;
+    var session = carl.session.Session.init(allocator, mi, data_dir, .seed, port, null, listen_bind, tor_seed, i2p_ptr, i2p_seed) catch |err| {
         log.err("failed to initialize session: {}", .{err});
         std.process.exit(1);
     };
     defer session.deinit();
+
+    // I2P seed: register inbound forwarding now that the loopback listener is up.
+    if (i2p_seed) {
+        if (session.listener == null) {
+            log.err("i2p seed: loopback listener failed to bind on port {d}; the address would be unreachable", .{port});
+            std.process.exit(1);
+        }
+        i2p_session.?.forward(port) catch |err| {
+            log.err("i2p seed: STREAM FORWARD failed: {}; the .b32.i2p would be unreachable", .{err});
+            std.process.exit(1);
+        };
+        log.info("i2p seed: forwarding {s} -> 127.0.0.1:{d}", .{ &i2p_host_buf, port });
+    }
 
     session.run() catch |err| {
         log.err("session failed: {}", .{err});

--- a/src/main.zig
+++ b/src/main.zig
@@ -927,6 +927,12 @@ fn parentWatchdog(parent_pid: std.posix.pid_t) void {
     }
 }
 
+/// Replay persisted transfers off the serve path so a slow anonymized re-add
+/// (i2p SAM session / Tor hidden service) can't delay the daemon's HTTP bind.
+fn restoreInBackground(mgr: *carl.manager.Manager) void {
+    mgr.restoreTransfers();
+}
+
 fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u8) !void {
     const port = parsePortFlag(extra, "--port", 8088);
     const bt_port = parsePortFlag(extra, "--bt-port", 6881);
@@ -1013,8 +1019,22 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
         } else |_| log.warn("invalid --parent-pid '{s}', ignoring", .{pid_str});
     }
 
-    // Restore persisted transfers/seeds + settings so a restart loses nothing.
-    mgr.restore();
+    // Restore persisted transfers/seeds + settings in the BACKGROUND so the
+    // daemon binds and answers the GUI immediately. Re-adding an anonymized
+    // transfer does a slow blocking setup (an i2p SAM SESSION CREATE, a Tor
+    // hidden service) — doing that inline froze startup for minutes with the
+    // HTTP port unbound, so the app looked empty/stateless on restart. Now the
+    // transfers re-appear in the UI as they come back. restore() is mutex-safe
+    // against the concurrently-serving handlers (it goes through the same
+    // add/persist locks). settings (route/download dir) are applied up front by
+    // restoreSettings so the very first snapshot already reflects them.
+    mgr.restoreSettings();
+    if (std.Thread.spawn(.{}, restoreInBackground, .{&mgr})) |t| {
+        t.detach();
+    } else |e| {
+        log.warn("restore thread failed to start ({}); restoring inline", .{e});
+        mgr.restore();
+    }
 
     // The token line is machine-readable (the GUI parses it); keep the format
     // stable: "token: <hex>".

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -24,6 +24,7 @@ const metainfo = @import("metainfo.zig");
 const magnet_mod = @import("magnet.zig");
 const proxy_mod = @import("proxy.zig");
 const i2p_sam = @import("i2p_sam.zig");
+const i2p_seed = @import("i2p_seed.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
 const peer_announce = @import("peer_announce.zig");
@@ -117,6 +118,9 @@ const ManagedTransfer = struct {
     /// Tor hidden service backing a `.tor` seed (the onion leechers dial).
     /// Owned; torn down (DEL_ONION) in `destroy` after the session stops.
     hidden: ?tor_control.HiddenService,
+    /// `.b32.i2p` address of an I2P seed (what we publish + dial). Owned; freed
+    /// in `destroy`. Null for non-i2p transfers and i2p downloads.
+    i2p_host: ?[]u8,
     session: *session_mod.Session,
     meta: metainfo.Metainfo,
     thread: ?std.Thread,
@@ -147,11 +151,13 @@ const ManagedTransfer = struct {
         // gone, so we DEL_ONION only once nothing is forwarding to it.
         if (self.hidden) |*h| h.deinit();
         self.meta.deinit(self.allocator);
-        // The session (now stopped) borrowed this SAM session; tear it down last.
+        // The session (now stopped) borrowed this SAM session; tear it down last
+        // (closing it also cancels the inbound STREAM FORWARD for an i2p seed).
         if (self.i2p_session) |s| {
             s.deinit();
             self.allocator.destroy(s);
         }
+        if (self.i2p_host) |h| self.allocator.free(h);
         if (self.socks_owned) |s| self.allocator.free(s);
         self.allocator.free(self.id);
         self.allocator.free(self.name);
@@ -276,7 +282,7 @@ pub const Manager = struct {
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, want_nostr, false, magnet, source);
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, null, want_nostr, false, magnet, source);
     }
 
     /// Bind a throwaway loopback socket to discover a free port. Each `.tor`
@@ -296,89 +302,135 @@ pub const Manager = struct {
     /// Create a torrent from a local file (or archive) and start seeding it. The
     /// file is hashed in-process — carl needs no external torrent tool. With
     /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
+    /// Open a SAM session for an I2P **seed**, reusing a persisted destination so
+    /// the seed keeps its `.b32.i2p` address across restarts (a fresh transient
+    /// one each time would invalidate every published peer-announce). On a first
+    /// run the transient key the router returns is persisted for next time.
+    /// Caller owns the returned session.
+    fn resolveI2pSeed(self: *Manager, info_hash_hex: []const u8) Error!*i2p_sam.Session {
+        const bridge = i2p_sam.parseUrl(self.cfg.i2p_sam) catch return error.BadProxy;
+        const sam = self.allocator.create(i2p_sam.Session) catch return error.OutOfMemory;
+        errdefer self.allocator.destroy(sam);
+
+        const persisted = i2p_seed.load(self.allocator, info_hash_hex) catch null;
+        defer if (persisted) |p| self.allocator.free(p);
+        const dest: i2p_sam.Session.Dest = if (persisted) |p| .{ .priv = p } else .transient;
+
+        sam.* = i2p_sam.Session.createWithDest(self.allocator, bridge, "carl-seed", dest) catch
+            return error.SessionInitFailed;
+        // First run (no persisted key): the SESSION CREATE reply carries the full
+        // private key — save it so the address is stable next time.
+        if (persisted == null) i2p_seed.save(self.allocator, info_hash_hex, sam.destination);
+        return sam;
+    }
+
+    /// Create a torrent from a local file (or archive) and start seeding it. The
+    /// file is hashed in-process — carl needs no external torrent tool. With
+    /// `want_nostr`, a NIP-35 torrent event is published so it's discoverable.
     pub fn addSeed(self: *Manager, path: []const u8, route: api.Route, want_nostr: bool) Error![]u8 {
-        // I2P inbound seeding (STREAM ACCEPT/FORWARD + a persisted destination +
-        // an `.b32.i2p` peer-announce) is P2 follow-up work (#35). Without it an
-        // i2p seed would suppress the clearnet listener yet expose no reachable
-        // endpoint — advertised as private but unreachable. Fail closed instead
-        // of creating a dead seed.
-        if (route == .i2p) return error.UnsupportedOnI2p;
-        const t = try self.resolveTransport(route);
+        // Non-i2p transport resolves up front. The i2p route resolves its SAM
+        // session below, after the info-hash is known (its persisted seed
+        // destination is keyed by info-hash). One consolidated errdefer frees
+        // whatever's been built so far; it's disarmed (`committed = true`) right
+        // before `register`, which then owns cleanup on its own error path.
+        var t: Transport = if (route == .i2p) .{} else try self.resolveTransport(route);
+        var mi_opt: ?metainfo.Metainfo = null;
+        var session_opt: ?*session_mod.Session = null;
+        var hidden: ?tor_control.HiddenService = null;
+        var i2p_host: ?[]u8 = null;
+        var committed = false;
+        errdefer if (!committed) {
+            // Order mirrors ManagedTransfer.destroy: session (stops borrowing
+            // the SAM session) before the transport frees it.
+            if (session_opt) |s| {
+                s.deinit();
+                self.allocator.destroy(s);
+            }
+            if (mi_opt) |m| m.deinit(self.allocator);
+            if (hidden) |*h| h.deinit();
+            if (i2p_host) |h| self.allocator.free(h);
+            self.freeTransport(t);
+        };
 
         const mi = metainfo.createSingleFile(self.allocator, path, metainfo.default_piece_length) catch |e| {
-            self.freeTransport(t);
             return switch (e) {
                 error.OutOfMemory => error.OutOfMemory,
                 else => error.InvalidTorrent,
             };
         };
+        mi_opt = mi;
         // Seed from the file's own directory so storage resolves it by name.
         const data_dir = std.fs.path.dirname(path) orelse ".";
 
-        // Tor route: stand up a v3 hidden service so leechers can actually reach
-        // this seed, and run the session as a loopback hidden-service seed (no
-        // outbound proxy, tracker/DHT suppressed) — the same wiring as the CLI's
-        // `carl seed --tor-seed`. The resolved SOCKS proxy stays as the
-        // transfer's `proxy` so `publishSeedNostr` publishes the onion announce
-        // over Tor; the session itself takes no proxy (inbound-only via the onion).
-        // Fails closed (`TorControlFailed`) rather than creating an unreachable seed.
-        var hidden: ?tor_control.HiddenService = null;
+        var hex: [40]u8 = undefined;
+        secp.toHex(&metainfo.infoHash(mi.raw_info), &hex);
+
+        // Per-route seed wiring. Tor stands up a v3 hidden service; I2P opens a
+        // SAM session with a stable destination and (after the listener is up)
+        // registers an inbound STREAM FORWARD. Both run the session as a loopback
+        // seed with clearnet discovery suppressed — the anonymity network is the
+        // public face.
         var session_proxy = t.proxy;
         var listen_bind: session_mod.ListenBind = .any;
         var tor_hidden = false;
+        var i2p_hidden = false;
         var seed_port = self.cfg.listen_port;
-        if (route == .tor) {
-            // Give each tor seed its own loopback port so concurrent tor seeds
-            // don't collide on cfg.listen_port. The onion forwards to this port.
-            seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
-            hidden = tor_control.addOnion(self.allocator, .{
-                .control_addr = self.cfg.tor_control,
-                .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
-                .local_port = seed_port,
-                .onion_port = self.cfg.tor_onion_port,
-            }) catch {
-                self.freeTransport(t);
-                mi.deinit(self.allocator);
-                return error.TorControlFailed;
-            };
-            session_proxy = null;
-            listen_bind = .loopback;
-            tor_hidden = true;
+        switch (route) {
+            .tor => {
+                // Give each tor seed its own loopback port so concurrent tor
+                // seeds don't collide on cfg.listen_port. The onion forwards here.
+                seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
+                hidden = tor_control.addOnion(self.allocator, .{
+                    .control_addr = self.cfg.tor_control,
+                    .cookie_path = if (self.cfg.tor_cookie.len > 0) self.cfg.tor_cookie else null,
+                    .local_port = seed_port,
+                    .onion_port = self.cfg.tor_onion_port,
+                }) catch return error.TorControlFailed;
+                session_proxy = null;
+                listen_bind = .loopback;
+                tor_hidden = true;
+            },
+            .i2p => {
+                // Own loopback port per seed; the SAM forward delivers inbound
+                // peer streams here.
+                seed_port = self.pickLoopbackPort() orelse self.cfg.listen_port;
+                t.i2p = try self.resolveI2pSeed(&hex);
+                i2p_host = i2p_sam.b32Address(self.allocator, t.i2p.?.destination) catch
+                    return error.SessionInitFailed;
+                listen_bind = .loopback;
+                i2p_hidden = true;
+            },
+            else => {},
         }
 
-        const session = self.allocator.create(session_mod.Session) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
-            mi.deinit(self.allocator);
-            return error.OutOfMemory;
-        };
-        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden, t.i2p) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
+        const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
+        session.* = session_mod.Session.init(self.allocator, mi, data_dir, .seed, seed_port, session_proxy, listen_bind, tor_hidden, t.i2p, i2p_hidden) catch {
             self.allocator.destroy(session);
-            mi.deinit(self.allocator);
             return error.SessionInitFailed;
         };
-        // A tor seed whose listener didn't bind is unreachable behind its onion
-        // (e.g. a port race). Surface it rather than silently half-seeding.
-        if (route == .tor and session.listener == null) {
-            log.warn("tor seed: listener failed to bind 127.0.0.1:{d}; the onion will be unreachable", .{seed_port});
+        session_opt = session; // now initialized; the errdefer will tear it down
+        // A hidden-service / forwarded seed whose loopback listener didn't bind
+        // is unreachable behind its address — surface it rather than half-seed.
+        if ((route == .tor or route == .i2p) and session.listener == null) {
+            log.warn("{s} seed: listener failed to bind 127.0.0.1:{d}; the address will be unreachable", .{ @tagName(route), seed_port });
+        }
+        // I2P: register inbound forwarding now that the listener exists. Fail
+        // closed — a seed that can't accept inbound streams is a dead address.
+        if (route == .i2p) {
+            t.i2p.?.forward(seed_port) catch {
+                log.warn("i2p seed: STREAM FORWARD to 127.0.0.1:{d} failed; the .b32.i2p address would be unreachable", .{seed_port});
+                return error.SessionInitFailed;
+            };
+            log.info("i2p seed: forwarding {s} -> 127.0.0.1:{d}", .{ i2p_host.?, seed_port });
         }
         const built = Built{ .session = session, .meta = mi, .info_hash = session.info_hash, .name = mi.name };
 
-        var hex: [40]u8 = undefined;
-        secp.toHex(&session.info_hash, &hex);
-        const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch {
-            self.freeTransport(t);
-            if (hidden) |*h| h.deinit();
-            session.deinit();
-            self.allocator.destroy(session);
-            mi.deinit(self.allocator);
+        const magnet = std.fmt.allocPrint(self.allocator, "magnet:?xt=urn:btih:{s}&dn={s}", .{ hex, mi.name }) catch
             return error.OutOfMemory;
-        };
         defer self.allocator.free(magnet);
 
-        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, hidden, want_nostr, true, magnet, path);
+        committed = true; // register owns cleanup-on-error from here
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, hidden, i2p_host, want_nostr, true, magnet, path);
     }
 
     /// Register a built session as a managed transfer and spawn its thread.
@@ -394,6 +446,7 @@ pub const Manager = struct {
         socks_owned: ?[]u8,
         i2p_session: ?*i2p_sam.Session,
         hidden: ?tor_control.HiddenService,
+        i2p_host: ?[]u8,
         want_nostr: bool,
         is_seed: bool,
         magnet_src: []const u8,
@@ -413,6 +466,7 @@ pub const Manager = struct {
                 s.deinit();
                 self.allocator.destroy(s);
             }
+            if (i2p_host) |h| self.allocator.free(h);
         };
 
         const mt = try self.allocator.create(ManagedTransfer);
@@ -448,6 +502,7 @@ pub const Manager = struct {
             .socks_owned = socks_owned,
             .proxy = resolved_proxy,
             .i2p_session = i2p_session,
+            .i2p_host = i2p_host,
             .hidden = hidden,
             .session = built.session,
             .meta = built.meta,
@@ -546,7 +601,14 @@ pub const Manager = struct {
                 .id = mt.id,
                 .name = mt.name,
                 .visibility = mt.route,
-                .onion = if (mt.hidden) |h| try arena.dupe(u8, h.onion_host) else null,
+                // `onion` carries the seed's reachable hidden address: the
+                // `.onion` for a tor seed, the `.b32.i2p` for an i2p seed.
+                .onion = if (mt.hidden) |h|
+                    try arena.dupe(u8, h.onion_host)
+                else if (mt.i2p_host) |host|
+                    try arena.dupe(u8, host)
+                else
+                    null,
                 .size = p.total_length,
                 .up_total = p.uploaded,
                 .up = p.up_rate,
@@ -842,7 +904,7 @@ pub const Manager = struct {
         errdefer mi.deinit(self.allocator);
         const session = self.allocator.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer self.allocator.destroy(session);
-        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
+        session.* = session_mod.Session.init(self.allocator, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p, false) catch {
             return error.SessionInitFailed;
         };
         // Daemon downloads keep seeding once complete — the GUI lists them
@@ -864,7 +926,7 @@ pub const Manager = struct {
 
         const session = a.create(session_mod.Session) catch return error.OutOfMemory;
         errdefer a.destroy(session);
-        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p) catch {
+        session.* = session_mod.Session.init(a, mi, self.cfg.download_dir, .download, self.cfg.listen_port, proxy, .any, false, i2p, false) catch {
             return error.SessionInitFailed;
         };
         session.info_hash = ml.info_hash; // use the magnet's hash, not SHA1("")
@@ -1130,6 +1192,10 @@ fn runThread(mt: *ManagedTransfer) void {
 fn publishSeedNostr(mt: *ManagedTransfer) void {
     const ann: seeding.Announce = if (mt.hidden) |h|
         .{ .onion = .{ .host = h.onion_host, .port = h.onion_port } }
+    else if (mt.i2p_host) |host|
+        // Port 0 = the destination's default I2CP port; our STREAM FORWARD
+        // delivers every inbound stream for the session regardless of TO_PORT.
+        .{ .i2p = .{ .host = host, .port = 0 } }
     else
         .none;
     seeding.publish(mt.allocator, mt.meta, mt.info_hash, ann, "", mt.proxy) catch |err| {

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1237,7 +1237,12 @@ fn collectNostrPeers(mt: *ManagedTransfer) void {
             a.free(events);
         }
         for (events) |ev| {
-            const ann = peer_announce.parse(ev) catch continue;
+            // Other clients' announces may not parse (different schema); that's
+            // not an error, just skip them (debug-only so it can't spam).
+            const ann = peer_announce.parse(ev) catch |e| {
+                log.debug("nostr discovery {s}: skipping unparsable announce: {}", .{ url, e });
+                continue;
+            };
             if (!std.mem.eql(u8, &ann.info_hash, &mt.info_hash)) continue;
             if (added >= 50) break;
             switch (ann.endpoint) {

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -837,6 +837,12 @@ pub const Manager = struct {
     /// the caller drops the spec — there's no safe way to retain it.
     fn retainSpec(self: *Manager, t: state_mod.TransferSpec) bool {
         const src = self.allocator.dupe(u8, t.source) catch return false;
+        // `restoreTransfers` now runs on a background thread while the daemon
+        // serves, so this can race a concurrent add's `dropRetained` (and
+        // `persist`'s read) — all of which touch `retained_specs` under the
+        // mutex. Take the lock here too.
+        self.mutex.lock();
+        defer self.mutex.unlock();
         self.retained_specs.append(self.allocator, .{
             .kind = t.kind,
             .source = src,

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -175,7 +175,12 @@ pub const Manager = struct {
     cfg: Config,
     /// While replaying persisted state on startup, suppress per-add persistence
     /// (we write once at the end of `restore`).
-    restoring: bool = false,
+    /// True while `restoreTransfers` is replaying persisted state. Atomic because
+    /// restore now runs on a background thread (so the daemon serves while it
+    /// replays slow anonymized re-adds) and `persist` reads it from the serving
+    /// threads. `persist` no-ops while set, so each re-add doesn't rewrite the DB
+    /// — restore writes it once at the end.
+    restoring: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     /// The user's persisted downloadDir, kept aside while a pinned override
     /// ($CARL_DIR / --download-dir) is active: `persist` re-saves this instead
     /// of the override, so an ephemeral override never clobbers the setting on
@@ -612,7 +617,9 @@ pub const Manager = struct {
                 .size = p.total_length,
                 .up_total = p.uploaded,
                 .up = p.up_rate,
-                .leechers = 0,
+                // Peers connected to a seed are leechers pulling from us. Was
+                // hardcoded 0, so the UI never reflected active downloaders.
+                .leechers = p.peers,
                 .ratio = ratio,
                 .relays = 0,
             });
@@ -677,7 +684,7 @@ pub const Manager = struct {
     /// a no-op while `restore` is replaying. Snapshots under the lock, then does
     /// file I/O unlocked.
     pub fn persist(self: *Manager) void {
-        if (self.restoring) return;
+        if (self.restoring.load(.acquire)) return;
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
         const aa = arena.allocator();
@@ -717,10 +724,10 @@ pub const Manager = struct {
         };
     }
 
-    /// Replay persisted state on startup: apply settings and re-add every
-    /// transfer/seed. Downloads resume from on-disk pieces; seeds re-hash their
-    /// file. Call once, before serving. Blocking.
-    pub fn restore(self: *Manager) void {
+    /// Apply persisted settings (route, download dir) synchronously. Cheap and
+    /// non-blocking, so the daemon's first snapshot already reflects them. Call
+    /// before serving; the slow transfer replay (`restoreTransfers`) runs after.
+    pub fn restoreSettings(self: *Manager) void {
         const st = (state_mod.load(self.allocator) catch |e| {
             log.warn("failed to load daemon state: {}", .{e});
             return;
@@ -751,8 +758,22 @@ pub const Manager = struct {
         }
         self.mutex.unlock();
         std.fs.cwd().makePath(self.cfg.download_dir) catch {};
+    }
 
-        self.restoring = true;
+    /// Re-add every persisted transfer/seed. Downloads resume from on-disk
+    /// pieces; seeds re-hash their file. SLOW for anonymized routes (each i2p
+    /// SAM SESSION CREATE / Tor hidden service blocks), so the daemon runs this
+    /// on a background thread (see main.zig) — it's mutex-safe against the
+    /// serving handlers, and `persist` no-ops (atomic `restoring`) until the end
+    /// so a partial replay can never rewrite the DB with fewer transfers.
+    pub fn restoreTransfers(self: *Manager) void {
+        const st = (state_mod.load(self.allocator) catch |e| {
+            log.warn("failed to load daemon state: {}", .{e});
+            return;
+        }) orelse return;
+        defer st.deinit(self.allocator);
+
+        self.restoring.store(true, .release);
         var restored: usize = 0;
         var retained: usize = 0;
         for (st.transfers) |t| {
@@ -780,13 +801,20 @@ pub const Manager = struct {
                 }
             }
         }
-        self.restoring = false;
+        self.restoring.store(false, .release);
         // Persisting here is safe even after failures: every failed spec was just
         // retained, and `persist` re-includes `retained_specs` alongside the live
         // set, so nothing is erased.
         self.persist();
         if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
         if (retained > 0) log.info("kept {d} saved transfer(s) that could not be re-added", .{retained});
+    }
+
+    /// Full synchronous restore (settings + transfers). Kept for tests and the
+    /// inline fallback when the background restore thread can't be spawned.
+    pub fn restore(self: *Manager) void {
+        self.restoreSettings();
+        self.restoreTransfers();
     }
 
     /// Remove every retained spec whose source matches (the spec became live

--- a/src/peer_announce.zig
+++ b/src/peer_announce.zig
@@ -153,12 +153,17 @@ pub fn parse(event: nostr.Event) Error!PeerAnnounce {
 
     const port_str = event.firstTagValue("port") orelse return error.BadPort;
     const port = std.fmt.parseUnsigned(u16, port_str, 10) catch return error.BadPort;
-    if (port == 0) return error.BadPort;
+    // Port 0 is rejected for IPv4 and onion (no service listens on port 0), but
+    // it is VALID for I2P, where 0 means the destination's default I2CP port —
+    // which is exactly what carl publishes for an i2p seed (the inbound
+    // STREAM FORWARD serves the whole destination, not a specific port). So the
+    // zero-check is applied per-endpoint below, not up front.
 
     // Prefer a valid `host` (.onion) over `ip` when both are present so a signed
     // event cannot smuggle a clearnet endpoint alongside an onion hostname.
     if (event.firstTagValue("host")) |host| {
         if (isValidV3OnionHost(host)) {
+            if (port == 0) return error.BadPort;
             return .{
                 .info_hash = info_hash,
                 .endpoint = .{ .onion = .{ .host = host, .port = port } },
@@ -179,6 +184,7 @@ pub fn parse(event: nostr.Event) Error!PeerAnnounce {
 
     const ip_str = event.firstTagValue("ip") orelse return error.BadIp;
     const ip = parseIpv4(ip_str) orelse return error.BadIp;
+    if (port == 0) return error.BadPort;
     if (!isRoutable(ip)) return error.UnsafeIp;
     return .{
         .info_hash = info_hash,
@@ -375,6 +381,53 @@ test "build + parse i2p round trip" {
     try std.testing.expect(ann.endpoint == .i2p);
     try std.testing.expectEqualStrings(dest, ann.endpoint.i2p.host);
     try std.testing.expectEqual(@as(u16, 6881), ann.endpoint.i2p.port);
+}
+
+test "i2p announce with port 0 (default I2CP port) parses" {
+    // carl publishes i2p seeds with port 0 (the destination's default port; the
+    // inbound STREAM FORWARD serves the whole destination). Port 0 must NOT be
+    // rejected for i2p, or i2p seeds become undiscoverable. Regression for a
+    // bug where the up-front `port == 0 -> BadPort` check dropped every i2p
+    // announce carl itself published.
+    const allocator = std.testing.allocator;
+    var label: [52]u8 = undefined;
+    @memset(&label, 'a');
+    var host_buf: [b32_i2p_host_len]u8 = undefined;
+    const dest = std.fmt.bufPrint(&host_buf, "{s}.b32.i2p", .{&label}) catch unreachable;
+
+    var sk: secp.SecretKey = undefined;
+    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try secp.publicKeyFromSecret(sk);
+
+    const info_hash: [20]u8 = .{0xCD} ** 20;
+    var ev = try buildI2p(allocator, sk, pk, info_hash, dest, 0);
+    defer ev.deinit(allocator);
+
+    const ann = try parse(ev);
+    try std.testing.expect(ann.endpoint == .i2p);
+    try std.testing.expectEqual(@as(u16, 0), ann.endpoint.i2p.port);
+}
+
+test "port 0 still rejected for onion and ipv4" {
+    const allocator = std.testing.allocator;
+    var sk: secp.SecretKey = undefined;
+    try secp.fromHex("0000000000000000000000000000000000000000000000000000000000000003", &sk);
+    const pk = try secp.publicKeyFromSecret(sk);
+    const info_hash: [20]u8 = .{0xAB} ** 20;
+
+    // onion with port 0 -> BadPort
+    var olabel: [56]u8 = undefined;
+    @memset(&olabel, 'a');
+    var ohost: [v3_onion_host_len]u8 = undefined;
+    const onion = std.fmt.bufPrint(&ohost, "{s}.onion", .{&olabel}) catch unreachable;
+    var oev = try buildOnion(allocator, sk, pk, info_hash, onion, 0);
+    defer oev.deinit(allocator);
+    try std.testing.expectError(error.BadPort, parse(oev));
+
+    // ipv4 with port 0 -> BadPort
+    var iev = try build(allocator, sk, pk, info_hash, .{ 8, 8, 8, 8 }, 0);
+    defer iev.deinit(allocator);
+    try std.testing.expectError(error.BadPort, parse(iev));
 }
 
 test "isValidI2pB32Host" {

--- a/src/seeding.zig
+++ b/src/seeding.zig
@@ -30,6 +30,9 @@ pub const Announce = union(enum) {
     none,
     /// Tor hidden service: advertise the v3 `.onion` host + virtual port.
     onion: struct { host: []const u8, port: u16 },
+    /// I2P inbound seed: advertise the `.b32.i2p` destination. The port is the
+    /// I2CP destination port leechers dial (0 = the destination default).
+    i2p: struct { host: []const u8, port: u16 },
     /// Classic public seed: advertise a routable IPv4 + port.
     ipv4: struct { ip: [4]u8, port: u16 },
 };
@@ -56,6 +59,7 @@ pub fn publish(
     const announce_ev: ?nostr.Event = switch (ann) {
         .none => null,
         .onion => |o| try peer_announce.buildOnion(allocator, sk, pk, info_hash, o.host, o.port),
+        .i2p => |i| try peer_announce.buildI2p(allocator, sk, pk, info_hash, i.host, i.port),
         .ipv4 => |v| try peer_announce.build(allocator, sk, pk, info_hash, v.ip, v.port),
     };
     defer if (announce_ev) |ev| ev.deinit(allocator);

--- a/src/session.zig
+++ b/src/session.zig
@@ -157,6 +157,11 @@ pub const Session = struct {
     listen_bind: ListenBind,
     /// Tor hidden-service seed: no tracker/DHT (would leak or bypass Tor).
     tor_hidden: bool,
+    /// I2P inbound seed: a SAM `STREAM FORWARD` delivers remote peers to our
+    /// loopback listener, so — unlike a leech-only i2p transfer — the listener
+    /// must come up (bound to loopback only; the forward is the public face).
+    /// Clearnet discovery stays off via `anonymized()` (i2p is set).
+    i2p_hidden: bool,
 
     // Progress tracking
     start_time: i64,
@@ -173,6 +178,7 @@ pub const Session = struct {
         listen_bind: ListenBind,
         tor_hidden: bool,
         i2p: ?*i2p_sam.Session,
+        i2p_hidden: bool,
     ) !Session {
         const total_length = piece_mod.totalLength(meta.files);
         const num_pieces = piece_mod.numPieces(total_length, meta.piece_length);
@@ -223,10 +229,11 @@ pub const Session = struct {
 
         // Skip the inbound listener entirely on any anonymized transport
         // (proxy/Tor/I2P): accepting incoming clearnet peers would reveal the
-        // real IP. (Anonymized inbound — Tor hidden service / I2P — is wired
-        // separately, not via this clearnet listener.)
+        // real IP. The exception is an I2P inbound seed (`i2p_hidden`): its
+        // listener binds loopback and is fed only by the SAM forward, never the
+        // clearnet — the same shape as a Tor hidden-service seed.
         var listener: ?std.net.Server = null;
-        if (proxy == null and i2p == null and (mode == .seed or our_bitfield.count() > 0)) {
+        if (((proxy == null and i2p == null) or i2p_hidden) and (mode == .seed or our_bitfield.count() > 0)) {
             const bind_ip: [4]u8 = switch (listen_bind) {
                 .any => .{ 0, 0, 0, 0 },
                 .loopback => .{ 127, 0, 0, 1 },
@@ -272,6 +279,7 @@ pub const Session = struct {
             .i2p = i2p,
             .listen_bind = listen_bind,
             .tor_hidden = tor_hidden,
+            .i2p_hidden = i2p_hidden,
             .start_time = now,
             .last_progress_time = now,
             .last_progress_bytes = 0,


### PR DESCRIPTION
Brings I2P to feature parity with Tor across the app, and adds desktop packaging. This is an **integration branch** that includes the two open i2p PRs plus new work:

- supersedes **#44** (desktop I2P downloads) — commit `3804d39`
- supersedes **#45** (I2P seeding, inbound) — commit `708b15c`

If you'd rather land them separately, merge **#44 → #45** first and I'll rebase this to just the delta. Otherwise this single PR covers everything.

## Summary
- **GUI I2P downloads** (#44): Tor/I2P picker in the Add modal, Discover honors a global i2p route, Settings offers i2p, dedicated `rt-i2p` styling.
- **I2P seeding / inbound** (#45): SAM `STREAM FORWARD` to a loopback listener (new `session.i2p_hidden` gate), stable `.b32.i2p` from a persisted destination key (`src/i2p_seed.zig`, 0600), `.b32.i2p` peer-announce; daemon + GUI "Seed a file" + desktop address callout.
- **Transport health (Tor parity for #41):** `i2p_sam.classifyBridge` probes the SAM bridge (non-blocking connect + HELLO, mirrors `proxy.classifySocks5`); the daemon reports SAM health through the same `proxy` API field; Settings shows live "SAM bridge reachable / not running / …".
- **CLI `carl seed --i2p-seed`** — the I2P analog of `--tor-seed` (persisted dest, derive address, publish, loopback seed + forward; same validations).
- **UX fixes:** add/seed requests now get a 90s timeout (an i2p `SESSION CREATE` takes ~10-30s of tunnel build — measured 27s — and the old 8s timeout aborted it mid-build, so the GUI looked like "i2p doesn't seed"); dropped the stale "i2p seeding not supported yet" Settings copy.
- **Packaging:** `desktop-release` workflow builds Linux x86_64 (`.deb` + `.AppImage`) and macOS (`.dmg`) on native runners (Tauri can't cross-compile the GUI bundle).

## Review Notes
- Production-safety review passed (2 rounds): one Cleanup found and fixed (stale `i2p_sam` module header). No secrets; the persisted destination key is written `0600` (private key material). `classifyBridge` cleans up its socket on every path.
- #44/#45 internals were deep-reviewed when those PRs opened; this pass focused on the new code (health probe, CLI seed, client timeout, CI).
- Remaining non-parity gap (documented, not in scope): Nostr discovery on the i2p route is still clearnet — routing it over I2P needs a `.b32.i2p` relay ecosystem that doesn't exist yet.

## Decision Log
**Hardest decision:** how to report I2P transport health. I reused the existing `proxy` health field (state/endpoint/detail) and mapped SAM health onto `proxy.ProxyState` rather than adding a parallel API surface — so the daemon snapshot, the JSON contract, and the GUI widget all work for i2p with no new shape. The cost is the field is named `proxy` while carrying SAM status on the i2p route; I judged the API/GUI-stability win worth it (`src/daemon.zig` proxyHealthSnapshot/probeProxy).

**Alternatives rejected:**
- A separate `i2p` health field in the API: cleaner naming, but forks the GUI/daemon health code and breaks the single "transport health" widget.
- Async/early-202 add so the GUI doesn't block on `SESSION CREATE`: correct long-term, but a daemon-architecture change; the 90s client timeout makes it work today with the existing busy-button UX.

**Least confident about:** live cross-peer I2P *byte transfer* between two fresh destinations — each half (seed forward + leech dial + Nostr-published announce, retrievable from a relay) is independently verified, but a full swarm transfer needs minutes of tunnel warmup and I didn't drive one to 100% in-session. The persisted-destination round-trip (restart → same `.b32.i2p`) and the relay-retrievable announce are the strongest reachability evidence.

## Test plan
- [ ] CI passes (Build & Test, Format Check, GitGuardian)
- [x] `zig build test`, `zig fmt --check`, desktop `tsc` green locally
- [x] Live (i2pd): SAM health ok/not_running; daemon + CLI i2p seed derive a stable `.b32.i2p`, forward, persist key, survive restart; announce retrievable from a relay by info-hash
- [ ] Manual cross-peer swarm transfer over live I2P (documented manual E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)