### PR TITLE
fix: retry nostr peer discovery while a download has zero peers

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -410,6 +410,7 @@ fn cmdDownload(allocator: std.mem.Allocator, source: []const u8, output_dir: []c
         session.metadata_only = true;
         session.seed_after_complete = want_seed;
         if (want_nostr) {
+            session.setPeerDiscovery(&session, cliRediscoverPeersCb);
             collectNostrPeers(allocator, ml.info_hash, &session);
         }
         session.run() catch |err| {
@@ -449,6 +450,7 @@ fn startDownload(allocator: std.mem.Allocator, mi: carl.metainfo.Metainfo, outpu
     defer session.deinit();
     if (want_nostr) {
         const info_hash = carl.metainfo.infoHash(mi.raw_info);
+        session.setPeerDiscovery(&session, cliRediscoverPeersCb);
         collectNostrPeers(allocator, info_hash, &session);
     }
     session.run() catch |err| {
@@ -1137,6 +1139,14 @@ fn fetchNip35Entry(
         }
     }
     return best;
+}
+
+/// `Session.PeerDiscovery` callback: re-run Nostr discovery when the download
+/// has zero peers. The session carries everything we need (allocator +
+/// info_hash), so the loop can keep retrying without extra state.
+fn cliRediscoverPeersCb(ctx: *anyopaque) void {
+    const session: *carl.session.Session = @ptrCast(@alignCast(ctx));
+    collectNostrPeers(session.allocator, session.info_hash, session);
 }
 
 fn collectNostrPeers(

--- a/src/main.zig
+++ b/src/main.zig
@@ -1170,6 +1170,10 @@ fn collectNostrPeers(
 
     var added: usize = 0;
     for (relay_urls) |url| {
+        // Bail promptly on shutdown: this also runs as the periodic re-discovery
+        // callback inside the session loop, so a Ctrl-C mid-query must be honored
+        // without waiting out every relay's timeout.
+        if (!session.running) return;
         var r = carl.relay.Relay.connect(allocator, url, session.proxy) catch |err| {
             log.debug("nostr peer-discover: {s}: {}", .{ url, err });
             continue;

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1211,11 +1211,28 @@ pub fn formatEta(buf: []u8, status: api.Status, remaining_bytes: u64, rate_bps: 
 
 fn runThread(mt: *ManagedTransfer) void {
     if (mt.want_nostr) {
-        if (mt.is_seed) publishSeedNostr(mt) else collectNostrPeers(mt);
+        if (mt.is_seed) {
+            publishSeedNostr(mt);
+        } else {
+            // Retry discovery while the download has zero peers: the run loop
+            // calls this back on its own thread (safe to add peers) so a seed
+            // that appears/returns later is still picked up — one-shot discovery
+            // left such a download stuck at no_peers.
+            mt.session.setPeerDiscovery(mt, rediscoverPeersCb);
+            collectNostrPeers(mt); // initial pass before the loop starts
+        }
     }
     mt.session.run() catch |err| {
         log.err("transfer {s}: session error: {}", .{ mt.id, err });
     };
+}
+
+/// `Session.PeerDiscovery` callback: re-run Nostr peer discovery for `ctx`
+/// (a `*ManagedTransfer`). Invoked on the session thread by the run loop.
+fn rediscoverPeersCb(ctx: *anyopaque) void {
+    const mt: *ManagedTransfer = @ptrCast(@alignCast(ctx));
+    log.info("transfer {s}: no peers, re-querying nostr for peers", .{mt.id});
+    collectNostrPeers(mt);
 }
 
 /// Publish a seed's Nostr events via the shared `seeding.publish` (the same path

--- a/src/session.zig
+++ b/src/session.zig
@@ -23,6 +23,21 @@ const max_peers: usize = 50;
 const unchoke_slots: usize = 4;
 const unchoke_interval_secs: i64 = 10;
 const optimistic_interval_secs: i64 = 30;
+/// How often to re-run Nostr peer discovery while a transfer has zero peers.
+/// One-shot discovery at startup isn't enough — a download whose only seed
+/// dropped (or that found nothing at first) must keep retrying or it stalls at
+/// no_peers forever. Re-querying relays is slow (~seconds per relay), so only
+/// retry when stuck at zero peers and not more often than this.
+const peer_rediscovery_interval_secs: i64 = 45;
+
+/// Periodic peer re-discovery hook. The session run loop calls `run(ctx)` on
+/// its own thread when the transfer has zero peers, so the callback can safely
+/// add peers (the peer set is single-threaded). The manager/CLI wire this to
+/// their Nostr peer-announce lookup for `--nostr` downloads.
+pub const PeerDiscovery = struct {
+    ctx: *anyopaque,
+    run: *const fn (ctx: *anyopaque) void,
+};
 
 /// Global flag for graceful shutdown on SIGINT. Atomic because it's
 /// written from a signal handler and read from event loop / test threads.
@@ -162,6 +177,12 @@ pub const Session = struct {
     /// must come up (bound to loopback only; the forward is the public face).
     /// Clearnet discovery stays off via `anonymized()` (i2p is set).
     i2p_hidden: bool,
+
+    /// Optional periodic peer re-discovery (set by the manager/CLI for `--nostr`
+    /// downloads). Invoked by the run loop when the transfer has zero peers.
+    peer_discovery: ?PeerDiscovery = null,
+    /// Timestamp of the last peer re-discovery, to rate-limit retries.
+    last_peer_discovery_s: i64 = 0,
 
     // Progress tracking
     start_time: i64,
@@ -410,9 +431,18 @@ pub const Session = struct {
         self.rate_last_out = out_bytes;
     }
 
+    /// Wire a periodic peer re-discovery callback (see `PeerDiscovery`). Call
+    /// before `run`; the loop invokes it on this thread when peers hit zero.
+    pub fn setPeerDiscovery(self: *Session, ctx: *anyopaque, run_fn: *const fn (ctx: *anyopaque) void) void {
+        self.peer_discovery = .{ .ctx = ctx, .run = run_fn };
+    }
+
     pub fn run(self: *Session) !void {
         const stdout = std.fs.File.stdout().deprecatedWriter();
         const stderr = std.fs.File.stderr().deprecatedWriter();
+        // Start the re-discovery clock now so the first retry waits a full
+        // interval after any startup discovery the caller already ran.
+        self.last_peer_discovery_s = std.time.timestamp();
 
         const act = std.posix.Sigaction{
             .handler = .{ .handler = sigintHandler },
@@ -1400,6 +1430,18 @@ pub const Session = struct {
             // DHT: retry more aggressively when we have zero peers
             if (self.peers.items.len == 0 and now - self.last_announce_time > 30) {
                 self.tryDhtPeerDiscovery() catch {};
+            }
+        }
+
+        // Nostr: when stuck at zero peers, periodically re-query the relays for
+        // fresh peer-announces — a seed may have appeared or come back. Runs on
+        // this (the session) thread, so the callback adds peers safely. Gated on
+        // zero peers so it never duplicates a live connection or competes with an
+        // active download, and rate-limited because relay queries are slow.
+        if (self.peer_discovery) |pd| {
+            if (self.peers.items.len == 0 and now - self.last_peer_discovery_s > peer_rediscovery_interval_secs) {
+                self.last_peer_discovery_s = now;
+                pd.run(pd.ctx);
             }
         }
     }

--- a/src/session.zig
+++ b/src/session.zig
@@ -1433,13 +1433,15 @@ pub const Session = struct {
             }
         }
 
-        // Nostr: when stuck at zero peers, periodically re-query the relays for
-        // fresh peer-announces — a seed may have appeared or come back. Runs on
-        // this (the session) thread, so the callback adds peers safely. Gated on
-        // zero peers so it never duplicates a live connection or competes with an
-        // active download, and rate-limited because relay queries are slow.
+        // Nostr: while DOWNLOADING with zero peers, periodically re-query the
+        // relays for fresh peer-announces — a seed may have appeared or come
+        // back. Runs on this (the session) thread, so the callback adds peers
+        // safely. Gated on download mode + zero peers so it never duplicates a
+        // live connection, competes with an active download, or fires once the
+        // transfer has completed and is only seeding (dialing out is pointless
+        // then); rate-limited because relay queries are slow.
         if (self.peer_discovery) |pd| {
-            if (self.peers.items.len == 0 and now - self.last_peer_discovery_s > peer_rediscovery_interval_secs) {
+            if (self.mode == .download and self.peers.items.len == 0 and now - self.last_peer_discovery_s > peer_rediscovery_interval_secs) {
                 self.last_peer_discovery_s = now;
                 pd.run(pd.ctx);
             }


### PR DESCRIPTION
## Summary
- Nostr peer discovery was **one-shot**: `collectNostrPeers` ran once when a transfer was added, never again. A download that found no peers at that moment — or whose only seed dropped and later returned — sat at `no_peers` forever, even though a re-query would have found a peer. Live-confirmed on the i2p path: a restarted seed was never rediscovered without a manual re-add.
- Adds a periodic re-discovery hook on the session run loop: `Session` gains an optional `PeerDiscovery` callback that `maintenance()` invokes when the peer set is empty, rate-limited to every 45s.
- Wired for `--nostr` downloads on both paths: the daemon (`manager.runThread` → `rediscoverPeersCb`) and the CLI (`download`/`startDownload` → `cliRediscoverPeersCb`). Seeds are unaffected (they publish, not discover).

## Review Notes
- **Thread-safety is the crux.** The peer set is single-threaded (mutated only on the session thread; `peer_count` is the atomic the daemon reads). So the callback must run *on the session thread* — calling the `connect*` helpers from any other thread would race `run()`. The hook fires inside `maintenance()` (session thread), so adding peers is safe. This is why it's a callback into the loop rather than a separate retry thread.
- **Gated on zero peers**, so it never duplicates a live connection and never competes with an active download; rate-limited because a relay query is slow (seconds per relay). Trackers/DHT already had their own zero-peer retry — this brings nostr to parity.
- Verified: a no-seed `--nostr` download logged `no peers, re-querying nostr for peers` every ~45s (twice in 100s).

## Decision Log
**Hardest decision:** how to retry without racing the session's peer set. The discovery I/O (relay queries) is slow and blocking, which argues for a background thread — but the `connect*Peer` helpers append to `session.peers`, which only the session thread may touch. Running discovery on a side thread would corrupt the peer list. So I inverted it: the session loop owns the cadence and calls back into discovery on its own thread (`Session.PeerDiscovery` in `session.zig`), accepting that the relay query briefly blocks the loop — which is fine precisely because it only runs when there are zero peers (the loop has nothing else to do).

**Alternatives rejected:**
- Background re-discovery thread: races `session.peers`; would need a lock or a hand-off queue — more machinery for no benefit since the loop is idle at zero peers anyway.
- Retry on every loop tick: hammers relays; the 45s rate-limit + zero-peer gate keeps it cheap.
- Also retry when peers are low (not just zero): risks duplicate dials to peers already connected (no dedup in `connect*Peer`); scoped to zero peers for safety. Worth revisiting with peer dedup.

**Least confident about:** the relay query blocking the session loop for its duration. It's bounded (each relay has a 10s cap, and `collectNostrPeers` bails between relays when `session.running` clears), and only happens at zero peers, so a stalled download isn't doing anything else — but on a torrent with a flaky single peer that flaps to zero, the loop could spend a few seconds in discovery at each flap. Acceptable, but a hand-off design would decouple it if it ever matters.

## Test plan
- [ ] CI passes
- [x] `zig build test`, `zig fmt --check` green
- [x] Live: no-seed `--nostr` download re-queries every ~45s; daemon + CLI both wired
- [ ] End-to-end: a seed that appears after the download starts is picked up on the next retry (the i2p recovery case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)