### PR TITLE
Fix duplicate block requests and make the request pipeline adaptive (~16x faster on high-latency links)

### DIFF
--- a/src/peer.zig
+++ b/src/peer.zig
@@ -14,7 +14,25 @@ pub const PeerState = enum {
     disconnected,
 };
 
-pub const max_pipeline: u32 = 5;
+/// Request-pipeline sizing. The pipeline must hold roughly
+/// `rate * RTT / block_size` outstanding requests to keep the link full
+/// (bandwidth-delay product); a fixed small depth caps throughput at
+/// `depth * 16 KiB / RTT` — e.g. 5 blocks over a 2 s I2P round trip is
+/// only 40 KiB/s. The session resizes `pipeline_limit` once a second from
+/// the peer's measured download rate, targeting `pipeline_queue_secs` of
+/// data in flight, clamped to [`min_pipeline`, `max_pipeline`].
+pub const min_pipeline: u32 = 16;
+pub const max_pipeline: u32 = 512;
+pub const pipeline_queue_secs: u32 = 4;
+
+/// An outstanding block request, stamped so the session can expire requests
+/// a connected-but-silent peer never answers.
+pub const PendingRequest = struct {
+    index: u32,
+    begin: u32,
+    length: u32,
+    requested_at: i64,
+};
 
 /// Per-peer connection state.
 pub const PeerConnection = struct {
@@ -56,11 +74,23 @@ pub const PeerConnection = struct {
 
     // Buffers
     recv_buf: std.ArrayList(u8),
+    /// Parse offset into `recv_buf`. Consumed messages advance this instead
+    /// of memmoving the remainder per message (compaction is amortized, like
+    /// the send side). Defaulted so the init struct literals need not set it.
+    recv_pos: usize = 0,
     send_buf: std.ArrayList(u8),
     send_pos: usize,
 
     // Request pipeline
-    pending_requests: std.ArrayList(wire.Message.BlockRequest),
+    pending_requests: std.ArrayList(PendingRequest),
+    /// Current pipeline depth, resized once a second by the session from the
+    /// measured download rate (see `updatePipelineLimit`). Defaulted so the
+    /// init struct literals need not set it.
+    pipeline_limit: u32 = min_pipeline,
+    /// EWMA download rate (bytes/s) and the `bytes_downloaded` value at the
+    /// last sample, both owned by `updatePipelineLimit`.
+    down_rate: u64 = 0,
+    rate_last_bytes: u64 = 0,
 
     // Stats for choking algorithm
     bytes_downloaded: u64,
@@ -151,6 +181,20 @@ pub const PeerConnection = struct {
     /// Connect timeout in seconds.
     pub const connect_timeout_secs: u32 = 5;
 
+    /// Disable Nagle on a peer socket (best-effort). Wire requests are tiny
+    /// and latency-sensitive; letting the kernel coalesce them behind delayed
+    /// ACKs stalls the request pipeline. Also applied to proxy/SAM bridge
+    /// sockets — those are local TCP connections where Nagle only adds delay.
+    pub fn setNoDelay(stream: std.net.Stream) void {
+        const one: c_int = 1;
+        std.posix.setsockopt(
+            stream.handle,
+            std.posix.IPPROTO.TCP,
+            std.posix.TCP.NODELAY,
+            std.mem.asBytes(&one),
+        ) catch {};
+    }
+
     /// Initiate TCP connection with a timeout.
     pub fn connect(self: *PeerConnection) !void {
         // Native I2P: open a SAM stream to the destination. Synchronous, so on
@@ -164,6 +208,7 @@ pub const PeerConnection = struct {
                 self.state = .disconnected;
                 return error.ConnectionFailed;
             };
+            setNoDelay(self.stream.?);
             self.state = .handshaking;
             return;
         }
@@ -183,6 +228,7 @@ pub const PeerConnection = struct {
                     return error.ConnectionFailed;
                 };
             }
+            setNoDelay(self.stream.?);
             self.state = .handshaking;
             return;
         }
@@ -248,6 +294,7 @@ pub const PeerConnection = struct {
         _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
 
         self.stream = .{ .handle = sock };
+        setNoDelay(self.stream.?);
         self.state = .handshaking;
     }
 
@@ -295,10 +342,12 @@ pub const PeerConnection = struct {
         return written;
     }
 
-    /// Read available data from socket into recv_buf.
+    /// Read available data from socket into recv_buf. The buffer is sized to
+    /// drain several piece messages per poll wake — a 16 KiB read forced one
+    /// syscall + poll round per block.
     pub fn readIncoming(self: *PeerConnection) !usize {
         const s = self.stream orelse return 0;
-        var buf: [16384]u8 = undefined;
+        var buf: [65536]u8 = undefined;
         const n = s.read(&buf) catch {
             self.state = .disconnected;
             return error.IoError;
@@ -312,30 +361,44 @@ pub const PeerConnection = struct {
         return n;
     }
 
+    /// Drop consumed bytes from the front of recv_buf. Amortized: a no-op
+    /// until everything is consumed or the consumed prefix dominates.
+    fn compactRecv(self: *PeerConnection) void {
+        if (self.recv_pos == 0) return;
+        if (self.recv_pos == self.recv_buf.items.len) {
+            self.recv_buf.clearRetainingCapacity();
+            self.recv_pos = 0;
+            return;
+        }
+        if (self.recv_pos > self.recv_buf.items.len / 2) {
+            const leftover = self.recv_buf.items[self.recv_pos..];
+            std.mem.copyForwards(u8, self.recv_buf.items[0..leftover.len], leftover);
+            self.recv_buf.shrinkRetainingCapacity(leftover.len);
+            self.recv_pos = 0;
+        }
+    }
+
     /// Try to parse the handshake from recv_buf. Returns the parsed handshake or null.
     pub fn tryParseHandshake(self: *PeerConnection) ?wire.Handshake {
-        if (self.recv_buf.items.len < wire.handshake_len) return null;
-        const hs = wire.Handshake.parse(self.recv_buf.items[0..wire.handshake_len]) catch return null;
+        const avail = self.recv_buf.items[self.recv_pos..];
+        if (avail.len < wire.handshake_len) return null;
+        const hs = wire.Handshake.parse(avail[0..wire.handshake_len]) catch return null;
 
-        // Consume handshake bytes
-        const leftover = self.recv_buf.items[wire.handshake_len..];
-        std.mem.copyForwards(u8, self.recv_buf.items[0..leftover.len], leftover);
-        self.recv_buf.shrinkRetainingCapacity(leftover.len);
+        self.recv_pos += wire.handshake_len;
+        self.compactRecv();
 
         return hs;
     }
 
     /// Parse and return the next complete message, or null if incomplete.
     pub fn nextMessage(self: *PeerConnection) !?wire.Message {
-        const result = wire.parseMessage(self.allocator, self.recv_buf.items) catch |err| {
+        const result = wire.parseMessage(self.allocator, self.recv_buf.items[self.recv_pos..]) catch |err| {
             self.state = .disconnected;
             return err;
         };
         if (result) |r| {
-            // Consume parsed bytes
-            const leftover = self.recv_buf.items[r.consumed..];
-            std.mem.copyForwards(u8, self.recv_buf.items[0..leftover.len], leftover);
-            self.recv_buf.shrinkRetainingCapacity(leftover.len);
+            self.recv_pos += r.consumed;
+            self.compactRecv();
             return r.msg;
         }
         return null;
@@ -350,24 +413,50 @@ pub const PeerConnection = struct {
     }
 
     pub fn canRequest(self: PeerConnection) bool {
-        return !self.peer_choking and self.pending_requests.items.len < max_pipeline;
+        return !self.peer_choking and self.pending_requests.items.len < self.pipeline_limit;
     }
 
     pub fn addPendingRequest(self: *PeerConnection, req: wire.Message.BlockRequest) !void {
-        self.pending_requests.append(self.allocator, req) catch return error.OutOfMemory;
+        self.pending_requests.append(self.allocator, .{
+            .index = req.index,
+            .begin = req.begin,
+            .length = req.length,
+            .requested_at = std.time.timestamp(),
+        }) catch return error.OutOfMemory;
     }
 
     pub fn completePendingRequest(self: *PeerConnection, index: u32, begin: u32) void {
         for (self.pending_requests.items, 0..) |r, i| {
             if (r.index == index and r.begin == begin) {
-                _ = self.pending_requests.orderedRemove(i);
+                _ = self.pending_requests.swapRemove(i);
                 return;
             }
         }
     }
 
+    pub fn hasPendingRequest(self: PeerConnection, index: u32, begin: u32) bool {
+        for (self.pending_requests.items) |r| {
+            if (r.index == index and r.begin == begin) return true;
+        }
+        return false;
+    }
+
     pub fn clearPendingRequests(self: *PeerConnection) void {
         self.pending_requests.clearRetainingCapacity();
+    }
+
+    /// Resample this peer's download rate (EWMA, alpha 1/4) and resize the
+    /// request pipeline to hold `pipeline_queue_secs` of data in flight.
+    /// Called once a second by the session's maintenance tick.
+    pub fn updatePipelineLimit(self: *PeerConnection, dt: i64) void {
+        if (dt <= 0) return;
+        const delta = self.bytes_downloaded -| self.rate_last_bytes;
+        self.rate_last_bytes = self.bytes_downloaded;
+        const inst = delta / @as(u64, @intCast(dt));
+        self.down_rate = (self.down_rate * 3 + inst) / 4;
+
+        const target = self.down_rate * pipeline_queue_secs / piece_mod.block_size;
+        self.pipeline_limit = @intCast(std.math.clamp(target, min_pipeline, max_pipeline));
     }
 
     pub fn hasPiece(self: PeerConnection, index: u32) bool {
@@ -419,8 +508,8 @@ test "peer request pipeline" {
     peer.peer_choking = false;
     try std.testing.expect(peer.canRequest());
 
-    // Fill pipeline
-    for (0..max_pipeline) |i| {
+    // Fill pipeline up to the current (initial) limit
+    for (0..min_pipeline) |i| {
         try peer.addPendingRequest(.{ .index = @intCast(i), .begin = 0, .length = 16384 });
     }
     try std.testing.expect(!peer.canRequest());
@@ -428,7 +517,31 @@ test "peer request pipeline" {
     // Complete one
     peer.completePendingRequest(2, 0);
     try std.testing.expect(peer.canRequest());
-    try std.testing.expectEqual(@as(usize, max_pipeline - 1), peer.pending_requests.items.len);
+    try std.testing.expectEqual(@as(usize, min_pipeline - 1), peer.pending_requests.items.len);
+    try std.testing.expect(peer.hasPendingRequest(3, 0));
+    try std.testing.expect(!peer.hasPendingRequest(2, 0));
+}
+
+test "peer pipeline limit scales with measured rate" {
+    const allocator = std.testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 6881);
+    var peer = PeerConnection.init(allocator, addr);
+    defer peer.deinit();
+
+    try std.testing.expectEqual(min_pipeline, peer.pipeline_limit);
+
+    // A fast peer grows the pipeline toward rate * queue_secs / block_size.
+    // Feed a steady 8 MiB/s until the EWMA converges.
+    for (0..16) |_| {
+        peer.bytes_downloaded += 8 * 1024 * 1024;
+        peer.updatePipelineLimit(1);
+    }
+    try std.testing.expect(peer.pipeline_limit > min_pipeline);
+    try std.testing.expect(peer.pipeline_limit <= max_pipeline);
+
+    // A stalled peer decays back to the floor (never below it).
+    for (0..64) |_| peer.updatePipelineLimit(1);
+    try std.testing.expectEqual(min_pipeline, peer.pipeline_limit);
 }
 
 test "peer enqueue and send buffer" {

--- a/src/piece.zig
+++ b/src/piece.zig
@@ -74,6 +74,13 @@ pub const PieceProgress = struct {
     piece_len: u32,
     num_blocks: u32,
     received: []u8,
+    /// Blocks currently requested from some peer (in flight). Tracked
+    /// separately from `received` so the scheduler never re-requests a block
+    /// that is already on the wire — without this, every pipeline slot fills
+    /// with duplicates of the first missing block. Bits are cleared when the
+    /// owning request is released (choke, disconnect, timeout) so the block
+    /// becomes schedulable again.
+    requested: []u8,
     data: []u8,
 
     pub fn init(allocator: Allocator, index: u32, piece_len: u32) error{OutOfMemory}!PieceProgress {
@@ -81,8 +88,14 @@ pub const PieceProgress = struct {
         const recv_bytes = (num_blocks + 7) / 8;
         const received = allocator.alloc(u8, recv_bytes) catch return error.OutOfMemory;
         @memset(received, 0);
+        const requested = allocator.alloc(u8, recv_bytes) catch {
+            allocator.free(received);
+            return error.OutOfMemory;
+        };
+        @memset(requested, 0);
         const data = allocator.alloc(u8, piece_len) catch {
             allocator.free(received);
+            allocator.free(requested);
             return error.OutOfMemory;
         };
         @memset(data, 0);
@@ -91,12 +104,14 @@ pub const PieceProgress = struct {
             .piece_len = piece_len,
             .num_blocks = num_blocks,
             .received = received,
+            .requested = requested,
             .data = data,
         };
     }
 
     pub fn deinit(self: PieceProgress, allocator: Allocator) void {
         allocator.free(self.received);
+        allocator.free(self.requested);
         allocator.free(self.data);
     }
 
@@ -140,6 +155,40 @@ pub const PieceProgress = struct {
         return null;
     }
 
+    pub fn isRequested(self: PieceProgress, block_idx: u32) bool {
+        if (block_idx >= self.num_blocks) return false;
+        const byte_idx = block_idx / 8;
+        const bit_idx: u3 = @intCast(7 - (block_idx % 8));
+        return (self.requested[byte_idx] & (@as(u8, 1) << bit_idx)) != 0;
+    }
+
+    pub fn markRequested(self: *PieceProgress, block_idx: u32) void {
+        if (block_idx >= self.num_blocks) return;
+        const byte_idx = block_idx / 8;
+        const bit_idx: u3 = @intCast(7 - (block_idx % 8));
+        self.requested[byte_idx] |= @as(u8, 1) << bit_idx;
+    }
+
+    /// Release an in-flight mark (the owning request was choked away,
+    /// timed out, or its peer disconnected) so the block is schedulable again.
+    pub fn clearRequested(self: *PieceProgress, block_idx: u32) void {
+        if (block_idx >= self.num_blocks) return;
+        const byte_idx = block_idx / 8;
+        const bit_idx: u3 = @intCast(7 - (block_idx % 8));
+        self.requested[byte_idx] &= ~(@as(u8, 1) << bit_idx);
+    }
+
+    /// Return the next block that is neither received nor in flight, or null.
+    /// This is what the scheduler uses; `nextMissingBlock` (received-only) is
+    /// for completeness checks where in-flight state must not hide a block.
+    pub fn nextUnrequestedBlock(self: PieceProgress) ?u32 {
+        for (0..self.num_blocks) |i| {
+            const idx: u32 = @intCast(i);
+            if (!self.hasBlock(idx) and !self.isRequested(idx)) return idx;
+        }
+        return null;
+    }
+
     /// Compute begin offset and length for a given block index.
     pub fn blockSpec(self: PieceProgress, block_idx: u32) struct { begin: u32, length: u32 } {
         const begin = block_idx * block_size;
@@ -148,9 +197,10 @@ pub const PieceProgress = struct {
         return .{ .begin = begin, .length = length };
     }
 
-    /// Reset all received state (for retry after hash failure).
+    /// Reset all received and in-flight state (for retry after hash failure).
     pub fn reset(self: *PieceProgress) void {
         @memset(self.received, 0);
+        @memset(self.requested, 0);
         @memset(self.data, 0);
     }
 };
@@ -290,6 +340,37 @@ test "piece progress next missing block" {
     try std.testing.expectEqual(@as(?u32, 2), pp.nextMissingBlock());
     _ = pp.addBlock(32768, &([_]u8{0} ** 16384));
     try std.testing.expectEqual(@as(?u32, null), pp.nextMissingBlock());
+}
+
+test "piece progress requested tracking" {
+    const allocator = std.testing.allocator;
+    var pp = try PieceProgress.init(allocator, 0, 49152); // 3 blocks
+    defer pp.deinit(allocator);
+
+    // Scheduling marks blocks in flight: each pick advances, never repeats.
+    try std.testing.expectEqual(@as(?u32, 0), pp.nextUnrequestedBlock());
+    pp.markRequested(0);
+    try std.testing.expectEqual(@as(?u32, 1), pp.nextUnrequestedBlock());
+    pp.markRequested(1);
+    pp.markRequested(2);
+    try std.testing.expectEqual(@as(?u32, null), pp.nextUnrequestedBlock());
+
+    // `nextMissingBlock` still sees in-flight blocks as missing.
+    try std.testing.expectEqual(@as(?u32, 0), pp.nextMissingBlock());
+
+    // Releasing an in-flight block (peer choked/disconnected/timed out)
+    // makes it schedulable again.
+    pp.clearRequested(1);
+    try std.testing.expectEqual(@as(?u32, 1), pp.nextUnrequestedBlock());
+
+    // A received block stays unschedulable even with no requested bit.
+    pp.clearRequested(0);
+    _ = pp.addBlock(0, &([_]u8{0} ** 16384));
+    try std.testing.expectEqual(@as(?u32, 1), pp.nextUnrequestedBlock());
+
+    // reset() clears in-flight state too.
+    pp.reset();
+    try std.testing.expectEqual(@as(?u32, 0), pp.nextUnrequestedBlock());
 }
 
 test "piece progress block spec" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -803,7 +803,11 @@ pub const Session = struct {
         if (req.length > piece_mod.block_size) return;
 
         const plen = piece_mod.pieceLength(req.index, self.piece_len, self.total_length);
-        if (req.begin + req.length > plen) return;
+        // Non-wrapping bounds check: both fields are attacker-controlled u32s,
+        // and `begin + length` could overflow — a panic in ReleaseSafe (remote
+        // DoS) or a wrap past the guard in ReleaseFast.
+        if (req.length == 0) return;
+        if (req.begin >= plen or req.length > plen - req.begin) return;
 
         const block = self.store.readRange(self.allocator, req.index, req.begin, req.length) catch return;
         defer self.allocator.free(block);

--- a/src/session.zig
+++ b/src/session.zig
@@ -29,6 +29,12 @@ const optimistic_interval_secs: i64 = 30;
 /// no_peers forever. Re-querying relays is slow (~seconds per relay), so only
 /// retry when stuck at zero peers and not more often than this.
 const peer_rediscovery_interval_secs: i64 = 45;
+/// How long an outstanding block request may go unanswered before it is
+/// cancelled and released back to the scheduler. Long enough that a slow
+/// anonymized route (I2P round trips run seconds) is never penalized; short
+/// enough that one silent peer can't hold blocks hostage while others could
+/// fetch them.
+const request_timeout_secs: i64 = 60;
 
 /// Periodic peer re-discovery hook. The session run loop calls `run(ctx)` on
 /// its own thread when the transfer has zero peers, so the callback can safely
@@ -125,6 +131,9 @@ pub const Session = struct {
     rate_last_s: i64 = 0,
     rate_last_in: u64 = 0,
     rate_last_out: u64 = 0,
+    // Last second `maintenance` ran the per-peer tick (pipeline resize +
+    // request expiry). Gates that work to 1 Hz like `sampleRate`.
+    peer_tick_last_s: i64 = 0,
     // BEP 9 metadata bytes received this session. Counted toward the download
     // rate (and progress timestamp) so the metadata-fetch phase shows real speed
     // even though piece `downloaded` is still 0 then.
@@ -675,7 +684,7 @@ pub const Session = struct {
         switch (msg) {
             .choke => {
                 p.peer_choking = true;
-                p.clearPendingRequests();
+                self.releasePeerRequests(p);
             },
             .unchoke => {
                 p.peer_choking = false;
@@ -774,6 +783,7 @@ pub const Session = struct {
                 for (self.peers.items) |peer| {
                     if (peer.state == .active) {
                         peer.enqueueMessage(.{ .have = pd.index }) catch {};
+                        cancelPieceRequests(peer, pd.index);
                     }
                 }
             } else {
@@ -795,10 +805,9 @@ pub const Session = struct {
         const plen = piece_mod.pieceLength(req.index, self.piece_len, self.total_length);
         if (req.begin + req.length > plen) return;
 
-        const data = self.store.readPiece(self.allocator, req.index, plen) catch return;
-        defer self.allocator.free(data);
+        const block = self.store.readRange(self.allocator, req.index, req.begin, req.length) catch return;
+        defer self.allocator.free(block);
 
-        const block = data[req.begin .. req.begin + req.length];
         p.enqueueMessage(.{ .piece = .{
             .index = req.index,
             .begin = req.begin,
@@ -1151,13 +1160,13 @@ pub const Session = struct {
         for (self.peers.items) |p| {
             if (p.state != .active) continue;
 
-            while (p.canRequest()) {
-                const piece_idx = if (self.endgame_active)
-                    self.pickEndgamePiece(p)
-                else
-                    self.pickRarestPiece(p);
+            if (self.endgame_active) {
+                self.scheduleEndgameRequests(p);
+                continue;
+            }
 
-                const idx = piece_idx orelse break;
+            outer: while (p.canRequest()) {
+                const idx = self.pickRarestPiece(p) orelse break;
 
                 const pp_ptr = self.active_pieces.get(idx) orelse blk: {
                     const plen = piece_mod.pieceLength(idx, self.piece_len, self.total_length);
@@ -1174,17 +1183,104 @@ pub const Session = struct {
                     break :blk pp;
                 };
 
-                const block_idx = pp_ptr.nextMissingBlock() orelse break;
-                const spec = pp_ptr.blockSpec(block_idx);
+                // Fill the pipeline from this piece before picking another:
+                // picking is O(num_pieces), the blocks within are O(1). Each
+                // scheduled block is marked in flight so neither this loop nor
+                // another peer re-requests it (the marks are released on
+                // choke, disconnect, and timeout).
+                while (p.canRequest()) {
+                    const block_idx = pp_ptr.nextUnrequestedBlock() orelse continue :outer;
+                    const spec = pp_ptr.blockSpec(block_idx);
+
+                    const req = wire.Message.BlockRequest{
+                        .index = idx,
+                        .begin = spec.begin,
+                        .length = spec.length,
+                    };
+
+                    p.enqueueMessage(.{ .request = req }) catch break :outer;
+                    p.addPendingRequest(req) catch break :outer;
+                    pp_ptr.markRequested(block_idx);
+                }
+            }
+        }
+    }
+
+    /// Endgame: request every still-missing block from every peer that has
+    /// it. Duplicates across peers are intentional (first response wins, the
+    /// completion path cancels the rest), but a peer never duplicates a block
+    /// within its own pipeline.
+    fn scheduleEndgameRequests(self: *Session, p: *peer_mod.PeerConnection) void {
+        for (0..self.num_pieces) |i| {
+            if (!p.canRequest()) return;
+            const idx: u32 = @intCast(i);
+            if (self.our_bitfield.hasPiece(idx)) continue;
+            if (!p.hasPiece(idx)) continue;
+            const pp = self.active_pieces.get(idx) orelse continue;
+
+            for (0..pp.num_blocks) |b| {
+                if (!p.canRequest()) return;
+                const block_idx: u32 = @intCast(b);
+                if (pp.hasBlock(block_idx)) continue;
+                const spec = pp.blockSpec(block_idx);
+                if (p.hasPendingRequest(idx, spec.begin)) continue;
 
                 const req = wire.Message.BlockRequest{
                     .index = idx,
                     .begin = spec.begin,
                     .length = spec.length,
                 };
+                p.enqueueMessage(.{ .request = req }) catch return;
+                p.addPendingRequest(req) catch return;
+                pp.markRequested(block_idx);
+            }
+        }
+    }
 
-                p.enqueueMessage(.{ .request = req }) catch break;
-                p.addPendingRequest(req) catch break;
+    /// Release every in-flight request this peer holds back to the scheduler
+    /// (clearing the per-piece `requested` marks) and drop them from the
+    /// peer's pipeline. Used on choke and disconnect — a leaked mark would
+    /// make its block permanently unschedulable.
+    fn releasePeerRequests(self: *Session, p: *peer_mod.PeerConnection) void {
+        for (p.pending_requests.items) |r| {
+            if (self.active_pieces.get(r.index)) |pp| {
+                pp.clearRequested(r.begin / piece_mod.block_size);
+            }
+        }
+        p.clearPendingRequests();
+    }
+
+    /// Release (and cancel) requests the peer has sat on longer than
+    /// `request_timeout_secs`, so a connected-but-unresponsive peer can't
+    /// hold blocks hostage while other peers could fetch them.
+    fn expireStaleRequests(self: *Session, p: *peer_mod.PeerConnection, now: i64) void {
+        var i: usize = 0;
+        while (i < p.pending_requests.items.len) {
+            const r = p.pending_requests.items[i];
+            if (now - r.requested_at > request_timeout_secs) {
+                if (self.active_pieces.get(r.index)) |pp| {
+                    pp.clearRequested(r.begin / piece_mod.block_size);
+                }
+                p.enqueueMessage(.{ .cancel = .{ .index = r.index, .begin = r.begin, .length = r.length } }) catch {};
+                _ = p.pending_requests.swapRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Cancel a peer's outstanding requests for a piece that just completed
+    /// (endgame requests the same block from several peers; without a cancel
+    /// every one of them answers with redundant data).
+    fn cancelPieceRequests(p: *peer_mod.PeerConnection, index: u32) void {
+        var i: usize = 0;
+        while (i < p.pending_requests.items.len) {
+            const r = p.pending_requests.items[i];
+            if (r.index == index) {
+                p.enqueueMessage(.{ .cancel = .{ .index = r.index, .begin = r.begin, .length = r.length } }) catch {};
+                _ = p.pending_requests.swapRemove(i);
+            } else {
+                i += 1;
             }
         }
     }
@@ -1199,9 +1295,9 @@ pub const Session = struct {
             if (self.our_bitfield.hasPiece(idx)) continue;
             if (!p.hasPiece(idx)) continue;
 
-            // Skip if already active and fully requested
+            // Skip if already active with every block received or in flight
             if (self.active_pieces.get(idx)) |pp| {
-                if (pp.nextMissingBlock() == null) continue;
+                if (pp.nextUnrequestedBlock() == null) continue;
             }
 
             const avail = if (idx < self.piece_availability.len) self.piece_availability[idx] else 0;
@@ -1232,23 +1328,6 @@ pub const Session = struct {
             const stderr = std.fs.File.stderr().deprecatedWriter();
             stderr.print("endgame mode: {d} pieces remaining\n", .{missing}) catch {};
         }
-    }
-
-    /// In endgame mode, request remaining blocks from ALL peers that have them.
-    fn pickEndgamePiece(self: *Session, p: *peer_mod.PeerConnection) ?u32 {
-        for (0..self.num_pieces) |i| {
-            const idx: u32 = @intCast(i);
-            if (self.our_bitfield.hasPiece(idx)) continue;
-            if (!p.hasPiece(idx)) continue;
-
-            if (self.active_pieces.get(idx)) |pp| {
-                if (pp.nextMissingBlock() != null) return idx;
-                // In endgame, also re-request blocks from other peers
-                // (the first response wins, duplicates are ignored)
-                return idx;
-            }
-        }
-        return null;
     }
 
     // --- Choking algorithm (BEP 3) ---
@@ -1379,6 +1458,7 @@ pub const Session = struct {
         };
         p.* = peer_mod.PeerConnection.init(self.allocator, conn.address);
         p.stream = conn.stream;
+        peer_mod.PeerConnection.setNoDelay(conn.stream);
         p.state = .handshaking;
 
         p.sendHandshake(self.info_hash, self.peer_id) catch {
@@ -1413,6 +1493,7 @@ pub const Session = struct {
                 if (p.peer_bitfield) |*bf| {
                     self.removeAvailability(bf);
                 }
+                self.releasePeerRequests(p);
                 p.deinit();
                 self.allocator.destroy(p);
                 _ = self.peers.orderedRemove(i);
@@ -1424,6 +1505,18 @@ pub const Session = struct {
                     p.disconnect();
                 }
                 i += 1;
+            }
+        }
+
+        // Once a second: resize each peer's request pipeline from its
+        // measured rate and release requests the peer has sat on too long.
+        const peer_dt = now - self.peer_tick_last_s;
+        if (peer_dt >= 1) {
+            self.peer_tick_last_s = now;
+            for (self.peers.items) |p| {
+                if (p.state != .active) continue;
+                p.updatePipelineLimit(peer_dt);
+                self.expireStaleRequests(p, now);
             }
         }
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -408,6 +408,43 @@ test "storage write and read roundtrip" {
     try std.testing.expectEqual(@as(u8, 0xBB), read1[0]);
 }
 
+test "readRange reads a mid-piece block spanning a file boundary" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const tmp_path = tmp_dir.dir.realpathAlloc(allocator, ".") catch return;
+    defer allocator.free(tmp_path);
+
+    // One 16 KiB piece split across two files (10000 + 6384 bytes), so a
+    // mid-piece range crosses the file boundary.
+    const files = [_]metainfo.FileInfo{
+        .{ .length = 10000, .path = &.{"a.bin"} },
+        .{ .length = 6384, .path = &.{"b.bin"} },
+    };
+
+    var store = Storage.init(allocator, testMeta(&files), tmp_path, true) catch return;
+    defer store.deinit();
+
+    var data: [16384]u8 = undefined;
+    for (&data, 0..) |*b, i| b.* = @truncate(i);
+    try store.writePiece(0, &data);
+
+    // Serve a block-request-sized range straddling the boundary: the offset
+    // math (`index * piece_len + begin`) must hold for a non-zero `begin`.
+    const begin: u32 = 9000;
+    const length: u32 = 2000;
+    const got = try store.readRange(allocator, 0, begin, length);
+    defer allocator.free(got);
+    try std.testing.expectEqualSlices(u8, data[begin .. begin + length], got);
+
+    // And a range entirely inside the second file.
+    const got2 = try store.readRange(allocator, 0, 12000, 1000);
+    defer allocator.free(got2);
+    try std.testing.expectEqualSlices(u8, data[12000..13000], got2);
+}
+
 fn testMeta(files: []const metainfo.FileInfo) metainfo.Metainfo {
     return .{
         .announce = "http://example.com",

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -272,6 +272,11 @@ pub const Storage = struct {
             buf_pos += chunk_len;
         }
 
+        // A range past the torrent's end maps to fewer bytes than requested;
+        // the unfilled allocation must never escape (it would leak heap
+        // contents to the peer being served).
+        if (buf_pos != length) return error.ReadFailed;
+
         return buf;
     }
 };
@@ -443,6 +448,12 @@ test "readRange reads a mid-piece block spanning a file boundary" {
     const got2 = try store.readRange(allocator, 0, 12000, 1000);
     defer allocator.free(got2);
     try std.testing.expectEqualSlices(u8, data[12000..13000], got2);
+
+    // A range past the torrent's end maps to fewer bytes than requested and
+    // must fail rather than return a partially-uninitialized buffer (which
+    // would leak heap contents to the requesting peer).
+    try std.testing.expectError(error.ReadFailed, store.readRange(allocator, 0, 16000, 1000));
+    try std.testing.expectError(error.ReadFailed, store.readRange(allocator, 9, 0, 16384));
 }
 
 fn testMeta(files: []const metainfo.FileInfo) metainfo.Metainfo {

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -250,7 +250,14 @@ pub const Storage = struct {
 
     /// Read a piece from disk. Caller owns the returned slice.
     pub fn readPiece(self: *Storage, allocator: Allocator, index: u32, length: u32) IoError![]u8 {
-        const torrent_offset = @as(u64, index) * self.piece_len;
+        return self.readRange(allocator, index, 0, length);
+    }
+
+    /// Read `length` bytes starting at `begin` within piece `index`. Caller
+    /// owns the returned slice. Serving a 16 KiB block request must not read
+    /// (and allocate) the whole piece — that is a 16-64x overhead per block.
+    pub fn readRange(self: *Storage, allocator: Allocator, index: u32, begin: u32, length: u32) IoError![]u8 {
+        const torrent_offset = @as(u64, index) * self.piece_len + begin;
         const buf = allocator.alloc(u8, length) catch return error.OutOfMemory;
         errdefer allocator.free(buf);
 

--- a/src/tracker.zig
+++ b/src/tracker.zig
@@ -220,6 +220,14 @@ pub fn announce(
 
     if (result.status != .ok) return error.HttpError;
 
+    // Flush the adapter's buffered tail: a response smaller than the adapter
+    // buffer (announce responses almost always are) would otherwise never
+    // reach `response_body` and parse as empty.
+    const buffered = adapter.new_interface.buffered();
+    if (buffered.len > 0) {
+        response_body.appendSlice(allocator, buffered) catch return error.OutOfMemory;
+    }
+
     return parseAnnounceResponse(allocator, response_body.items);
 }
 


### PR DESCRIPTION
Stacked on #51 (retargets to main automatically when that merges).

## Summary

Downloads were pathologically slow on high-latency links — the exact "single I2P peer crawls at stale/downloading" symptom. Root causes, all fixed here:

- **Duplicate block requests (the big one).** The scheduler tracked only *received* blocks, so every free pipeline slot filled with a duplicate request for the first still-missing block, and every peer requested the same blocks. Effective depth was ~1–2 unique blocks in flight with 3–5x redundant wire traffic. `PieceProgress` now keeps a `requested` (in-flight) bitmap; marks are released on choke, disconnect, and a 60s per-request timeout, and outstanding duplicates are cancelled when a piece completes.
- **Fixed pipeline of 5 requests** (80 KiB in flight) capped throughput at 80 KiB/RTT — 40 KiB/s on a 2s I2P round trip. The pipeline now scales with the peer's measured rate to hold ~4s of data in flight, clamped to [16, 512] requests.
- **Scheduler cost:** picking a piece was O(num_pieces) per *block*; it now fills the pipeline piece-at-a-time.
- **Seeding read amplification:** serving one 16 KiB block read and allocated the whole piece (16–64x overhead). `Storage.readRange` reads just the block — this is the hosting side of the single-I2P-seeder setup.
- **I/O details:** 64 KiB socket reads per poll wake (was 16 KiB), amortized recv-buffer parse offset instead of a memmove per message, `TCP_NODELAY` on all peer sockets.
- **Tracker announce bug (pre-existing):** the HTTP response sat unflushed in the writer adapter's 4 KiB buffer, so any response under 4 KiB — i.e. all of them — parsed as empty and failed with `InvalidResponse`. Same bug was already fixed in the web-seed path; this call site was missed.

## Measurements (loopback e2e, real binaries, single seeder)

| Scenario | Before | After |
|----------|--------|-------|
| 8 MiB through a 300ms-RTT relay | 2m51s (~49 KB/s) | **10.5s (~800 KB/s)** |
| 64 MiB raw loopback | 9.0s | **7.2s** |

Both runs produced byte-identical files (`cmp`).

## Review Notes

- All `requested`-bitmap state stays on the single session thread; no atomics needed.
- Endgame still duplicates across peers intentionally (first response wins) but no longer within one peer's pipeline, and completion now sends `cancel` to the losers.
- The request timeout (60s) is sized so an adaptive queue (~4s of data) can never legitimately exceed it, even on slow routes.

## Decision Log

**Hardest decision:** counting a block as "in flight" globally (one bitmap per piece) rather than per peer. A per-peer view would allow deliberate cross-peer redundancy outside endgame, which can help against flaky peers — but it is exactly the duplicate-traffic bug being fixed, and endgame plus the 60s expiry already cover the flaky-peer case.

**Alternatives rejected:**
- Just raising `max_pipeline` to a bigger constant: without in-flight tracking the extra slots fill with more duplicates of the same block — measured no improvement; with tracking but no rate-adaptation, 512 outstanding requests against a slow peer take minutes to drain after the peer stalls.
- Sliding-window/AIMD queue sizing (libtorrent-style): more faithful, but the rate-EWMA target is far simpler and converges within a few seconds in practice.

**Least confident about:** the interaction of the 60s request expiry with a peer whose rate collapses *after* the queue grew large — transiently the queue can exceed 60s of data and produce a burst of cancels and re-requests. It self-corrects (the EWMA shrinks the limit within seconds) but IDK if there's a pathological oscillation on extremely jittery links; happy to revisit if anyone observes it.

## Test plan
- [x] `zig build test` — 251/251 (new unit tests: requested-bitmap tracking, rate-adaptive pipeline limit)
- [x] Loopback e2e with real binaries (seed + tracker + download), byte-identical output
- [x] 300ms-RTT relay e2e, before/after measured
- [ ] Real I2P single-seeder transfer (needs a live I2P router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)