### PR TITLE
feat: carl follow — mirror a Nostr publisher's torrents (download + reseed)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { Sidebar, type Screen } from "./Sidebar";
 import { TransfersScreen } from "./screens/Transfers";
 import { DiscoverScreen } from "./screens/Discover";
 import { SeedingScreen } from "./screens/Seeding";
+import { FollowingScreen } from "./screens/Following";
 import { SettingsScreen } from "./screens/Settings";
 import { AddModal } from "./modals/AddModal";
 import { Icon } from "./components/icons";
@@ -161,6 +162,7 @@ export function App() {
           <TransfersScreen openAdd={() => setShowAdd(true)} />
         )}
         {screen === "discover" && <DiscoverScreen />}
+        {screen === "following" && <FollowingScreen />}
         {screen === "seeding" && <SeedingScreen />}
         {screen === "settings" && <SettingsScreen />}
       </main>

--- a/desktop/src/Sidebar.tsx
+++ b/desktop/src/Sidebar.tsx
@@ -3,11 +3,17 @@ import { RouteBadge, RelayDot } from "./components/atoms";
 import { trunc } from "./components/format";
 import { useCarl } from "./api/store";
 
-export type Screen = "transfers" | "discover" | "seeding" | "settings";
+export type Screen =
+  | "transfers"
+  | "discover"
+  | "following"
+  | "seeding"
+  | "settings";
 
 const NAV: [Screen, string, string][] = [
   ["transfers", "Transfers", "transfers"],
   ["discover", "Discover", "discover"],
+  ["following", "Following", "pulse"],
   ["seeding", "Seeding", "seeding"],
   ["settings", "Settings", "settings"],
 ];
@@ -24,6 +30,7 @@ export function Sidebar({
     transfers: state.transfers.filter(
       (t) => t.status === "downloading" || t.status === "metadata",
     ).length,
+    following: (state.follows ?? []).length,
     seeding: state.seeds.length,
   };
   const connectedRelays = state.relays.filter(

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -115,6 +115,28 @@ export class DaemonClient {
     }
   }
 
+  /** Follow a publisher: mirror (download + reseed) everything they announce
+   *  via NIP-35. `pubkey` is an npub or 64-char hex; route is direct|i2p. */
+  async addFollow(pubkey: string, route: Route): Promise<{ id: string }> {
+    const res = await this.fetch("/api/follows", {
+      method: "POST",
+      body: JSON.stringify({ pubkey, route }),
+    });
+    return this.json<{ id: string }>(res);
+  }
+
+  /** Unfollow. The daemon joins the mirror's worker threads before answering,
+   *  which can take a few seconds if a relay query is mid-flight. */
+  async removeFollow(id: string): Promise<void> {
+    const res = await this.fetch(`/api/follows/${id}`, {
+      method: "DELETE",
+      signal: AbortSignal.timeout(SESSION_SETUP_TIMEOUT_MS),
+    });
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`${res.status} ${res.statusText}`);
+    }
+  }
+
   async search(query: string): Promise<DiscoverResult[]> {
     const res = await this.fetch("/api/search", {
       method: "POST",

--- a/desktop/src/api/store.tsx
+++ b/desktop/src/api/store.tsx
@@ -22,6 +22,8 @@ interface CarlContextValue {
   error: string | null;
   addTransfer: (source: string, route: Route, nostr: boolean) => Promise<void>;
   removeTransfer: (id: string) => Promise<void>;
+  addFollow: (pubkey: string, route: Route) => Promise<void>;
+  removeFollow: (id: string) => Promise<void>;
   search: (query: string) => Promise<import("./types").DiscoverResult[]>;
   setRoute: (route: Route) => Promise<void>;
   updateSettings: (patch: {
@@ -140,6 +142,26 @@ export function CarlProvider({ children }: { children: React.ReactNode }) {
     [refresh],
   );
 
+  const addFollow = useCallback(
+    async (pubkey: string, route: Route) => {
+      const c = clientRef.current;
+      if (!c) throw new Error("daemon not connected");
+      await c.addFollow(pubkey, route);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const removeFollow = useCallback(
+    async (id: string) => {
+      const c = clientRef.current;
+      if (!c) return;
+      await c.removeFollow(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
   const search = useCallback(async (query: string) => {
     const c = clientRef.current;
     if (!c) throw new Error("daemon not connected");
@@ -188,6 +210,8 @@ export function CarlProvider({ children }: { children: React.ReactNode }) {
     error,
     addTransfer,
     removeTransfer,
+    addFollow,
+    removeFollow,
     search,
     setRoute,
     updateSettings,

--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -54,6 +54,30 @@ export interface Seed {
   relays: number;
 }
 
+/** One torrent inside a followed publisher's mirror. */
+export interface FollowTorrent {
+  name: string;
+  hash: string;
+  state: "starting" | "downloading" | "seeding" | "failed";
+  pct: number;
+  peers: number;
+  down: number;
+  up: number;
+}
+
+/** A followed publisher: carl mirrors (downloads + reseeds) everything this
+ *  pubkey announces via NIP-35. */
+export interface Follow {
+  id: string;
+  npub: string;
+  route: Route;
+  dir: string;
+  seeding: number;
+  downloading: number;
+  failed: number;
+  torrents: FollowTorrent[];
+}
+
 export interface Identity {
   npub: string;
 }
@@ -110,6 +134,7 @@ export interface DiscoverResult {
 export interface AppState {
   transfers: Transfer[];
   seeds: Seed[];
+  follows: Follow[];
   relays: Relay[];
   proxy: ProxyHealth;
   identity: Identity;
@@ -119,6 +144,7 @@ export interface AppState {
 export const emptyState: AppState = {
   transfers: [],
   seeds: [],
+  follows: [],
   relays: [],
   proxy: { state: "disabled", endpoint: "", detail: "" },
   identity: { npub: "" },

--- a/desktop/src/screens/Following.tsx
+++ b/desktop/src/screens/Following.tsx
@@ -1,0 +1,307 @@
+// Following: mirror everything a Nostr publisher announces (NIP-35).
+//
+// Each followed npub gets a publisher card: the identity + route up top, then
+// one row per mirrored torrent with its live phase (downloading → seeding).
+// The daemon runs one mirror worker per follow (see src/follow.zig); this
+// screen is a thin view over `state.follows` pushed on the WebSocket tick.
+
+import { useState } from "react";
+import { Icon } from "../components/icons";
+import {
+  RouteBadge,
+  StatusPill,
+  ProgressBar,
+  CopyField,
+} from "../components/atoms";
+import { fmtSpeed, trunc } from "../components/format";
+import { useCarl } from "../api/store";
+import type { Follow, FollowTorrent, Route, Status } from "../api/types";
+
+/** Map a mirror phase onto the shared status-pill vocabulary. */
+function pillStatus(state: FollowTorrent["state"]): Status {
+  switch (state) {
+    case "seeding":
+      return "seeding";
+    case "downloading":
+      return "downloading";
+    case "failed":
+      return "stalled";
+    default:
+      return "connecting";
+  }
+}
+
+function TorrentRow({ t }: { t: FollowTorrent }) {
+  const status = pillStatus(t.state);
+  return (
+    <div className="fol-trow">
+      <div className="fol-trow-main">
+        <span className="seed-name mono">{t.name || trunc(t.hash, 10)}</span>
+        <StatusPill status={status} />
+      </div>
+      {t.state === "downloading" && (
+        <div className="fol-trow-bar">
+          <ProgressBar pct={t.pct} status={status} />
+          <span className="mono dim" style={{ fontSize: 11 }}>
+            {t.pct}%
+          </span>
+        </div>
+      )}
+      <div className="trow-stat">
+        <span className="ts-val mono">{t.peers}</span>
+        <span className="ts-lbl">peers</span>
+      </div>
+      <div className="trow-stat">
+        <span className="ts-val mono dl">{fmtSpeed(t.down)}</span>
+        <span className="ts-lbl">down</span>
+      </div>
+      <div className="trow-stat">
+        <span className="ts-val mono ul">{fmtSpeed(t.up)}</span>
+        <span className="ts-lbl">up</span>
+      </div>
+    </div>
+  );
+}
+
+function FollowCard({ f }: { f: Follow }) {
+  const { removeFollow } = useCarl();
+  const [busy, setBusy] = useState(false);
+
+  async function unfollow() {
+    setBusy(true);
+    try {
+      await removeFollow(f.id);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fol-card">
+      <div className="fol-head">
+        <span className="fol-ic">
+          <Icon name="pulse" size={16} />
+        </span>
+        <div className="fol-id">
+          <CopyField value={f.npub} />
+          <span className="fol-sub dim">
+            mirroring into <span className="mono">{f.dir}</span>
+          </span>
+        </div>
+        <RouteBadge route={f.route} size="sm" />
+        <div className="fol-counts mono">
+          <span className="ul">{f.seeding} seeding</span>
+          {f.downloading > 0 && <span className="dl">{f.downloading} downloading</span>}
+          {f.failed > 0 && <span className="fol-failed">{f.failed} failed</span>}
+        </div>
+        <button
+          className="icon-btn"
+          title="Unfollow (mirrored files stay on disk)"
+          disabled={busy}
+          onClick={unfollow}
+        >
+          <Icon name="trash" size={15} />
+        </button>
+      </div>
+      {f.torrents.length === 0 ? (
+        <div className="fol-empty dim">
+          Watching relays — nothing published by this key yet.
+        </div>
+      ) : (
+        <div className="fol-trows">
+          {f.torrents.map((t) => (
+            <TorrentRow key={t.hash} t={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ROUTE_LABEL: Partial<Record<Route, string>> = {
+  direct: "Direct",
+  i2p: "I2P",
+};
+const ROUTE_DESC: Partial<Record<Route, string>> = {
+  direct:
+    "Download and reseed over the clearnet. Fast; your IP is visible to peers.",
+  i2p: "Download AND reseed over I2P. Each mirrored torrent gets a stable .b32.i2p address; no clearnet IP exposed.",
+};
+
+function FollowModal({ onClose }: { onClose: () => void }) {
+  const { state, addFollow } = useCarl();
+  const [pubkey, setPubkey] = useState("");
+  const [route, setRoute] = useState<Route>(
+    state.settings.route === "i2p" ? "i2p" : "direct",
+  );
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const valid =
+    pubkey.trim().startsWith("npub1") || /^[0-9a-fA-F]{64}$/.test(pubkey.trim());
+
+  async function submit() {
+    if (!valid) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await addFollow(pubkey.trim(), route);
+      onClose();
+    } catch (e) {
+      setErr(String(e));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="modal-scrim" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2 className="modal-title">Follow a publisher</h2>
+          <button className="icon-btn" onClick={onClose}>
+            <Icon name="close" size={16} />
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <div className="field">
+            <div className="field-label">
+              Publisher key
+              <span className="fl-hint">npub1… or 64-char hex</span>
+            </div>
+            <input
+              className="text-input add-input mono"
+              placeholder="npub1…"
+              value={pubkey}
+              autoFocus
+              onChange={(e) => setPubkey(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+              }}
+            />
+            <div className="field-hint">
+              carl watches this key's NIP-35 torrent events on your relays,
+              downloads everything it publishes, and keeps reseeding it —
+              announcing your mirror under your own identity so others can
+              fetch from it too.
+            </div>
+          </div>
+
+          <div className="field-label">Mirror route</div>
+          <div className="vis-options">
+            {(["direct", "i2p"] as const).map((id) => (
+              <button
+                key={id}
+                className={"vis-opt" + (route === id ? " active" : "")}
+                onClick={() => setRoute(id)}
+              >
+                <div className="vis-opt-top">
+                  <RouteBadge route={id} size="sm" />
+                  {route === id && (
+                    <span className="vis-check">
+                      <Icon name="check" size={13} stroke={2.4} />
+                    </span>
+                  )}
+                </div>
+                <div className="vis-opt-name">{ROUTE_LABEL[id]}</div>
+                <div className="vis-opt-desc">{ROUTE_DESC[id]}</div>
+              </button>
+            ))}
+          </div>
+
+          {err && (
+            <div className="callout-note" style={{ color: "var(--danger)" }}>
+              <Icon name="close" size={15} stroke={1.8} />
+              <span>{err}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="modal-foot">
+          <span className="field-hint">
+            Mirrors restart with the daemon and resume from disk.
+          </span>
+          <div className="modal-foot-actions">
+            <button className="btn" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className={"btn btn-primary" + (valid && !busy ? "" : " disabled")}
+              disabled={!valid || busy}
+              onClick={submit}
+            >
+              <Icon name="plus" size={14} stroke={2.2} />
+              {busy ? "Starting…" : "Follow"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FollowingScreen() {
+  const { state } = useCarl();
+  const follows = state.follows ?? [];
+  const [showAdd, setShowAdd] = useState(false);
+  const mirrored = follows.reduce((a, f) => a + f.seeding, 0);
+  const pulling = follows.reduce((a, f) => a + f.downloading, 0);
+
+  return (
+    <div className="screen">
+      <div className="topbar">
+        <div className="topbar-l">
+          <h1 className="screen-title">Following</h1>
+          <div className="rate-readout">
+            <span className="dim" style={{ fontSize: 12 }}>
+              {follows.length} publisher{follows.length === 1 ? "" : "s"} ·{" "}
+              <span className="ul">{mirrored} mirrored</span>
+              {pulling > 0 && (
+                <>
+                  {" "}
+                  · <span className="dl">{pulling} downloading</span>
+                </>
+              )}
+            </span>
+          </div>
+        </div>
+        <div className="topbar-r">
+          <button className="btn btn-primary" onClick={() => setShowAdd(true)}>
+            <Icon name="plus" size={15} stroke={2} /> Follow publisher
+          </button>
+        </div>
+      </div>
+
+      <div className="content">
+        {follows.length === 0 ? (
+          <div className="empty">
+            <div className="empty-glyph">
+              <Icon name="pulse" size={26} />
+            </div>
+            <div className="empty-title">Not following anyone yet</div>
+            <div className="empty-sub">
+              Follow a publisher's npub and carl becomes their mirror: every
+              torrent they announce over Nostr is downloaded and reseeded from
+              here — over I2P if you want the mirror itself to stay anonymous.
+              Their files outlive their laptop.
+            </div>
+            <button
+              className="btn btn-primary"
+              style={{ marginTop: 10 }}
+              onClick={() => setShowAdd(true)}
+            >
+              <Icon name="plus" size={15} stroke={2} /> Follow a publisher
+            </button>
+          </div>
+        ) : (
+          <div className="fol-list">
+            {follows.map((f) => (
+              <FollowCard key={f.id} f={f} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showAdd && <FollowModal onClose={() => setShowAdd(false)} />}
+    </div>
+  );
+}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -462,3 +462,22 @@ html[data-density="compact"] .trow-stat{ width:74px; flex-basis:74px; }
   .dm-hash{ display:none; }
 }
 @media (prefers-reduced-motion:reduce){ *{ animation:none!important; } }
+
+/* ============ FOLLOWING ============ */
+.fol-list{ display:flex; flex-direction:column; gap:14px; }
+.fol-card{ background:var(--bg-1); border:1px solid var(--border-soft); border-radius:var(--r-lg); overflow:hidden; }
+.fol-card:hover{ border-color:var(--border); }
+.fol-head{ display:flex; align-items:center; gap:14px; padding:14px 16px; border-bottom:1px solid var(--border-soft); background:var(--bg-2); }
+.fol-ic{ width:34px; height:34px; border-radius:9px; background:var(--accent-soft); color:var(--accent-dim);
+  display:flex; align-items:center; justify-content:center; flex:0 0 auto; }
+.fol-id{ flex:1; min-width:0; display:flex; flex-direction:column; gap:3px; }
+.fol-sub{ font-size:11px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.fol-counts{ display:flex; gap:12px; font-size:11.5px; flex:0 0 auto; }
+.fol-failed{ color:var(--danger, #e06c75); }
+.fol-empty{ padding:18px 16px; font-size:12.5px; }
+.fol-trows{ display:flex; flex-direction:column; }
+.fol-trow{ display:flex; align-items:center; gap:16px; padding:var(--row-pad) 16px; border-bottom:1px solid var(--border-soft); }
+.fol-trow:last-child{ border-bottom:none; }
+.fol-trow-main{ flex:1; min-width:0; display:flex; align-items:center; gap:10px; }
+.fol-trow-bar{ flex:0 0 180px; display:flex; align-items:center; gap:8px; }
+.fol-trow-bar .pbar{ flex:1; }

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -156,6 +156,30 @@ reachable; if it isn't, the request fails `400` with
 `{ "error": "Tor hidden service setup failed: …" }`. `direct`/`proxy` seeds
 publish only the discoverable NIP-35 metadata (no routable endpoint to announce).
 
+### `GET /api/follows` → `[Follow]`
+
+The followed publishers (see `docs/follow.md`) with their mirrored torrents and
+live per-torrent phase/progress. Also included in `GET /api/state` and the
+WebSocket push under `follows`.
+
+### `POST /api/follows`
+
+Body: `{ "pubkey": "<npub1…|64-char hex>", "route": "direct|i2p" }` (`route`
+defaults to the configured route when it's one of those, else `direct`).
+Follows the publisher: a mirror worker downloads everything that pubkey
+announces via NIP-35 and reseeds it, publishing the mirror's own kind-30078
+peer-announce under the local identity. Mirror data lands in
+`<downloadDir>/follow-<pubkey prefix>`. Returns `{ "id": "f<N>" }`; `400` with
+`{ "error": … }` on a malformed pubkey, an unsupported route, or a duplicate
+follow. Follows persist and are restored on restart (resuming from
+checkpointed torrents).
+
+### `DELETE /api/follows/<id>`
+
+Unfollow: stops the mirror worker (joins its threads — may take a few seconds
+if a relay query is mid-flight). Mirrored data stays on disk. `204` on
+success, `404` if unknown.
+
 ### `POST /api/search`
 
 Body `{ "query": "<text>" }` (or `?q=<text>`). Searches configured Nostr relays
@@ -208,6 +232,8 @@ daemon does not read client frames; closing the socket ends the push.
 `DiscoverResult`: `{ id, title, hash, size, files, trackers, desc, verified, relays:[url], author, age }`.
 `Relay`: `{ url, state: "connected|connecting|unreachable|configured", net: "clearnet|tor", events }`.
 `Seed`: `{ id, name, visibility, onion|null, size, upTotal, up, leechers, ratio, relays }`.
+`Follow`: `{ id, npub, route, dir, seeding, downloading, failed, torrents:[FollowTorrent] }`.
+`FollowTorrent`: `{ name, hash, state: "starting|downloading|seeding|failed", pct, peers, down, up }`.
 `Identity`: `{ npub: "<bech32|''>" }` — the nsec is **never** serialized.
 `Settings`: `{ route, socks, relays:[url], downloadDir, listenPort, maxActive, peerLimit, publishNip35 }`.
 

--- a/docs/follow.md
+++ b/docs/follow.md
@@ -85,6 +85,16 @@ From then on the file is fetchable even with the laptop off — any client
 following the same npub (or downloading the magnet with `--nostr` on an
 i2p-routed daemon) finds the mirror's announce and pulls from it.
 
+## Desktop / daemon
+
+The desktop app has a **Following** tab with the same engine embedded in the
+daemon: paste an npub, pick `direct` or `i2p`, and each followed publisher
+shows its mirrored torrents with live phase (downloading → seeding) and rates.
+Follows persist in the daemon's SQLite state and are restored (resuming from
+the checkpointed torrents) on restart. The HTTP API is
+`GET/POST /api/follows` + `DELETE /api/follows/<id>` (see
+`docs/daemon-api.md`).
+
 ### Running as a service
 
 A systemd user unit (`%i` is the npub):

--- a/docs/follow.md
+++ b/docs/follow.md
@@ -1,0 +1,124 @@
+# `carl follow` — mirror a publisher
+
+`carl follow <npub>` turns a machine into a **mirror** of everything a Nostr
+pubkey publishes: it watches the publisher's NIP-35 torrent events (kind 2003),
+downloads every torrent it doesn't have yet, and re-seeds each one
+indefinitely — publishing its **own** kind-30078 peer-announce so leechers can
+dial the mirror too.
+
+The headline use case: seed files from your laptop, and a server elsewhere
+(e.g. on I2P) follows your npub and keeps everything alive even when the
+laptop is offline.
+
+```
+carl follow <npub|pubkey-hex> [--route direct|i2p] [--dir d]
+            [--i2p-sam host:port] [--external-ip ip] [--interval secs]
+```
+
+## How it works
+
+Per torrent, the mirror runs a two-phase, restart-safe lifecycle:
+
+1. **download** — an outbound-only session. With no local `.torrent` yet, the
+   metadata is bootstrapped over BEP 9 (magnet-style) from the publisher's
+   seed; peers come from kind-30078 peer-announces on the configured relays
+   and are re-queried whenever the transfer has zero peers. The resolved
+   `.torrent` is checkpointed to `<dir>/<infohash>.follow.torrent`, so a
+   restart resumes from disk (verifying existing pieces) instead of
+   re-bootstrapping.
+2. **seed** — a fresh session built from the resolved metainfo:
+   - `--route i2p`: same shape as `carl seed --i2p-seed` — a SAM session with
+     a **persisted destination** (stable `.b32.i2p` per torrent, key under
+     `<config>/i2p-seeds/`) feeds a loopback listener via `STREAM FORWARD`.
+   - `--route direct`: a public listener on a free port; with
+     `--external-ip <ip>` the mirror publishes a dialable IPv4 announce.
+
+   Either way the mirror publishes its peer-announce **under the local Nostr
+   identity** (run `carl nostr-keygen` once on the mirror host; `carl whoami`
+   prints the configured npub). Kind 30078 is parameterized-replaceable keyed
+   by infohash *per author*, so the publisher's announce and any number of
+   mirrors' announces coexist — leechers discover and dial all of them.
+
+The relay poll repeats every `--interval` seconds (default 60), so torrents
+published while the mirror is running are picked up live. Events are verified
+(Schnorr) and the author is checked against the followed pubkey — a malicious
+relay can't inject foreign torrents into the mirror.
+
+## Why Nostr (and not BEP 46)
+
+The closest BitTorrent-native analog is BEP 46 (mutable DHT pointers,
+`urn:btpk:`), but it carries only the *latest* item per key — no back-catalog —
+and has very sparse client support. A relay-stored event log gives the full
+catalog, works behind NAT/I2P, and survives the publisher being offline.
+RSS-style auto-download (autobrr/flexget) is the same architecture with a
+centralized feed; here the feed is the publisher's signed events on relays.
+
+## Demo: laptop seeds, server mirrors over I2P
+
+Prereqs on both machines: an I2P router with SAM enabled (default
+`127.0.0.1:7656`).
+
+On the **laptop** (publisher):
+
+```sh
+carl nostr-keygen            # once; `carl whoami` prints your npub
+carl create myfile.bin -o myfile.torrent
+carl seed myfile.torrent /path/to/dir --port 17901 --i2p-seed --nostr
+```
+
+On the **server** (mirror):
+
+```sh
+carl nostr-keygen            # the mirror's own identity, used for announces
+carl follow <your npub> --route i2p
+```
+
+The server discovers the kind-2003 event, downloads over I2P from the
+laptop's `.b32.i2p`, then logs:
+
+```
+info(follow): mirror seeding myfile.bin at <mirror>.b32.i2p
+info(follow): peer-announce published: 2/3 relays
+```
+
+From then on the file is fetchable even with the laptop off — any client
+following the same npub (or downloading the magnet with `--nostr` on an
+i2p-routed daemon) finds the mirror's announce and pulls from it.
+
+### Running as a service
+
+A systemd user unit (`%i` is the npub):
+
+```ini
+# ~/.config/systemd/user/carl-follow@.service
+[Unit]
+Description=carl follow mirror for %i (download + reseed over I2P)
+After=network-online.target
+
+[Service]
+ExecStart=%h/bin/carl follow %i --route i2p --interval 60
+StandardOutput=append:%h/carl-follow.log
+StandardError=append:%h/carl-follow.log
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+```sh
+systemctl --user enable --now carl-follow@<npub>.service
+loginctl enable-linger   # keep it running after logout (may need an admin)
+```
+
+## Limits / follow-ups
+
+- Routes: `direct` and `i2p`. A `tor` mirror needs per-torrent hidden
+  services via the ControlPort (the seeding machinery exists; wiring it into
+  follow is a follow-up).
+- NIP-09 deletions (kind 5) are not yet honored — a polite mirror should stop
+  seeding a torrent its publisher deleted.
+- A failed mirror thread (e.g. invalid checkpoint) is retried on the next
+  process restart, not in-session.
+- The mirror dials every announce for an infohash; it doesn't yet dedupe
+  endpoints across relays (harmless duplicate connections).

--- a/src/api.zig
+++ b/src/api.zig
@@ -184,6 +184,35 @@ pub const Seed = struct {
     relays: u32 = 0,
 };
 
+/// One torrent inside a followed publisher's mirror.
+pub const FollowTorrent = struct {
+    name: []const u8,
+    /// info-hash, lowercase hex (40 chars).
+    hash: []const u8,
+    /// "starting" | "downloading" | "seeding" | "failed"
+    state: []const u8,
+    pct: u8,
+    peers: u32,
+    down: u64,
+    up: u64,
+};
+
+/// A followed publisher: carl mirrors (downloads + reseeds) everything this
+/// pubkey announces via NIP-35. One row in the Following screen.
+pub const Follow = struct {
+    id: []const u8,
+    /// bech32 npub of the followed publisher.
+    npub: []const u8,
+    route: Route,
+    /// Mirror data directory.
+    dir: []const u8,
+    /// Aggregates over `torrents` (computed by the manager snapshot).
+    seeding: u32,
+    downloading: u32,
+    failed: u32,
+    torrents: []const FollowTorrent,
+};
+
 /// Local Nostr identity. The secret key (nsec) is NEVER serialized.
 pub const Identity = struct {
     /// bech32 npub, or empty if no key is configured.
@@ -472,6 +501,34 @@ pub fn writeSeed(j: *Json, s: Seed) Allocator.Error!void {
     try j.endObject();
 }
 
+pub fn writeFollowTorrent(j: *Json, t: FollowTorrent) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("name", t.name);
+    try j.keyString("hash", t.hash);
+    try j.keyString("state", t.state);
+    try j.keyNumber("pct", t.pct);
+    try j.keyNumber("peers", t.peers);
+    try j.keyNumber("down", t.down);
+    try j.keyNumber("up", t.up);
+    try j.endObject();
+}
+
+pub fn writeFollow(j: *Json, f: Follow) Allocator.Error!void {
+    try j.beginObject();
+    try j.keyString("id", f.id);
+    try j.keyString("npub", f.npub);
+    try j.keyString("route", f.route.jsonName());
+    try j.keyString("dir", f.dir);
+    try j.keyNumber("seeding", f.seeding);
+    try j.keyNumber("downloading", f.downloading);
+    try j.keyNumber("failed", f.failed);
+    try j.key("torrents");
+    try j.beginArray();
+    for (f.torrents) |t| try writeFollowTorrent(j, t);
+    try j.endArray();
+    try j.endObject();
+}
+
 pub fn writeIdentity(j: *Json, id: Identity) Allocator.Error!void {
     try j.beginObject();
     try j.keyString("npub", id.npub);
@@ -683,6 +740,38 @@ test "writeSeed: upTotal camelCase and float ratio" {
     try testing.expectEqual(@as(i64, 382), o.get("upTotal").?.integer);
     try testing.expectApproxEqAbs(@as(f64, 3.41), o.get("ratio").?.float, 0.001);
     try testing.expectEqualStrings("abc.onion", o.get("onion").?.string);
+}
+
+test "writeFollow: nested torrents round-trip through std.json" {
+    const allocator = testing.allocator;
+    const torrents = [_]FollowTorrent{
+        .{ .name = "a.bin", .hash = "aa" ** 20, .state = "seeding", .pct = 100, .peers = 2, .down = 0, .up = 1024 },
+        .{ .name = "b.bin", .hash = "bb" ** 20, .state = "downloading", .pct = 40, .peers = 1, .down = 2048, .up = 0 },
+    };
+    const f = Follow{
+        .id = "f1",
+        .npub = "npub1test",
+        .route = .i2p,
+        .dir = "/data/follow-abc",
+        .seeding = 1,
+        .downloading = 1,
+        .failed = 0,
+        .torrents = &torrents,
+    };
+    var j = Json.init(allocator);
+    defer j.deinit();
+    try writeFollow(&j, f);
+
+    var p = try parse(allocator, j.buf.items);
+    defer p.deinit();
+    const o = p.value.object;
+    try testing.expectEqualStrings("npub1test", o.get("npub").?.string);
+    try testing.expectEqualStrings("i2p", o.get("route").?.string);
+    try testing.expectEqual(@as(i64, 1), o.get("seeding").?.integer);
+    const ts = o.get("torrents").?.array.items;
+    try testing.expectEqual(@as(usize, 2), ts.len);
+    try testing.expectEqualStrings("seeding", ts[0].object.get("state").?.string);
+    try testing.expectEqual(@as(i64, 40), ts[1].object.get("pct").?.integer);
 }
 
 test "Route.parse round-trips names" {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -377,6 +377,7 @@ const Conn = struct {
             if (std.mem.eql(u8, path, "/api/relays")) return self.serveRelays();
             if (std.mem.eql(u8, path, "/api/identity")) return self.serveIdentity();
             if (std.mem.eql(u8, path, "/api/settings")) return self.serveSettings();
+            if (std.mem.eql(u8, path, "/api/follows")) return self.serveFollows();
             return self.sendStatus(.not_found);
         }
         if (std.mem.eql(u8, req.method, "POST")) {
@@ -385,12 +386,18 @@ const Conn = struct {
             if (std.mem.eql(u8, path, "/api/torrents")) return self.createTorrent(body);
             if (std.mem.eql(u8, path, "/api/search")) return self.search(req, body);
             if (std.mem.eql(u8, path, "/api/settings")) return self.updateSettings(body);
+            if (std.mem.eql(u8, path, "/api/follows")) return self.addFollow(body);
             return self.sendStatus(.not_found);
         }
         if (std.mem.eql(u8, req.method, "DELETE")) {
             if (std.mem.startsWith(u8, path, "/api/transfers/")) {
                 const id = path["/api/transfers/".len..];
                 const removed = self.daemon.manager.removeTransfer(id) catch false;
+                return self.sendStatus(if (removed) .no_content else .not_found);
+            }
+            if (std.mem.startsWith(u8, path, "/api/follows/")) {
+                const id = path["/api/follows/".len..];
+                const removed = self.daemon.manager.removeFollow(id) catch false;
                 return self.sendStatus(if (removed) .no_content else .not_found);
             }
             return self.sendStatus(.not_found);
@@ -479,7 +486,52 @@ const Conn = struct {
         try self.sendJson(.ok, j.buf.items);
     }
 
+    fn serveFollows(self: *Conn) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+        const follows = try self.daemon.manager.followsSnapshot(aa);
+        var j = api.Json.init(aa);
+        try j.beginArray();
+        for (follows) |f| try api.writeFollow(&j, f);
+        try j.endArray();
+        try self.sendJson(.ok, j.buf.items);
+    }
+
     // ----- POST/DELETE handlers -----
+
+    /// POST /api/follows — body is JSON {pubkey, route?}. `pubkey` is an npub
+    /// or 64-char hex; `route` is "direct"|"i2p" (default: the configured route
+    /// when it's one of those, else direct). Returns { id }.
+    fn addFollow(self: *Conn, body: []const u8) !void {
+        const a = self.daemon.allocator;
+        var arena = std.heap.ArenaAllocator.init(a);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        const parsed = std.json.parseFromSlice(std.json.Value, aa, body, .{}) catch
+            return self.sendStatus(.bad_request);
+        const obj = if (parsed.value == .object) parsed.value.object else return self.sendStatus(.bad_request);
+        const pubkey = strField(obj, "pubkey") orelse return self.sendStatus(.bad_request);
+        const default_route: api.Route = if (self.daemon.manager.cfg.route == .i2p) .i2p else .direct;
+        const route_val = api.Route.parse(strField(obj, "route") orelse "") orelse default_route;
+
+        const id = self.daemon.manager.addFollow(pubkey, route_val) catch |err| {
+            log.warn("addFollow failed: {}", .{err});
+            if (err == error.InvalidFollow) {
+                return self.sendError(.bad_request, "Invalid follow: expected an npub or 64-char hex pubkey not already followed, on the direct or i2p route.");
+            }
+            return self.sendStatus(.bad_request);
+        };
+        defer a.free(id);
+
+        var j = api.Json.init(aa);
+        try j.beginObject();
+        try j.keyString("id", id);
+        try j.endObject();
+        try self.sendJson(.ok, j.buf.items);
+    }
 
     fn addTransfer(self: *Conn, body: []const u8) !void {
         const a = self.daemon.allocator;
@@ -905,6 +957,10 @@ fn buildStateJson(arena: Allocator, daemon: *Daemon, relays: []const api.Relay, 
     try j.beginArray();
     for (seeds) |s| try api.writeSeed(&j, s);
     try j.endArray();
+    try j.key("follows");
+    try j.beginArray();
+    for (try daemon.manager.followsSnapshot(arena)) |f| try api.writeFollow(&j, f);
+    try j.endArray();
     try j.key("relays");
     try j.beginArray();
     for (relays) |r| try api.writeRelay(&j, r);
@@ -1160,6 +1216,7 @@ test "buildStateJson: produces the five top-level keys" {
     const o = p.value.object;
     try testing.expect(o.get("transfers").? == .array);
     try testing.expect(o.get("seeds").? == .array);
+    try testing.expect(o.get("follows").? == .array);
     try testing.expect(o.get("relays").? == .array);
     try testing.expect(o.get("identity").? == .object);
     try testing.expect(o.get("settings").? == .object);

--- a/src/follow.zig
+++ b/src/follow.zig
@@ -14,12 +14,17 @@
 //!      `<dir>/<infohash>.follow.torrent` so a restart resumes from disk.
 //!   2. seed — a fresh session built from the resolved metainfo. On the i2p
 //!      route this mirrors `carl seed --i2p-seed`: a SAM session with a
-//!      persisted destination (stable `.b32.i2p` across restarts) feeding a
-//!      loopback listener via STREAM FORWARD. On the direct route it binds a
-//!      public listener and announces `--external-ip` when given.
+//!      persisted destination (stable `.b32.i2p` per torrent, key under
+//!      `<config>/i2p-seeds/`) feeding a loopback listener via STREAM FORWARD.
+//!      On the direct route it binds a public listener and announces
+//!      `--external-ip` when given.
 //!
 //! Routes: `direct` and `i2p`. The tor route needs per-mirror hidden services
 //! (ControlPort wiring) and is a follow-up.
+//!
+//! Two consumers share this module: the blocking CLI entry (`run`, exits on
+//! SIGINT) and the daemon (`Mirror.create`/`start`/`stop`/`destroy`, one
+//! mirror per followed publisher, with `torrentsSnapshot` feeding the GUI).
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -50,6 +55,7 @@ pub const Error = error{
     Incomplete,
     InvalidTorrent,
     NoListener,
+    ThreadSpawnFailed,
     OutOfMemory,
 };
 
@@ -74,6 +80,29 @@ pub const Options = struct {
     /// Cap on concurrently mirrored torrents (defends against a flooding
     /// publisher filling the disk).
     max_mirrors: usize = 128,
+};
+
+/// Lifecycle of one mirrored torrent, for status displays.
+pub const Phase = enum(u8) {
+    starting,
+    downloading,
+    seeding,
+    failed,
+
+    pub fn jsonName(self: Phase) []const u8 {
+        return @tagName(self);
+    }
+};
+
+/// A snapshot row for one mirrored torrent (strings live in the caller's arena).
+pub const TorrentInfo = struct {
+    name: []const u8,
+    hash_hex: [40]u8,
+    phase: Phase,
+    pct: u8,
+    peers: u32,
+    down: u64,
+    up: u64,
 };
 
 /// Parse a follow target: an `npub1...` (NIP-19) or a 64-char hex pubkey.
@@ -101,11 +130,125 @@ pub fn hashFromSavedName(name: []const u8) ?[20]u8 {
     return hash;
 }
 
-const Mirror = struct {
+pub const Mirror = struct {
     allocator: Allocator,
+    /// Owned copies of the caller's option strings (`dir`, `i2p_sam`), so an
+    /// embedded mirror survives the caller mutating its config.
     opts: Options,
     mutex: std.Thread.Mutex = .{},
     transfers: std.ArrayList(*Transfer) = .empty,
+    /// Per-mirror stop request (the daemon stops one mirror without stopping
+    /// the process). The global `session_mod.shutdown_requested` still stops
+    /// everything (SIGINT).
+    stop_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    poll_thread: ?std.Thread = null,
+    pk_hex: [64]u8 = undefined,
+
+    /// Heap-allocate a mirror with owned copies of the option strings.
+    pub fn create(allocator: Allocator, opts: Options) Error!*Mirror {
+        const dir = allocator.dupe(u8, opts.dir) catch return error.OutOfMemory;
+        errdefer allocator.free(dir);
+        const sam = allocator.dupe(u8, opts.i2p_sam) catch return error.OutOfMemory;
+        errdefer allocator.free(sam);
+        const self = allocator.create(Mirror) catch return error.OutOfMemory;
+        self.* = .{ .allocator = allocator, .opts = opts };
+        self.opts.dir = dir;
+        self.opts.i2p_sam = sam;
+        secp.toHex(&opts.pubkey, &self.pk_hex);
+        return self;
+    }
+
+    /// Start the poll loop on its own thread. Resumes checkpointed torrents
+    /// first, then polls relays every `poll_interval_s`.
+    pub fn start(self: *Mirror) Error!void {
+        std.fs.cwd().makePath(self.opts.dir) catch {};
+        {
+            const npub = nip19.encode32(self.allocator, .npub, self.opts.pubkey) catch null;
+            defer if (npub) |n| self.allocator.free(n);
+            log.info("following {s} (route {s}, dir {s})", .{
+                npub orelse @as([]const u8, &self.pk_hex), @tagName(self.opts.route), self.opts.dir,
+            });
+        }
+        // The mirror publishes its own peer-announces; without a local identity
+        // it still seeds, but nobody can discover it. Say so once, up front.
+        if (nostr_config.readSecretKey(self.allocator)) |_| {} else |_| {
+            log.warn("no nostr identity found; mirrored seeds won't be announced. Run `carl nostr-keygen` first.", .{});
+        }
+        self.poll_thread = std.Thread.spawn(.{}, pollLoop, .{self}) catch return error.ThreadSpawnFailed;
+    }
+
+    /// Request stop and join every thread. Safe to call once; `destroy` calls
+    /// it too, so callers may simply destroy. Can block for up to a relay
+    /// timeout (~10s/relay) if a poll or discovery query is mid-flight.
+    pub fn stop(self: *Mirror) void {
+        self.stop_flag.store(true, .release);
+        // Kick live sessions out of their run loops (same cross-thread `running`
+        // signal the manager uses on its sessions).
+        self.mutex.lock();
+        for (self.transfers.items) |t| {
+            if (t.live_session) |s| s.running = false;
+        }
+        self.mutex.unlock();
+        if (self.poll_thread) |p| {
+            p.join();
+            self.poll_thread = null;
+        }
+        // After the poll thread is gone nothing appends to `transfers`; join
+        // the per-torrent threads without holding the mutex.
+        for (self.transfers.items) |t| {
+            if (t.thread) |th| {
+                th.join();
+                t.thread = null;
+            }
+        }
+    }
+
+    /// Stop (if still running) and free everything.
+    pub fn destroy(self: *Mirror) void {
+        self.stop();
+        for (self.transfers.items) |t| t.destroy();
+        self.transfers.deinit(self.allocator);
+        self.allocator.free(self.opts.dir);
+        self.allocator.free(self.opts.i2p_sam);
+        self.allocator.destroy(self);
+    }
+
+    /// True when this mirror (or the whole process) is shutting down.
+    pub fn stopping(self: *Mirror) bool {
+        return self.stop_flag.load(.acquire) or
+            session_mod.shutdown_requested.load(.acquire);
+    }
+
+    /// Snapshot every mirrored torrent into `arena` (names duped; progress
+    /// read from the live session when one is running).
+    pub fn torrentsSnapshot(self: *Mirror, arena: Allocator) Allocator.Error![]TorrentInfo {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const out = try arena.alloc(TorrentInfo, self.transfers.items.len);
+        for (self.transfers.items, 0..) |t, i| {
+            var info: TorrentInfo = .{
+                .name = try arena.dupe(u8, t.title),
+                .hash_hex = t.hash_hex,
+                .phase = @enumFromInt(t.phase.load(.monotonic)),
+                .pct = 0,
+                .peers = 0,
+                .down = 0,
+                .up = 0,
+            };
+            if (t.live_session) |s| {
+                const p = s.progressSnapshot();
+                info.pct = pctFromCounts(p.have, p.num_pieces);
+                info.peers = p.peers;
+                info.down = p.down_rate;
+                info.up = p.up_rate;
+                if (info.phase == .seeding) info.pct = 100;
+            } else if (info.phase == .seeding) {
+                info.pct = 100;
+            }
+            out[i] = info;
+        }
+        return out;
+    }
 
     fn count(self: *Mirror) usize {
         self.mutex.lock();
@@ -123,6 +266,12 @@ const Mirror = struct {
     }
 };
 
+fn pctFromCounts(have: u32, num_pieces: u32) u8 {
+    if (num_pieces == 0) return 0;
+    const p = @as(u64, have) * 100 / num_pieces;
+    return @intCast(@min(p, 100));
+}
+
 const Transfer = struct {
     allocator: Allocator,
     mirror: *Mirror,
@@ -135,6 +284,30 @@ const Transfer = struct {
     /// `<dir>/<infohash>.follow.torrent`. Owned.
     torrent_path: []u8,
     thread: ?std.Thread = null,
+    /// Current `Phase`, published for snapshots (written by the mirror thread).
+    phase: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(Phase.starting)),
+    /// The session currently driven by this transfer's thread, for cross-thread
+    /// progress reads and stop signaling. Guarded by `mirror.mutex`; cleared
+    /// before the session is deinitialized.
+    live_session: ?*session_mod.Session = null,
+
+    fn setPhase(self: *Transfer, p: Phase) void {
+        self.phase.store(@intFromEnum(p), .monotonic);
+    }
+
+    /// Publish `session` as this transfer's live session for the duration of a
+    /// phase. Returns a guard whose `release` clears it again.
+    fn publishSession(self: *Transfer, session: *session_mod.Session) void {
+        self.mirror.mutex.lock();
+        self.live_session = session;
+        self.mirror.mutex.unlock();
+    }
+
+    fn clearSession(self: *Transfer) void {
+        self.mirror.mutex.lock();
+        self.live_session = null;
+        self.mirror.mutex.unlock();
+    }
 
     fn destroy(self: *Transfer) void {
         const a = self.allocator;
@@ -150,30 +323,9 @@ fn sigintHandler(_: i32) callconv(.c) void {
     session_mod.shutdown_requested.store(true, .release);
 }
 
-fn shuttingDown() bool {
-    return session_mod.shutdown_requested.load(.acquire);
-}
-
-/// Run the follow loop until SIGINT. Blocks.
+/// Run the follow loop until SIGINT. Blocks. (CLI entry; the daemon embeds
+/// `Mirror` directly.)
 pub fn run(allocator: Allocator, opts: Options) !void {
-    std.fs.cwd().makePath(opts.dir) catch {};
-
-    var pk_hex: [64]u8 = undefined;
-    secp.toHex(&opts.pubkey, &pk_hex);
-    {
-        const npub = nip19.encode32(allocator, .npub, opts.pubkey) catch null;
-        defer if (npub) |n| allocator.free(n);
-        log.info("following {s} (route {s}, dir {s})", .{
-            npub orelse @as([]const u8, &pk_hex), @tagName(opts.route), opts.dir,
-        });
-    }
-
-    // The mirror publishes its own peer-announces; without a local identity it
-    // still seeds, but nobody can discover it. Say so once, up front.
-    if (nostr_config.readSecretKey(allocator)) |_| {} else |_| {
-        log.warn("no nostr identity found; mirrored seeds won't be announced. Run `carl nostr-keygen` first.", .{});
-    }
-
     const act = std.posix.Sigaction{
         .handler = .{ .handler = sigintHandler },
         .mask = std.posix.sigemptyset(),
@@ -181,29 +333,27 @@ pub fn run(allocator: Allocator, opts: Options) !void {
     };
     std.posix.sigaction(std.posix.SIG.INT, &act, null);
 
-    var mirror = Mirror{ .allocator = allocator, .opts = opts };
-    defer {
-        // Threads observe the shutdown flag inside their session loops; join
-        // them before freeing anything they borrow.
-        for (mirror.transfers.items) |t| {
-            if (t.thread) |th| th.join();
-            t.destroy();
-        }
-        mirror.transfers.deinit(allocator);
+    const mirror = try Mirror.create(allocator, opts);
+    defer mirror.destroy();
+    try mirror.start();
+
+    while (!mirror.stopping()) {
+        std.Thread.sleep(200 * std.time.ns_per_ms);
     }
+    log.info("shutting down; stopping {d} mirror(s)...", .{mirror.count()});
+}
 
-    resumeSaved(&mirror);
-
-    while (!shuttingDown()) {
-        pollOnce(&mirror, &pk_hex);
-        // Sleep the poll interval in small slices so Ctrl-C lands promptly.
+fn pollLoop(mirror: *Mirror) void {
+    resumeSaved(mirror);
+    while (!mirror.stopping()) {
+        pollOnce(mirror);
+        // Sleep the poll interval in small slices so stop lands promptly.
         var slept_ms: u64 = 0;
-        while (!shuttingDown() and slept_ms < opts.poll_interval_s * 1000) {
+        while (!mirror.stopping() and slept_ms < mirror.opts.poll_interval_s * 1000) {
             std.Thread.sleep(200 * std.time.ns_per_ms);
             slept_ms += 200;
         }
     }
-    log.info("shutting down; stopping {d} mirror(s)...", .{mirror.count()});
 }
 
 /// Re-add every checkpointed torrent in the mirror dir, so a restart resumes
@@ -225,13 +375,13 @@ fn resumeSaved(mirror: *Mirror) void {
 
 /// One relay sweep: fetch the publisher's kind-2003 events and start a mirror
 /// for every infohash we don't have yet.
-fn pollOnce(mirror: *Mirror, pk_hex: *const [64]u8) void {
+fn pollOnce(mirror: *Mirror) void {
     const a = mirror.allocator;
 
     const relay_urls = nostr_config.readRelays(a) catch return;
     defer nostr_config.freeRelays(a, relay_urls);
 
-    var authors_arr = [_][]const u8{pk_hex};
+    var authors_arr = [_][]const u8{&mirror.pk_hex};
     const filter: nostr.Filter = .{
         .authors = &authors_arr,
         .kinds = &[_]u32{nip35.kind_torrent},
@@ -240,7 +390,7 @@ fn pollOnce(mirror: *Mirror, pk_hex: *const [64]u8) void {
 
     var started: usize = 0;
     for (relay_urls) |url| {
-        if (shuttingDown()) return;
+        if (mirror.stopping()) return;
         var r = relay_mod.Relay.connect(a, url, null) catch |err| {
             log.debug("relay {s}: {}", .{ url, err });
             continue;
@@ -340,6 +490,7 @@ fn startTransfer(
     t.thread = std.Thread.spawn(.{}, mirrorThread, .{t}) catch {
         // Leave the (threadless) entry registered: removing it would require
         // unwinding ownership mid-list; the next restart retries it.
+        t.setPhase(.failed);
         log.warn("could not spawn mirror thread for {s}", .{&t.hash_hex});
         return;
     };
@@ -347,7 +498,8 @@ fn startTransfer(
 
 fn mirrorThread(t: *Transfer) void {
     mirrorTorrent(t) catch |err| {
-        if (shuttingDown()) return;
+        if (t.mirror.stopping()) return;
+        t.setPhase(.failed);
         log.warn("mirror {s} ({s}) stopped: {}", .{ &t.hash_hex, t.title, err });
     };
 }
@@ -358,7 +510,7 @@ fn mirrorTorrent(t: *Transfer) Error!void {
     // Phase 1 — get the data (and the resolved metainfo) onto disk.
     const mi = try ensureDownloaded(t);
     defer mi.deinit(a);
-    if (shuttingDown()) return;
+    if (t.mirror.stopping()) return;
 
     log.info("mirror {s}: download complete, starting reseed", .{t.title});
 
@@ -376,6 +528,16 @@ fn ensureDownloaded(t: *Transfer) Error!metainfo_mod.Metainfo {
         defer a.free(data);
         const mi = metainfo_mod.parse(a, data) catch return error.InvalidTorrent;
         errdefer mi.deinit(a);
+        // The checkpoint's name beats the (possibly empty) NIP-35 title for
+        // status displays — resumed transfers start with an empty title.
+        if (t.title.len == 0 and mi.name.len > 0) {
+            if (a.dupe(u8, mi.name)) |dup| {
+                t.mirror.mutex.lock();
+                a.free(t.title);
+                t.title = dup;
+                t.mirror.mutex.unlock();
+            } else |_| {}
+        }
         try runDownload(t, mi, false);
         return mi;
     }
@@ -480,8 +642,12 @@ fn runDownload(t: *Transfer, mi: metainfo_mod.Metainfo, magnet: bool) Error!void
     // Phase 1 must RETURN on completion (phase 2 builds the real seed session).
     session.seed_after_complete = false;
     session.setPeerDiscovery(&session, rediscoverPeersCb);
-    discoverPeers(a, t.info_hash, &session);
 
+    t.publishSession(&session);
+    defer t.clearSession();
+    t.setPhase(.downloading);
+
+    discoverPeers(a, t.info_hash, &session);
     session.run() catch return error.SessionFailed;
 
     if (magnet) {
@@ -531,6 +697,10 @@ fn seedForever(t: *Transfer, mi: metainfo_mod.Metainfo) Error!void {
                 return error.SamFailed;
             };
 
+            t.publishSession(&session);
+            defer t.clearSession();
+            t.setPhase(.seeding);
+
             publishAnnounce(a, t.info_hash, .{ .i2p_host = host });
             log.info("mirror seeding {s} at {s}", .{ t.title, host });
             session.run() catch return error.SessionFailed;
@@ -541,6 +711,10 @@ fn seedForever(t: *Transfer, mi: metainfo_mod.Metainfo) Error!void {
                 return error.SessionInitFailed;
             defer session.deinit();
             if (session.listener == null) return error.NoListener;
+
+            t.publishSession(&session);
+            defer t.clearSession();
+            t.setPhase(.seeding);
 
             if (opts.external_ip) |ip| {
                 publishAnnounce(a, t.info_hash, .{ .ipv4 = .{ .ip = ip, .port = port } });
@@ -615,7 +789,7 @@ fn discoverPeers(a: Allocator, info_hash: [20]u8, session: *session_mod.Session)
 
     var added: usize = 0;
     for (relay_urls) |url| {
-        if (!session.running or shuttingDown()) return;
+        if (!session.running or session_mod.shutdown_requested.load(.acquire)) return;
         var r = relay_mod.Relay.connect(a, url, null) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
@@ -741,4 +915,30 @@ test "placeholderMetainfo carries title and NIP-35 trackers" {
 test "pickFreePort returns a usable port" {
     const port = pickFreePort(true) orelse return error.TestUnexpectedResult;
     try std.testing.expect(port > 0);
+}
+
+test "Mirror create/start/stop lifecycle with no relays reachable" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+
+    const mirror = try Mirror.create(a, .{
+        .pubkey = .{7} ** 32,
+        .dir = dir,
+        .poll_interval_s = 1,
+    });
+    // No start(): create/destroy alone must not leak or hang.
+    try std.testing.expectEqual(@as(usize, 0), mirror.count());
+    var arena = std.heap.ArenaAllocator.init(a);
+    defer arena.deinit();
+    const snap = try mirror.torrentsSnapshot(arena.allocator());
+    try std.testing.expectEqual(@as(usize, 0), snap.len);
+    mirror.destroy();
+}
+
+test "Phase jsonName matches enum tags" {
+    try std.testing.expectEqualStrings("downloading", Phase.downloading.jsonName());
+    try std.testing.expectEqualStrings("seeding", Phase.seeding.jsonName());
 }

--- a/src/follow.zig
+++ b/src/follow.zig
@@ -1,0 +1,744 @@
+//! `carl follow` — mirror every torrent a Nostr pubkey publishes (NIP-35).
+//!
+//! A follow node subscribes to a publisher's kind-2003 torrent events
+//! (NIP-35), downloads each torrent it hasn't mirrored yet (BEP 9 magnet-style
+//! bootstrap, peers discovered via kind-30078 peer-announces), and re-seeds it
+//! indefinitely — publishing its OWN kind-30078 peer-announce under the local
+//! Nostr identity so other leechers can dial the mirror too. The result: seed
+//! a file on a laptop, and a follow server elsewhere picks it up and keeps it
+//! alive.
+//!
+//! Two-phase lifecycle per torrent, both restart-safe:
+//!   1. download — outbound-only session (metadata via BEP 9 when no .torrent
+//!      is saved yet); the resolved `.torrent` is checkpointed to
+//!      `<dir>/<infohash>.follow.torrent` so a restart resumes from disk.
+//!   2. seed — a fresh session built from the resolved metainfo. On the i2p
+//!      route this mirrors `carl seed --i2p-seed`: a SAM session with a
+//!      persisted destination (stable `.b32.i2p` across restarts) feeding a
+//!      loopback listener via STREAM FORWARD. On the direct route it binds a
+//!      public listener and announces `--external-ip` when given.
+//!
+//! Routes: `direct` and `i2p`. The tor route needs per-mirror hidden services
+//! (ControlPort wiring) and is a follow-up.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const nostr = @import("nostr.zig");
+const nip19 = @import("nip19.zig");
+const nip35 = @import("nip35.zig");
+const relay_mod = @import("relay.zig");
+const nostr_config = @import("nostr_config.zig");
+const peer_announce = @import("peer_announce.zig");
+const session_mod = @import("session.zig");
+const metainfo_mod = @import("metainfo.zig");
+const extension = @import("extension.zig");
+const i2p_sam = @import("i2p_sam.zig");
+const i2p_seed = @import("i2p_seed.zig");
+const secp = @import("secp.zig");
+const api = @import("api.zig");
+
+const log = std.log.scoped(.follow);
+
+pub const Error = error{
+    InvalidPubkey,
+    UnsupportedRoute,
+    BadSamBridge,
+    SamFailed,
+    SessionInitFailed,
+    SessionFailed,
+    Incomplete,
+    InvalidTorrent,
+    NoListener,
+    OutOfMemory,
+};
+
+/// Suffix for checkpointed torrents in the mirror dir. The basename is the
+/// 40-char infohash hex, so `resumeSaved` can recover the hash from the name.
+pub const torrent_suffix = ".follow.torrent";
+
+pub const Options = struct {
+    /// The publisher to follow (x-only pubkey).
+    pubkey: [32]u8,
+    /// Mirror transport: `direct` or `i2p`.
+    route: api.Route = .direct,
+    /// Where downloaded data + checkpointed torrents live.
+    dir: []const u8,
+    /// SAM bridge for the i2p route.
+    i2p_sam: []const u8 = "127.0.0.1:7656",
+    /// Routable IPv4 to put in direct-route peer-announces. Without it a
+    /// direct mirror still seeds, but publishes no dialable announce.
+    external_ip: ?[4]u8 = null,
+    /// Seconds between relay polls for new kind-2003 events.
+    poll_interval_s: u64 = 60,
+    /// Cap on concurrently mirrored torrents (defends against a flooding
+    /// publisher filling the disk).
+    max_mirrors: usize = 128,
+};
+
+/// Parse a follow target: an `npub1...` (NIP-19) or a 64-char hex pubkey.
+pub fn parsePubkeyArg(arg: []const u8) Error![32]u8 {
+    if (std.mem.startsWith(u8, arg, "npub1")) {
+        const dec = nip19.decode32(arg) catch return error.InvalidPubkey;
+        if (dec.kind != .npub) return error.InvalidPubkey;
+        return dec.data;
+    }
+    if (arg.len == 64) {
+        var pk: [32]u8 = undefined;
+        secp.fromHex(arg, &pk) catch return error.InvalidPubkey;
+        return pk;
+    }
+    return error.InvalidPubkey;
+}
+
+/// Recover the infohash from a checkpointed torrent's filename
+/// (`<40 hex>.follow.torrent`), or null if the name isn't one of ours.
+pub fn hashFromSavedName(name: []const u8) ?[20]u8 {
+    if (name.len != 40 + torrent_suffix.len) return null;
+    if (!std.mem.endsWith(u8, name, torrent_suffix)) return null;
+    var hash: [20]u8 = undefined;
+    secp.fromHex(name[0..40], &hash) catch return null;
+    return hash;
+}
+
+const Mirror = struct {
+    allocator: Allocator,
+    opts: Options,
+    mutex: std.Thread.Mutex = .{},
+    transfers: std.ArrayList(*Transfer) = .empty,
+
+    fn count(self: *Mirror) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.transfers.items.len;
+    }
+
+    fn hasInfoHash(self: *Mirror, hash: [20]u8) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        for (self.transfers.items) |t| {
+            if (std.mem.eql(u8, &t.info_hash, &hash)) return true;
+        }
+        return false;
+    }
+};
+
+const Transfer = struct {
+    allocator: Allocator,
+    mirror: *Mirror,
+    info_hash: [20]u8,
+    hash_hex: [40]u8,
+    /// Display title from the NIP-35 event (may be empty). Owned.
+    title: []u8,
+    /// Tracker URLs from the NIP-35 event. Owned.
+    trackers: [][]u8,
+    /// `<dir>/<infohash>.follow.torrent`. Owned.
+    torrent_path: []u8,
+    thread: ?std.Thread = null,
+
+    fn destroy(self: *Transfer) void {
+        const a = self.allocator;
+        a.free(self.title);
+        for (self.trackers) |t| a.free(t);
+        a.free(self.trackers);
+        a.free(self.torrent_path);
+        a.destroy(self);
+    }
+};
+
+fn sigintHandler(_: i32) callconv(.c) void {
+    session_mod.shutdown_requested.store(true, .release);
+}
+
+fn shuttingDown() bool {
+    return session_mod.shutdown_requested.load(.acquire);
+}
+
+/// Run the follow loop until SIGINT. Blocks.
+pub fn run(allocator: Allocator, opts: Options) !void {
+    std.fs.cwd().makePath(opts.dir) catch {};
+
+    var pk_hex: [64]u8 = undefined;
+    secp.toHex(&opts.pubkey, &pk_hex);
+    {
+        const npub = nip19.encode32(allocator, .npub, opts.pubkey) catch null;
+        defer if (npub) |n| allocator.free(n);
+        log.info("following {s} (route {s}, dir {s})", .{
+            npub orelse @as([]const u8, &pk_hex), @tagName(opts.route), opts.dir,
+        });
+    }
+
+    // The mirror publishes its own peer-announces; without a local identity it
+    // still seeds, but nobody can discover it. Say so once, up front.
+    if (nostr_config.readSecretKey(allocator)) |_| {} else |_| {
+        log.warn("no nostr identity found; mirrored seeds won't be announced. Run `carl nostr-keygen` first.", .{});
+    }
+
+    const act = std.posix.Sigaction{
+        .handler = .{ .handler = sigintHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.INT, &act, null);
+
+    var mirror = Mirror{ .allocator = allocator, .opts = opts };
+    defer {
+        // Threads observe the shutdown flag inside their session loops; join
+        // them before freeing anything they borrow.
+        for (mirror.transfers.items) |t| {
+            if (t.thread) |th| th.join();
+            t.destroy();
+        }
+        mirror.transfers.deinit(allocator);
+    }
+
+    resumeSaved(&mirror);
+
+    while (!shuttingDown()) {
+        pollOnce(&mirror, &pk_hex);
+        // Sleep the poll interval in small slices so Ctrl-C lands promptly.
+        var slept_ms: u64 = 0;
+        while (!shuttingDown() and slept_ms < opts.poll_interval_s * 1000) {
+            std.Thread.sleep(200 * std.time.ns_per_ms);
+            slept_ms += 200;
+        }
+    }
+    log.info("shutting down; stopping {d} mirror(s)...", .{mirror.count()});
+}
+
+/// Re-add every checkpointed torrent in the mirror dir, so a restart resumes
+/// (and re-seeds) without waiting for relays.
+fn resumeSaved(mirror: *Mirror) void {
+    var dir = std.fs.cwd().openDir(mirror.opts.dir, .{ .iterate = true }) catch return;
+    defer dir.close();
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const hash = hashFromSavedName(entry.name) orelse continue;
+        if (mirror.hasInfoHash(hash)) continue;
+        startTransfer(mirror, hash, "", &.{}) catch |err| {
+            log.warn("could not resume saved torrent {s}: {}", .{ entry.name, err });
+        };
+        log.info("resuming saved torrent {s}", .{entry.name});
+    }
+}
+
+/// One relay sweep: fetch the publisher's kind-2003 events and start a mirror
+/// for every infohash we don't have yet.
+fn pollOnce(mirror: *Mirror, pk_hex: *const [64]u8) void {
+    const a = mirror.allocator;
+
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var authors_arr = [_][]const u8{pk_hex};
+    const filter: nostr.Filter = .{
+        .authors = &authors_arr,
+        .kinds = &[_]u32{nip35.kind_torrent},
+        .limit = 500,
+    };
+
+    var started: usize = 0;
+    for (relay_urls) |url| {
+        if (shuttingDown()) return;
+        var r = relay_mod.Relay.connect(a, url, null) catch |err| {
+            log.debug("relay {s}: {}", .{ url, err });
+            continue;
+        };
+        defer r.deinit();
+        const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
+            .timeout_ms = 10_000,
+            .max_events = 500,
+            .verify_signatures = true,
+        }) catch continue;
+        defer {
+            for (events) |e| e.deinit(a);
+            a.free(events);
+        }
+        for (events) |ev| {
+            // The authors filter is relay-side and untrusted; the signature
+            // check only proves the event matches its *claimed* pubkey. Make
+            // sure that pubkey is the one we follow.
+            if (!std.mem.eql(u8, &ev.pubkey, &mirror.opts.pubkey)) continue;
+            const entry = nip35.parseEvent(a, ev) catch continue;
+            defer entry.deinit(a);
+            if (mirror.hasInfoHash(entry.info_hash)) continue;
+            if (mirror.count() >= mirror.opts.max_mirrors) {
+                log.warn("mirror cap ({d}) reached; skipping new torrents", .{mirror.opts.max_mirrors});
+                return;
+            }
+            startTransfer(mirror, entry.info_hash, entry.title, entry.trackers) catch |err| {
+                log.warn("could not start mirror for {s}: {}", .{ entry.title, err });
+                continue;
+            };
+            started += 1;
+            log.info("new torrent from publisher: {s}", .{entry.title});
+        }
+    }
+    if (started > 0) log.info("started {d} new mirror(s)", .{started});
+}
+
+/// Create the Transfer, register it (so dedupe sees it immediately), and spawn
+/// its mirror thread.
+fn startTransfer(
+    mirror: *Mirror,
+    info_hash: [20]u8,
+    title: []const u8,
+    trackers: []const []const u8,
+) Error!void {
+    const a = mirror.allocator;
+
+    var hash_hex: [40]u8 = undefined;
+    secp.toHex(&info_hash, &hash_hex);
+
+    const title_dup = a.dupe(u8, title) catch return error.OutOfMemory;
+    errdefer a.free(title_dup);
+
+    var tr_list: std.ArrayList([]u8) = .empty;
+    errdefer {
+        for (tr_list.items) |s| a.free(s);
+        tr_list.deinit(a);
+    }
+    for (trackers) |tr| {
+        const dup = a.dupe(u8, tr) catch return error.OutOfMemory;
+        tr_list.append(a, dup) catch {
+            a.free(dup);
+            return error.OutOfMemory;
+        };
+    }
+    const tr_owned = tr_list.toOwnedSlice(a) catch return error.OutOfMemory;
+    errdefer {
+        for (tr_owned) |s| a.free(s);
+        a.free(tr_owned);
+    }
+
+    const torrent_path = std.fmt.allocPrint(a, "{s}/{s}{s}", .{ mirror.opts.dir, &hash_hex, torrent_suffix }) catch
+        return error.OutOfMemory;
+    errdefer a.free(torrent_path);
+
+    const t = a.create(Transfer) catch return error.OutOfMemory;
+    t.* = .{
+        .allocator = a,
+        .mirror = mirror,
+        .info_hash = info_hash,
+        .hash_hex = hash_hex,
+        .title = title_dup,
+        .trackers = tr_owned,
+        .torrent_path = torrent_path,
+    };
+
+    mirror.mutex.lock();
+    mirror.transfers.append(a, t) catch {
+        mirror.mutex.unlock();
+        // Raw destroy: the owned pieces are still freed by the errdefers above
+        // (t.destroy() here would double-free them).
+        a.destroy(t);
+        return error.OutOfMemory;
+    };
+    mirror.mutex.unlock();
+
+    t.thread = std.Thread.spawn(.{}, mirrorThread, .{t}) catch {
+        // Leave the (threadless) entry registered: removing it would require
+        // unwinding ownership mid-list; the next restart retries it.
+        log.warn("could not spawn mirror thread for {s}", .{&t.hash_hex});
+        return;
+    };
+}
+
+fn mirrorThread(t: *Transfer) void {
+    mirrorTorrent(t) catch |err| {
+        if (shuttingDown()) return;
+        log.warn("mirror {s} ({s}) stopped: {}", .{ &t.hash_hex, t.title, err });
+    };
+}
+
+fn mirrorTorrent(t: *Transfer) Error!void {
+    const a = t.allocator;
+
+    // Phase 1 — get the data (and the resolved metainfo) onto disk.
+    const mi = try ensureDownloaded(t);
+    defer mi.deinit(a);
+    if (shuttingDown()) return;
+
+    log.info("mirror {s}: download complete, starting reseed", .{t.title});
+
+    // Phase 2 — reseed forever (until shutdown).
+    try seedForever(t, mi);
+}
+
+/// Make sure the torrent's data is fully on disk. Returns the resolved
+/// metainfo (caller owns). Uses the checkpointed `.torrent` when present
+/// (restart path); otherwise bootstraps metadata over BEP 9 and checkpoints it.
+fn ensureDownloaded(t: *Transfer) Error!metainfo_mod.Metainfo {
+    const a = t.allocator;
+
+    if (std.fs.cwd().readFileAlloc(a, t.torrent_path, 10 * 1024 * 1024) catch null) |data| {
+        defer a.free(data);
+        const mi = metainfo_mod.parse(a, data) catch return error.InvalidTorrent;
+        errdefer mi.deinit(a);
+        try runDownload(t, mi, false);
+        return mi;
+    }
+
+    // No checkpoint yet: magnet-style bootstrap from the NIP-35 entry.
+    {
+        const mi = try placeholderMetainfo(a, t);
+        defer mi.deinit(a);
+        try runDownload(t, mi, true);
+    }
+    const data = std.fs.cwd().readFileAlloc(a, t.torrent_path, 10 * 1024 * 1024) catch
+        return error.InvalidTorrent;
+    defer a.free(data);
+    return metainfo_mod.parse(a, data) catch error.InvalidTorrent;
+}
+
+/// Build the placeholder metainfo a magnet-style session starts from: just the
+/// display name and the NIP-35 trackers; geometry arrives with the metadata.
+fn placeholderMetainfo(a: Allocator, t: *Transfer) Error!metainfo_mod.Metainfo {
+    const name = a.dupe(u8, if (t.title.len > 0) t.title else "unknown") catch return error.OutOfMemory;
+    errdefer a.free(name);
+
+    const path0 = a.alloc([]const u8, 1) catch return error.OutOfMemory;
+    errdefer a.free(path0);
+    path0[0] = a.dupe(u8, name) catch return error.OutOfMemory;
+    errdefer a.free(path0[0]);
+
+    const files = a.alloc(metainfo_mod.FileInfo, 1) catch return error.OutOfMemory;
+    errdefer a.free(files);
+    files[0] = .{ .length = 0, .path = path0 };
+
+    var announce_list: ?[]const []const []const u8 = null;
+    errdefer if (announce_list) |tiers| {
+        for (tiers) |tier| {
+            for (tier) |tr| a.free(tr);
+            a.free(tier);
+        }
+        a.free(tiers);
+    };
+    if (t.trackers.len > 0) {
+        const tier = a.alloc([]const u8, t.trackers.len) catch return error.OutOfMemory;
+        var filled: usize = 0;
+        errdefer {
+            for (tier[0..filled]) |tr| a.free(tr);
+            a.free(tier);
+        }
+        while (filled < t.trackers.len) : (filled += 1) {
+            tier[filled] = a.dupe(u8, t.trackers[filled]) catch return error.OutOfMemory;
+        }
+        const tiers = a.alloc([]const []const u8, 1) catch return error.OutOfMemory;
+        tiers[0] = tier;
+        announce_list = tiers;
+    }
+
+    const announce = a.dupe(u8, if (t.trackers.len > 0) t.trackers[0] else "") catch return error.OutOfMemory;
+    errdefer a.free(announce);
+
+    return .{
+        .announce = announce,
+        .announce_list = announce_list,
+        .name = name,
+        .piece_length = 0,
+        .pieces = &.{},
+        .files = files,
+        .comment = null,
+        .creation_date = null,
+        .created_by = null,
+        .raw_info = &.{},
+        .url_list = null,
+    };
+}
+
+/// Phase 1: run an outbound-only download session to completion. With
+/// `magnet`, the session bootstraps metadata over BEP 9 and we checkpoint the
+/// resolved `.torrent` (even on an incomplete run, so the next attempt skips
+/// the bootstrap). Peers come from kind-30078 announces, re-queried by the
+/// session whenever it has none.
+fn runDownload(t: *Transfer, mi: metainfo_mod.Metainfo, magnet: bool) Error!void {
+    const a = t.allocator;
+    const opts = t.mirror.opts;
+
+    var i2p_session: ?i2p_sam.Session = null;
+    defer if (i2p_session) |*s| s.deinit();
+    if (opts.route == .i2p) {
+        const bridge = i2p_sam.parseUrl(opts.i2p_sam) catch return error.BadSamBridge;
+        i2p_session = i2p_sam.Session.create(a, bridge, "carl-follow") catch |err| {
+            log.warn("i2p SAM session failed: {} (is the router running with SAM enabled?)", .{err});
+            return error.SamFailed;
+        };
+    }
+    const i2p_ptr: ?*i2p_sam.Session = if (i2p_session) |*s| s else null;
+
+    const port = pickFreePort(false) orelse 6881;
+    var session = session_mod.Session.init(a, mi, opts.dir, .download, port, null, .any, false, i2p_ptr, false) catch
+        return error.SessionInitFailed;
+    defer session.deinit();
+    if (magnet) {
+        session.info_hash = t.info_hash;
+        session.metadata_download = extension.MetadataDownload.init(a, t.info_hash);
+        session.metadata_only = true;
+    }
+    // Phase 1 must RETURN on completion (phase 2 builds the real seed session).
+    session.seed_after_complete = false;
+    session.setPeerDiscovery(&session, rediscoverPeersCb);
+    discoverPeers(a, t.info_hash, &session);
+
+    session.run() catch return error.SessionFailed;
+
+    if (magnet) {
+        if (session.copyTorrent(a)) |blob| {
+            defer a.free(blob);
+            writeFileAtomic(t.torrent_path, blob) catch |err| {
+                log.warn("could not checkpoint {s}: {}", .{ t.torrent_path, err });
+            };
+        }
+    }
+
+    const p = session.progressSnapshot();
+    if (!(p.num_pieces > 0 and p.have >= p.num_pieces)) return error.Incomplete;
+}
+
+/// Phase 2: build the seed session for the route and run it until shutdown.
+fn seedForever(t: *Transfer, mi: metainfo_mod.Metainfo) Error!void {
+    const a = t.allocator;
+    const opts = t.mirror.opts;
+
+    switch (opts.route) {
+        .i2p => {
+            const bridge = i2p_sam.parseUrl(opts.i2p_sam) catch return error.BadSamBridge;
+            const port = pickFreePort(true) orelse return error.NoListener;
+
+            // Persisted destination keyed by infohash → stable `.b32.i2p`, so
+            // the announce survives restarts (same scheme as `carl seed`).
+            const persisted = i2p_seed.load(a, &t.hash_hex) catch null;
+            defer if (persisted) |p| a.free(p);
+            const dest: i2p_sam.Session.Dest = if (persisted) |p| .{ .priv = p } else .transient;
+            var sam = i2p_sam.Session.createWithDest(a, bridge, "carl-follow-seed", dest) catch |err| {
+                log.warn("i2p SAM seed session failed: {}", .{err});
+                return error.SamFailed;
+            };
+            defer sam.deinit();
+            if (persisted == null) i2p_seed.save(a, &t.hash_hex, sam.destination);
+
+            const host = i2p_sam.b32Address(a, sam.destination) catch return error.SamFailed;
+            defer a.free(host);
+
+            var session = session_mod.Session.init(a, mi, opts.dir, .seed, port, null, .loopback, false, &sam, true) catch
+                return error.SessionInitFailed;
+            defer session.deinit();
+            if (session.listener == null) return error.NoListener;
+            sam.forward(port) catch {
+                log.warn("i2p STREAM FORWARD failed; mirror would be unreachable", .{});
+                return error.SamFailed;
+            };
+
+            publishAnnounce(a, t.info_hash, .{ .i2p_host = host });
+            log.info("mirror seeding {s} at {s}", .{ t.title, host });
+            session.run() catch return error.SessionFailed;
+        },
+        .direct => {
+            const port = pickFreePort(false) orelse return error.NoListener;
+            var session = session_mod.Session.init(a, mi, opts.dir, .seed, port, null, .any, false, null, false) catch
+                return error.SessionInitFailed;
+            defer session.deinit();
+            if (session.listener == null) return error.NoListener;
+
+            if (opts.external_ip) |ip| {
+                publishAnnounce(a, t.info_hash, .{ .ipv4 = .{ .ip = ip, .port = port } });
+            } else {
+                log.warn("no --external-ip; reseeding {s} without a dialable announce", .{t.title});
+            }
+            log.info("mirror seeding {s} on port {d}", .{ t.title, port });
+            session.run() catch return error.SessionFailed;
+        },
+        else => return error.UnsupportedRoute,
+    }
+}
+
+const AnnounceEndpoint = union(enum) {
+    i2p_host: []const u8,
+    ipv4: struct { ip: [4]u8, port: u16 },
+};
+
+/// Publish our kind-30078 peer-announce for a mirrored torrent under the local
+/// identity. Best-effort: without a key (or with all relays down) the mirror
+/// still seeds; it's just not discoverable, which was warned about at startup.
+fn publishAnnounce(a: Allocator, info_hash: [20]u8, endpoint: AnnounceEndpoint) void {
+    const sk = nostr_config.readSecretKey(a) catch return;
+    const pk = secp.publicKeyFromSecret(sk) catch return;
+
+    const ev = switch (endpoint) {
+        .i2p_host => |host| peer_announce.buildI2p(a, sk, pk, info_hash, host, 0),
+        .ipv4 => |v| peer_announce.build(a, sk, pk, info_hash, v.ip, v.port),
+    } catch |err| {
+        log.warn("could not build peer-announce: {}", .{err});
+        return;
+    };
+    defer ev.deinit(a);
+
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var acks: usize = 0;
+    for (relay_urls) |url| {
+        var r = relay_mod.Relay.connect(a, url, null) catch continue;
+        defer r.deinit();
+        if (relay_mod.publishAndWait(a, &r, ev, 5_000)) acks += 1;
+    }
+    log.info("peer-announce published: {d}/{d} relays", .{ acks, relay_urls.len });
+}
+
+/// `Session.PeerDiscovery` callback (session thread): re-query announces when
+/// the transfer has zero peers.
+fn rediscoverPeersCb(ctx: *anyopaque) void {
+    const session: *session_mod.Session = @ptrCast(@alignCast(ctx));
+    discoverPeers(session.allocator, session.info_hash, session);
+}
+
+/// Query relays for kind-30078 peer-announces on `info_hash` and connect every
+/// endpoint the session's transport can reach: IPv4 on the direct route, I2P
+/// destinations over the SAM transport. (Onion peers need a SOCKS proxy the
+/// follow routes don't carry; skipped.)
+fn discoverPeers(a: Allocator, info_hash: [20]u8, session: *session_mod.Session) void {
+    var ih_hex: [40]u8 = undefined;
+    secp.toHex(&info_hash, &ih_hex);
+
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var values_arr = [_][]const u8{&ih_hex};
+    var tag_filters = [_]nostr.Filter.TagFilter{.{ .letter = 'd', .values = &values_arr }};
+    const filter: nostr.Filter = .{
+        .kinds = &[_]u32{peer_announce.kind_peer_announce},
+        .tags = &tag_filters,
+        .limit = 200,
+    };
+
+    var added: usize = 0;
+    for (relay_urls) |url| {
+        if (!session.running or shuttingDown()) return;
+        var r = relay_mod.Relay.connect(a, url, null) catch continue;
+        defer r.deinit();
+        const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
+            .timeout_ms = 10_000,
+            .max_events = 200,
+            .verify_signatures = true,
+        }) catch continue;
+        defer {
+            for (events) |e| e.deinit(a);
+            a.free(events);
+        }
+        for (events) |ev| {
+            const ann = peer_announce.parse(ev) catch continue;
+            if (!std.mem.eql(u8, &ann.info_hash, &info_hash)) continue;
+            if (added >= 50) break;
+            switch (ann.endpoint) {
+                .ipv4 => |ep| {
+                    if (session.i2p != null) continue; // no clearnet on i2p
+                    const addr = std.net.Address.initIp4(ep.ip, ep.port);
+                    session.connectDirectPeer(addr) catch continue;
+                    added += 1;
+                },
+                .onion => continue,
+                .i2p => |ep| {
+                    if (session.i2p == null) continue;
+                    session.connectI2pPeer(ep.host, ep.port) catch continue;
+                    added += 1;
+                },
+            }
+        }
+    }
+    if (added > 0) log.info("connected {d} peer(s) from nostr announces", .{added});
+}
+
+/// Discover a free port by binding port 0 (loopback for forwarded i2p seeds,
+/// 0.0.0.0 for public listeners). Tiny TOCTOU window before the session
+/// re-binds; callers treat a later bind failure as fatal for the mirror.
+fn pickFreePort(loopback: bool) ?u16 {
+    const ip: [4]u8 = if (loopback) .{ 127, 0, 0, 1 } else .{ 0, 0, 0, 0 };
+    var server = std.net.Address.initIp4(ip, 0).listen(.{ .reuse_address = true }) catch return null;
+    defer server.deinit();
+    return server.listen_address.getPort();
+}
+
+/// Write via a temp file + rename so a crash mid-write never leaves a torn
+/// checkpoint (a torn `.torrent` would wedge the restart path).
+fn writeFileAtomic(path: []const u8, data: []const u8) !void {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const tmp = try std.fmt.bufPrint(&buf, "{s}.tmp", .{path});
+    {
+        var f = try std.fs.cwd().createFile(tmp, .{ .truncate = true });
+        defer f.close();
+        try f.writeAll(data);
+    }
+    try std.fs.cwd().rename(tmp, path);
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+test "parsePubkeyArg accepts hex and npub, rejects junk" {
+    var pk: [32]u8 = undefined;
+    for (&pk, 0..) |*b, i| b.* = @intCast(i);
+    var hex: [64]u8 = undefined;
+    secp.toHex(&pk, &hex);
+
+    const from_hex = try parsePubkeyArg(&hex);
+    try std.testing.expectEqualSlices(u8, &pk, &from_hex);
+
+    const npub = try nip19.encode32(std.testing.allocator, .npub, pk);
+    defer std.testing.allocator.free(npub);
+    const from_npub = try parsePubkeyArg(npub);
+    try std.testing.expectEqualSlices(u8, &pk, &from_npub);
+
+    try std.testing.expectError(error.InvalidPubkey, parsePubkeyArg("not-a-key"));
+    try std.testing.expectError(error.InvalidPubkey, parsePubkeyArg("npub1invalid"));
+    // nsec must be rejected even though it decodes as valid bech32.
+    const nsec = try nip19.encode32(std.testing.allocator, .nsec, pk);
+    defer std.testing.allocator.free(nsec);
+    try std.testing.expectError(error.InvalidPubkey, parsePubkeyArg(nsec));
+}
+
+test "hashFromSavedName round-trips and rejects other files" {
+    var hash: [20]u8 = undefined;
+    @memset(&hash, 0xAB);
+    var hex: [40]u8 = undefined;
+    secp.toHex(&hash, &hex);
+
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "{s}{s}", .{ &hex, torrent_suffix });
+    const got = hashFromSavedName(name) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualSlices(u8, &hash, &got);
+
+    try std.testing.expect(hashFromSavedName("data.bin") == null);
+    try std.testing.expect(hashFromSavedName("short.follow.torrent") == null);
+    // Right length, bad hex.
+    const bad = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.follow.torrent";
+    try std.testing.expect(hashFromSavedName(bad) == null);
+}
+
+test "placeholderMetainfo carries title and NIP-35 trackers" {
+    const a = std.testing.allocator;
+    var mirror = Mirror{ .allocator = a, .opts = .{ .pubkey = .{0} ** 32, .dir = "." } };
+    var trackers_arr = [_][]u8{ @constCast("http://t1/announce"), @constCast("udp://t2:1337") };
+    var t = Transfer{
+        .allocator = a,
+        .mirror = &mirror,
+        .info_hash = .{0xCD} ** 20,
+        .hash_hex = .{'c'} ** 40,
+        .title = @constCast("My File"),
+        .trackers = &trackers_arr,
+        .torrent_path = @constCast("unused"),
+    };
+    const mi = try placeholderMetainfo(a, &t);
+    defer mi.deinit(a);
+    try std.testing.expectEqualStrings("My File", mi.name);
+    try std.testing.expectEqualStrings("http://t1/announce", mi.announce);
+    try std.testing.expect(mi.announce_list != null);
+    try std.testing.expectEqual(@as(usize, 2), mi.announce_list.?[0].len);
+}
+
+test "pickFreePort returns a usable port" {
+    const port = pickFreePort(true) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(port > 0);
+}

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -30,6 +30,7 @@ pub const manager = @import("manager.zig");
 pub const daemon = @import("daemon.zig");
 pub const state = @import("state.zig");
 pub const workdir = @import("workdir.zig");
+pub const follow = @import("follow.zig");
 
 test {
     _ = bencode;
@@ -63,5 +64,6 @@ test {
     _ = daemon;
     _ = state;
     _ = workdir;
+    _ = follow;
     _ = @import("integration_test.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -123,8 +123,16 @@ pub fn main() !void {
         const limit = parseUnsignedFlag(args[3..], "--limit", 50);
         const single_relay = parseFlag(args[3..], "--relay");
         try cmdSearch(allocator, stdout, args[2], limit, single_relay, parseProxy(args[3..]));
+    } else if (std.mem.eql(u8, command, "follow")) {
+        if (args.len < 3) {
+            log.err("usage: carl follow <npub|pubkey-hex> [--route direct|i2p] [--dir d] [--i2p-sam host:port] [--external-ip ip] [--interval secs]", .{});
+            std.process.exit(1);
+        }
+        try cmdFollow(allocator, args[2], args[3..]);
     } else if (std.mem.eql(u8, command, "nostr-keygen")) {
         try cmdNostrKeygen(allocator, stdout);
+    } else if (std.mem.eql(u8, command, "whoami")) {
+        try cmdWhoami(allocator, stdout);
     } else if (std.mem.eql(u8, command, "daemon")) {
         try cmdDaemon(allocator, stdout, args[2..]);
     } else {
@@ -163,7 +171,16 @@ fn printUsage() void {
         \\           -o defaults to <name>.torrent in the current directory.
         \\  search <query> [--limit n] [--relay <wss://...>]
         \\           search nostr relays for kind-2003 torrent events
+        \\  follow <npub|pubkey-hex> [--route direct|i2p] [--dir d] [--i2p-sam host:port]
+        \\         [--external-ip ip] [--interval secs]
+        \\           mirror a publisher: download every torrent they announce on
+        \\           nostr (NIP-35) and reseed it, publishing our own
+        \\           peer-announce so leechers can dial this mirror.
+        \\           --route i2p: download AND reseed over I2P (stable .b32.i2p
+        \\           per torrent); --external-ip enables dialable direct announces.
+        \\           --dir defaults to <work dir>/follow-<pubkey prefix>.
         \\  nostr-keygen                                     generate a fresh nostr key
+        \\  whoami                                           print the configured identity's npub
         \\  daemon [--port p] [--bt-port p] [--route direct|proxy|tor|i2p] [--socks url]
         \\         [--i2p-sam host:port] [--download-dir d] [--token tok] [--parent-pid pid]
         \\         [--tor-control host:port] [--tor-cookie path] [--tor-onion-port p]
@@ -874,6 +891,61 @@ fn printSearchResult(stdout: anytype, entry: carl.nip35.TorrentEntry) !void {
 }
 
 // -------------------------------------------------------------------------
+// `carl follow` — mirror everything a Nostr pubkey publishes
+// -------------------------------------------------------------------------
+
+fn cmdFollow(allocator: std.mem.Allocator, pubkey_arg: []const u8, extra: []const [:0]u8) !void {
+    const pubkey = carl.follow.parsePubkeyArg(pubkey_arg) catch {
+        log.err("invalid pubkey '{s}' (expected npub1... or 64-char hex)", .{pubkey_arg});
+        std.process.exit(1);
+    };
+
+    const route_str = parseFlag(extra, "--route") orelse "direct";
+    const route = carl.api.Route.parse(route_str) orelse {
+        log.err("invalid --route '{s}' (expected direct|i2p)", .{route_str});
+        std.process.exit(1);
+    };
+    if (route != .direct and route != .i2p) {
+        log.err("carl follow supports --route direct|i2p (tor/proxy mirrors are a follow-up)", .{});
+        std.process.exit(1);
+    }
+
+    var external_ip: ?[4]u8 = null;
+    if (parseFlag(extra, "--external-ip")) |s| {
+        external_ip = parseIpv4(s) orelse {
+            log.err("invalid --external-ip: {s}", .{s});
+            std.process.exit(1);
+        };
+        if (!carl.peer_announce.isRoutable(external_ip.?)) {
+            log.err("--external-ip {s} is not routable; refusing to publish peer-announces", .{s});
+            std.process.exit(1);
+        }
+    }
+
+    // Default mirror dir: <workdir>/follow-<pubkey prefix>, so different
+    // followed publishers never mix data and the workdir stays reseedable.
+    var dir_owned: ?[]u8 = null;
+    defer if (dir_owned) |d| allocator.free(d);
+    const dir = parseFlag(extra, "--dir") orelse blk: {
+        var pk_hex: [64]u8 = undefined;
+        carl.secp.toHex(&pubkey, &pk_hex);
+        const base = try carl.workdir.ensure(allocator);
+        defer allocator.free(base);
+        dir_owned = try std.fmt.allocPrint(allocator, "{s}/follow-{s}", .{ base, pk_hex[0..12] });
+        break :blk @as([]const u8, dir_owned.?);
+    };
+
+    try carl.follow.run(allocator, .{
+        .pubkey = pubkey,
+        .route = route,
+        .dir = dir,
+        .i2p_sam = parseFlag(extra, "--i2p-sam") orelse "127.0.0.1:7656",
+        .external_ip = external_ip,
+        .poll_interval_s = parseUnsignedFlag(extra, "--interval", 60),
+    });
+}
+
+// -------------------------------------------------------------------------
 // `carl nostr-keygen`
 // -------------------------------------------------------------------------
 
@@ -899,6 +971,26 @@ fn cmdNostrKeygen(allocator: std.mem.Allocator, stdout: anytype) !void {
     try stdout.print("wrote nsec (secret key) to your config dir\n", .{});
     try stdout.print("npub: {s}\n", .{npub});
     try stdout.print("\nkeep your nsec private. anyone with it can publish as you.\n", .{});
+}
+
+// -------------------------------------------------------------------------
+// `carl whoami` — print the configured identity's npub
+// -------------------------------------------------------------------------
+
+fn cmdWhoami(allocator: std.mem.Allocator, stdout: anytype) !void {
+    const sk = carl.nostr_config.readSecretKey(allocator) catch {
+        log.err("no nostr identity configured; run `carl nostr-keygen` first", .{});
+        std.process.exit(1);
+    };
+    const pk = carl.secp.publicKeyFromSecret(sk) catch {
+        log.err("could not derive public key", .{});
+        std.process.exit(1);
+    };
+    const npub = try carl.nip19.encode32(allocator, .npub, pk);
+    defer allocator.free(npub);
+    var pk_hex: [64]u8 = undefined;
+    carl.secp.toHex(&pk, &pk_hex);
+    try stdout.print("npub: {s}\nhex:  {s}\n", .{ npub, &pk_hex });
 }
 
 // -------------------------------------------------------------------------

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -32,9 +32,11 @@ const seeding = @import("seeding.zig");
 const tor_control = @import("tor_control.zig");
 const state_mod = @import("state.zig");
 const workdir = @import("workdir.zig");
+const follow_mod = @import("follow.zig");
 const nostr_config = @import("nostr_config.zig");
 const nostr_mod = @import("nostr.zig");
 const secp = @import("secp.zig");
+const nip19 = @import("nip19.zig");
 const api = @import("api.zig");
 
 const log = std.log.scoped(.manager);
@@ -55,6 +57,9 @@ pub const Error = error{
     /// than creating a seed nobody can reach.
     TorControlFailed,
     NotFound,
+    /// A follow request was invalid: a malformed pubkey, an unsupported route
+    /// (follows run on `direct` or `i2p`), or the publisher is already followed.
+    InvalidFollow,
 } || Allocator.Error;
 
 /// Daemon-level configuration mirrored to the Settings screen. String fields
@@ -167,11 +172,38 @@ const ManagedTransfer = struct {
     }
 };
 
+/// One followed publisher: the embedded mirror worker plus the metadata the
+/// daemon needs to list and persist it.
+const FollowHandle = struct {
+    allocator: Allocator,
+    id: []u8,
+    pubkey: [32]u8,
+    pk_hex: [64]u8,
+    npub: []u8,
+    route: api.Route,
+    dir: []u8,
+    mirror: *follow_mod.Mirror,
+
+    /// Stop the mirror (joins its threads — can block on in-flight relay
+    /// queries) and free everything. Call without holding the manager mutex.
+    fn destroy(self: *FollowHandle) void {
+        self.mirror.destroy();
+        self.allocator.free(self.id);
+        self.allocator.free(self.npub);
+        self.allocator.free(self.dir);
+        self.allocator.destroy(self);
+    }
+};
+
 pub const Manager = struct {
     allocator: Allocator,
     mutex: std.Thread.Mutex = .{},
     transfers: std.ArrayList(*ManagedTransfer) = .empty,
     next_id: usize = 1,
+    /// Followed publishers (mirror workers). Guarded by `mutex` like
+    /// `transfers`; handles are destroyed outside the lock (joins threads).
+    follows: std.ArrayList(*FollowHandle) = .empty,
+    next_follow_id: usize = 1,
     cfg: Config,
     /// While replaying persisted state on startup, suppress per-add persistence
     /// (we write once at the end of `restore`).
@@ -217,6 +249,8 @@ pub const Manager = struct {
 
     pub fn deinit(self: *Manager) void {
         // No lock: deinit happens after the server loop has stopped.
+        for (self.follows.items) |f| f.destroy();
+        self.follows.deinit(self.allocator);
         for (self.transfers.items) |mt| mt.destroy();
         self.transfers.deinit(self.allocator);
         for (self.retained_specs.items) |s| self.allocator.free(s.source);
@@ -570,6 +604,153 @@ pub const Manager = struct {
     }
 
     // -----------------------------------------------------------------------
+    // Follows (mirror a Nostr publisher)
+    // -----------------------------------------------------------------------
+
+    /// Follow a publisher: spawn a mirror worker that downloads + reseeds
+    /// everything `pubkey_str` (npub or 64-char hex) announces via NIP-35.
+    /// Follows run on `direct` or `i2p`. Returns the new follow id (owned by
+    /// the caller).
+    pub fn addFollow(self: *Manager, pubkey_str: []const u8, route: api.Route) Error![]u8 {
+        const pubkey = follow_mod.parsePubkeyArg(pubkey_str) catch return error.InvalidFollow;
+        if (route != .direct and route != .i2p) return error.InvalidFollow;
+
+        var pk_hex: [64]u8 = undefined;
+        secp.toHex(&pubkey, &pk_hex);
+
+        self.mutex.lock();
+        for (self.follows.items) |f| {
+            if (std.mem.eql(u8, &f.pubkey, &pubkey)) {
+                self.mutex.unlock();
+                return error.InvalidFollow; // already following
+            }
+        }
+        const id_num = self.next_follow_id;
+        self.next_follow_id += 1;
+        // Mirror data lives beside regular downloads, namespaced by publisher.
+        const dir = std.fmt.allocPrint(self.allocator, "{s}/follow-{s}", .{ self.cfg.download_dir, pk_hex[0..12] }) catch {
+            self.mutex.unlock();
+            return error.OutOfMemory;
+        };
+        const sam = self.allocator.dupe(u8, self.cfg.i2p_sam) catch {
+            self.mutex.unlock();
+            self.allocator.free(dir);
+            return error.OutOfMemory;
+        };
+        self.mutex.unlock();
+        defer self.allocator.free(sam);
+
+        // Once the handle owns these, its `destroy` frees them; the errdefers
+        // below are disarmed so a later failure can't double-free.
+        var handle_owned = false;
+        errdefer if (!handle_owned) self.allocator.free(dir);
+
+        const id = std.fmt.allocPrint(self.allocator, "f{d}", .{id_num}) catch return error.OutOfMemory;
+        errdefer if (!handle_owned) self.allocator.free(id);
+        const npub = nip19.encode32(self.allocator, .npub, pubkey) catch return error.OutOfMemory;
+        errdefer if (!handle_owned) self.allocator.free(npub);
+
+        const mirror = follow_mod.Mirror.create(self.allocator, .{
+            .pubkey = pubkey,
+            .route = route,
+            .dir = dir,
+            .i2p_sam = sam,
+        }) catch return error.OutOfMemory;
+        errdefer if (!handle_owned) mirror.destroy();
+        mirror.start() catch return error.SessionInitFailed;
+
+        const handle = self.allocator.create(FollowHandle) catch return error.OutOfMemory;
+        handle.* = .{
+            .allocator = self.allocator,
+            .id = id,
+            .pubkey = pubkey,
+            .pk_hex = pk_hex,
+            .npub = npub,
+            .route = route,
+            .dir = dir,
+            .mirror = mirror,
+        };
+        handle_owned = true;
+
+        self.mutex.lock();
+        self.follows.append(self.allocator, handle) catch {
+            self.mutex.unlock();
+            handle.destroy(); // frees id/npub/dir + stops the mirror
+            return error.OutOfMemory;
+        };
+        self.mutex.unlock();
+
+        self.persist();
+        return self.allocator.dupe(u8, id);
+    }
+
+    /// Stop and remove the follow with `id`. Returns true if found. Joins the
+    /// mirror's threads, so this can block on an in-flight relay query.
+    pub fn removeFollow(self: *Manager, id: []const u8) Error!bool {
+        self.mutex.lock();
+        var found: ?*FollowHandle = null;
+        var idx: usize = 0;
+        for (self.follows.items, 0..) |f, i| {
+            if (std.mem.eql(u8, f.id, id)) {
+                found = f;
+                idx = i;
+                break;
+            }
+        }
+        if (found) |_| _ = self.follows.orderedRemove(idx);
+        self.mutex.unlock();
+
+        if (found) |f| {
+            f.destroy(); // joins threads outside the lock
+            self.persist();
+            return true;
+        }
+        return false;
+    }
+
+    /// Snapshot all follows (with their mirrored torrents) into `arena`.
+    pub fn followsSnapshot(self: *Manager, arena: Allocator) Allocator.Error![]api.Follow {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const out = try arena.alloc(api.Follow, self.follows.items.len);
+        for (self.follows.items, 0..) |f, i| {
+            const infos = try f.mirror.torrentsSnapshot(arena);
+            const torrents = try arena.alloc(api.FollowTorrent, infos.len);
+            var seeding_n: u32 = 0;
+            var downloading_n: u32 = 0;
+            var failed_n: u32 = 0;
+            for (infos, 0..) |info, k| {
+                switch (info.phase) {
+                    .seeding => seeding_n += 1,
+                    .downloading, .starting => downloading_n += 1,
+                    .failed => failed_n += 1,
+                }
+                torrents[k] = .{
+                    .name = info.name,
+                    .hash = try arena.dupe(u8, &info.hash_hex),
+                    .state = info.phase.jsonName(),
+                    .pct = info.pct,
+                    .peers = info.peers,
+                    .down = info.down,
+                    .up = info.up,
+                };
+            }
+            out[i] = .{
+                .id = try arena.dupe(u8, f.id),
+                .npub = try arena.dupe(u8, f.npub),
+                .route = f.route,
+                .dir = try arena.dupe(u8, f.dir),
+                .seeding = seeding_n,
+                .downloading = downloading_n,
+                .failed = failed_n,
+                .torrents = torrents,
+            };
+        }
+        return out;
+    }
+
+    // -----------------------------------------------------------------------
     // Snapshots
     // -----------------------------------------------------------------------
 
@@ -717,9 +898,14 @@ pub const Manager = struct {
                 .nostr = s.nostr,
             }) catch break;
         }
+        var follow_specs: std.ArrayList(state_mod.FollowSpec) = .empty;
+        for (self.follows.items) |f| {
+            const pk = aa.dupe(u8, &f.pk_hex) catch break;
+            follow_specs.append(aa, .{ .pubkey = pk, .route = f.route }) catch break;
+        }
         self.mutex.unlock();
 
-        state_mod.save(self.allocator, route, dir, specs.items) catch |e| {
+        state_mod.save(self.allocator, route, dir, specs.items, follow_specs.items) catch |e| {
             log.warn("failed to persist daemon state: {}", .{e});
         };
     }
@@ -801,12 +987,25 @@ pub const Manager = struct {
                 }
             }
         }
+        // Re-spawn persisted follows. A failed re-add (bad key, OOM) is logged
+        // and dropped — unlike transfers there's no transient transport setup
+        // here; the mirror itself retries its relays/peers forever once spawned.
+        var followed: usize = 0;
+        for (st.follows) |f| {
+            if (self.addFollow(f.pubkey, f.route)) |id| {
+                self.allocator.free(id);
+                followed += 1;
+            } else |e| {
+                log.warn("restore: could not re-follow '{s}': {}", .{ f.pubkey, e });
+            }
+        }
         self.restoring.store(false, .release);
         // Persisting here is safe even after failures: every failed spec was just
         // retained, and `persist` re-includes `retained_specs` alongside the live
         // set, so nothing is erased.
         self.persist();
         if (restored > 0) log.info("restored {d} transfer(s) from saved state", .{restored});
+        if (followed > 0) log.info("restored {d} follow(s) from saved state", .{followed});
         if (retained > 0) log.info("kept {d} saved transfer(s) that could not be re-added", .{retained});
     }
 

--- a/src/state.zig
+++ b/src/state.zig
@@ -44,6 +44,9 @@ const SCHEMA =
     \\CREATE TABLE IF NOT EXISTS transfers(
     \\  id INTEGER PRIMARY KEY AUTOINCREMENT,
     \\  kind TEXT NOT NULL, source TEXT NOT NULL, route TEXT NOT NULL, nostr INTEGER NOT NULL);
+    \\CREATE TABLE IF NOT EXISTS follows(
+    \\  id INTEGER PRIMARY KEY AUTOINCREMENT,
+    \\  pubkey TEXT NOT NULL, route TEXT NOT NULL);
 ;
 
 pub const Error = error{ DbOpen, DbExec, DbPrepare } || Allocator.Error;
@@ -68,15 +71,26 @@ pub const TransferSpec = struct {
     nostr: bool,
 };
 
+/// A followed publisher to re-create on restart: the pubkey (64-char hex) and
+/// the mirror route. The mirror dir is derived from the download dir + pubkey,
+/// so it's not persisted.
+pub const FollowSpec = struct {
+    pubkey: []const u8,
+    route: api.Route,
+};
+
 pub const State = struct {
     route: api.Route,
     download_dir: []const u8,
     transfers: []const TransferSpec,
+    follows: []const FollowSpec = &.{},
 
     pub fn deinit(self: State, a: Allocator) void {
         a.free(self.download_dir);
         for (self.transfers) |t| a.free(t.source);
         a.free(self.transfers);
+        for (self.follows) |f| a.free(f.pubkey);
+        a.free(self.follows);
     }
 };
 
@@ -111,12 +125,13 @@ pub fn save(
     route: api.Route,
     download_dir: []const u8,
     specs: []const TransferSpec,
+    follows: []const FollowSpec,
 ) !void {
     const dir = try nostr_config.ensureConfigDir(a);
     defer a.free(dir);
     const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
     defer a.free(path);
-    try saveTo(path, route, download_dir, specs);
+    try saveTo(path, route, download_dir, specs, follows);
 }
 
 fn saveTo(
@@ -124,6 +139,7 @@ fn saveTo(
     route: api.Route,
     download_dir: []const u8,
     specs: []const TransferSpec,
+    follows: []const FollowSpec,
 ) Error!void {
     const db = try open(path);
     defer _ = sqlite3_close(db);
@@ -146,6 +162,18 @@ fn saveTo(
         bindText(stmt, 3, s.route.jsonName());
         _ = sqlite3_bind_int(stmt, 4, if (s.nostr) 1 else 0);
         if (sqlite3_step(stmt) != SQLITE_DONE) return error.DbExec;
+    }
+
+    try exec(db, "DELETE FROM follows");
+    var fstmt: ?*Stmt = null;
+    const fsql = "INSERT INTO follows(pubkey,route) VALUES(?,?)";
+    if (sqlite3_prepare_v2(db, fsql, @intCast(fsql.len), &fstmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(fstmt);
+    for (follows) |f| {
+        _ = sqlite3_reset(fstmt);
+        bindText(fstmt, 1, f.pubkey);
+        bindText(fstmt, 2, f.route.jsonName());
+        if (sqlite3_step(fstmt) != SQLITE_DONE) return error.DbExec;
     }
 
     try exec(db, "COMMIT");
@@ -191,7 +219,33 @@ fn loadFrom(a: Allocator, path: [:0]const u8) Error!State {
         try list.append(a, .{ .kind = kind, .source = src, .route = r, .nostr = nostr });
     }
 
-    return .{ .route = route, .download_dir = download_dir, .transfers = try list.toOwnedSlice(a) };
+    var follows: std.ArrayList(FollowSpec) = .empty;
+    errdefer {
+        for (follows.items) |f| a.free(f.pubkey);
+        follows.deinit(a);
+    }
+    var fstmt: ?*Stmt = null;
+    const fsql = "SELECT pubkey,route FROM follows ORDER BY id";
+    if (sqlite3_prepare_v2(db, fsql, @intCast(fsql.len), &fstmt, null) != SQLITE_OK) return error.DbPrepare;
+    defer _ = sqlite3_finalize(fstmt);
+    while (sqlite3_step(fstmt) == SQLITE_ROW) {
+        const pk = try a.dupe(u8, columnText(fstmt, 0));
+        errdefer a.free(pk);
+        const r = api.Route.parse(columnText(fstmt, 1)) orelse .direct;
+        try follows.append(a, .{ .pubkey = pk, .route = r });
+    }
+
+    const transfers = try list.toOwnedSlice(a);
+    errdefer {
+        for (transfers) |t| a.free(t.source);
+        a.free(transfers);
+    }
+    return .{
+        .route = route,
+        .download_dir = download_dir,
+        .transfers = transfers,
+        .follows = try follows.toOwnedSlice(a),
+    };
 }
 
 /// Read just the persisted `downloadDir` setting, or null when there is no
@@ -267,7 +321,7 @@ test "sqlite save/load round-trips settings + transfers" {
         .{ .kind = .download, .source = "magnet:?xt=urn:btih:abc", .route = .tor, .nostr = true },
         .{ .kind = .seed, .source = "/data/movie.tar", .route = .direct, .nostr = false },
     };
-    try saveTo(path, .proxy, "/home/u/dl", &specs);
+    try saveTo(path, .proxy, "/home/u/dl", &specs, &.{});
 
     const st = try loadFrom(a, path);
     defer st.deinit(a);
@@ -292,14 +346,43 @@ test "sqlite save replaces prior transfers (no accumulation)" {
     defer a.free(path);
 
     const one = [_]TransferSpec{.{ .kind = .download, .source = "a", .route = .direct, .nostr = false }};
-    try saveTo(path, .direct, "/x", &one);
-    try saveTo(path, .tor, "/y", &one); // overwrite
+    try saveTo(path, .direct, "/x", &one, &.{});
+    try saveTo(path, .tor, "/y", &one, &.{}); // overwrite
 
     const st = try loadFrom(a, path);
     defer st.deinit(a);
     try testing.expectEqual(@as(usize, 1), st.transfers.len);
     try testing.expectEqual(api.Route.tor, st.route);
     try testing.expectEqualStrings("/y", st.download_dir);
+}
+
+test "sqlite save/load round-trips follows" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+    const path = try std.fmt.allocPrintSentinel(a, "{s}/carl.db", .{dir}, 0);
+    defer a.free(path);
+
+    const follows = [_]FollowSpec{
+        .{ .pubkey = "16e8c40c332df0746a15d1e8c0a569af59d8da3ac0bafbe8f1c3f23156c44313", .route = .i2p },
+        .{ .pubkey = "ab" ** 32, .route = .direct },
+    };
+    try saveTo(path, .direct, "/dl", &.{}, &follows);
+
+    const st = try loadFrom(a, path);
+    defer st.deinit(a);
+    try testing.expectEqual(@as(usize, 2), st.follows.len);
+    try testing.expectEqualStrings(follows[0].pubkey, st.follows[0].pubkey);
+    try testing.expectEqual(api.Route.i2p, st.follows[0].route);
+    try testing.expectEqual(api.Route.direct, st.follows[1].route);
+
+    // Re-save with none: the table is rebuilt, not accumulated.
+    try saveTo(path, .direct, "/dl", &.{}, &.{});
+    const st2 = try loadFrom(a, path);
+    defer st2.deinit(a);
+    try testing.expectEqual(@as(usize, 0), st2.follows.len);
 }
 
 test "loadDownloadDirFrom reads the setting; empty/missing read as unset" {
@@ -314,11 +397,11 @@ test "loadDownloadDirFrom reads the setting; empty/missing read as unset" {
     // Fresh DB (schema only): no setting yet.
     try testing.expect(loadDownloadDirFrom(a, path) == null);
 
-    try saveTo(path, .direct, "/home/u/dl", &.{});
+    try saveTo(path, .direct, "/home/u/dl", &.{}, &.{});
     const got = loadDownloadDirFrom(a, path) orelse return error.TestUnexpectedResult;
     defer a.free(got);
     try testing.expectEqualStrings("/home/u/dl", got);
 
-    try saveTo(path, .direct, "", &.{});
+    try saveTo(path, .direct, "", &.{}, &.{});
     try testing.expect(loadDownloadDirFrom(a, path) == null);
 }


### PR DESCRIPTION
## What

New `carl follow <npub>` command: a **mirror/seed-server mode**. It watches a publisher's NIP-35 torrent events (kind 2003), downloads every torrent it doesn't have yet, and re-seeds each one indefinitely — publishing the mirror's own kind-30078 peer-announce under the local Nostr identity so leechers can dial the mirror too.

Headline use case: seed files from a laptop; a server on I2P follows the laptop's npub and keeps everything alive when the laptop goes offline.

## How

Per torrent, a restart-safe two-phase lifecycle (`src/follow.zig`):

1. **download** — outbound-only session; metadata bootstrapped over BEP 9 when no `.torrent` is checkpointed yet; peers from kind-30078 announces (re-queried at zero peers via the existing `PeerDiscovery` hook). The resolved torrent is checkpointed to `<dir>/<infohash>.follow.torrent` so restarts resume from disk.
2. **seed** — fresh session from the resolved metainfo. `--route i2p` mirrors `carl seed --i2p-seed`: persisted SAM destination (stable `.b32.i2p` per torrent) + `STREAM FORWARD` into a loopback listener. `--route direct` binds a public listener and announces `--external-ip` when given.

Events are Schnorr-verified **and author-checked** against the followed pubkey, so a malicious relay can't inject foreign torrents. Kind-30078 is parameterized-replaceable per author, so publisher + N mirrors' announces coexist.

Also adds `carl whoami` (prints the configured identity's npub — what you hand to a mirror) and `docs/follow.md` (usage, design rationale vs BEP 46, systemd user unit).

## Tested

- `zig build test` green (new unit tests: pubkey arg parsing npub/hex/nsec-rejection, checkpoint filename round-trip, placeholder metainfo, port picking).
- Local 3-node e2e over I2P: publisher seeds → follower mirrors (checksum-verified) → publisher killed → a third node downloads **from the mirror only**. Full rehost loop proven.
- Real demo: desktop (macOS) seeds over I2P, Hetzner server (Debian, systemd user unit) follows the desktop npub, downloads over I2P and reseeds at its own stable `.b32.i2p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)