### PR TITLE
Seeds shelf: restart recipes under <dir>/seeds + retained-spec retry

### DIFF
--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -246,6 +246,11 @@ pub const Daemon = struct {
             // Persist any newly-resolved magnet torrents (headless coverage; the
             // WS push also does this ~1/s when the GUI is connected).
             self.manager.checkpoint();
+            // Re-add transfers whose transport was unavailable at restore (an
+            // i2p seed restored before the router was up, a proxy that was
+            // down) so they come back within a tick instead of after the next
+            // restart — until now they existed only as invisible DB rows.
+            self.manager.retryRetained();
             var slept: u64 = 0;
             while (slept < probe_interval_ns and
                 self.running.load(.acquire) and

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -287,7 +287,61 @@ pub const Manager = struct {
             return err;
         };
         const magnet = if (std.mem.startsWith(u8, source, "magnet:")) source else "";
-        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, null, want_nostr, false, magnet, source);
+        // Pin a local `.torrent` source onto the seeds shelf: the picked file
+        // can live anywhere (a file-picker temp path, a folder the user later
+        // cleans), and the restart replay would silently fail once it's gone.
+        // Persist the recipe as `<download_dir>/seeds/<infohash>.torrent`
+        // instead. Best-effort: on any failure the original source is kept.
+        var pinned: ?[]u8 = null;
+        defer if (pinned) |p| self.allocator.free(p);
+        if (magnet.len == 0 and
+            !std.mem.startsWith(u8, source, "http://") and
+            !std.mem.startsWith(u8, source, "https://"))
+        {
+            pinned = self.pinTorrentSource(source, built.info_hash);
+        }
+        return self.register(built, route, t.proxy, t.socks_owned, t.i2p, null, null, want_nostr, false, magnet, pinned orelse source);
+    }
+
+    /// Ensure the seeds shelf (`<dir>/seeds`) exists and return its path, or
+    /// null when it can't be created. Caller owns the slice.
+    fn ensureSeedsDir(self: *Manager, dir: []const u8) ?[]u8 {
+        const sdir = workdir.seedsDir(self.allocator, dir) catch return null;
+        std.fs.cwd().makePath(sdir) catch {
+            self.allocator.free(sdir);
+            return null;
+        };
+        return sdir;
+    }
+
+    /// Copy a local `.torrent` recipe onto the seeds shelf, named by
+    /// info-hash. Returns the owned shelf path, or null when the copy isn't
+    /// possible (the original path is then persisted unchanged). A source that
+    /// already is the shelf file — a restart replaying the persisted spec —
+    /// is returned as-is without rewriting it onto itself.
+    fn pinTorrentSource(self: *Manager, source: []const u8, info_hash: [20]u8) ?[]u8 {
+        var hex: [40]u8 = undefined;
+        secp.toHex(&info_hash, &hex);
+        const sdir = self.ensureSeedsDir(self.cfg.download_dir) orelse return null;
+        defer self.allocator.free(sdir);
+        const dest = std.fmt.allocPrint(self.allocator, "{s}/{s}.torrent", .{ sdir, &hex }) catch return null;
+        if (std.mem.eql(u8, dest, source)) return dest;
+
+        const data = std.fs.cwd().readFileAlloc(self.allocator, source, 10 * 1024 * 1024) catch {
+            self.allocator.free(dest);
+            return null;
+        };
+        defer self.allocator.free(data);
+        var f = std.fs.cwd().createFile(dest, .{ .truncate = true }) catch {
+            self.allocator.free(dest);
+            return null;
+        };
+        defer f.close();
+        f.writeAll(data) catch {
+            self.allocator.free(dest);
+            return null;
+        };
+        return dest;
     }
 
     /// Bind a throwaway loopback socket to discover a free port. Each `.tor`
@@ -369,6 +423,13 @@ pub const Manager = struct {
 
         var hex: [40]u8 = undefined;
         secp.toHex(&metainfo.infoHash(mi.raw_info), &hex);
+
+        // Checkpoint the created torrent onto the seeds shelf
+        // (`<download_dir>/seeds/<infohash>.torrent`): a stable artifact other
+        // tooling (e.g. the `carl follow` mirror flow) can pick up, independent
+        // of where the data file lives. Best-effort — the seed itself restores
+        // by re-hashing its data file at the persisted path.
+        self.writeSeedTorrent(&hex, mi);
 
         // Per-route seed wiring. Tor stands up a v3 hidden service; I2P opens a
         // SAM session with a stable destination and (after the listener is up)
@@ -817,6 +878,59 @@ pub const Manager = struct {
         self.restoreTransfers();
     }
 
+    /// Best-effort write of a seed's `.torrent` onto the seeds shelf; a failure
+    /// only costs the artifact (the seed still restores by re-hashing its data
+    /// file at the persisted path).
+    fn writeSeedTorrent(self: *Manager, hex: *const [40]u8, mi: metainfo.Metainfo) void {
+        const blob = session_mod.buildTorrentBytes(self.allocator, mi) catch return;
+        defer self.allocator.free(blob);
+        const sdir = self.ensureSeedsDir(self.cfg.download_dir) orelse return;
+        defer self.allocator.free(sdir);
+        const path = std.fmt.allocPrint(self.allocator, "{s}/{s}.torrent", .{ sdir, hex }) catch return;
+        defer self.allocator.free(path);
+        var f = std.fs.cwd().createFile(path, .{ .truncate = true }) catch return;
+        defer f.close();
+        f.writeAll(blob) catch {};
+    }
+
+    /// Retry every retained spec — a persisted transfer whose re-add failed at
+    /// restore (the I2P router / SAM bridge or Tor still starting, a proxy
+    /// down, a file on a not-yet-mounted disk). Called periodically by the
+    /// daemon's health loop, so a seed lost to a slow-starting router comes
+    /// back within one tick (~30s) instead of "after the next restart" — until
+    /// then the transfer existed only as an invisible DB row, which to the user
+    /// reads as "I restarted and my seed is gone". A successful re-add drops
+    /// the retained copy via `register`; failures stay retained for the next
+    /// tick (and the next restart) and are logged at debug to avoid a warning
+    /// every 30s for a genuinely-dead spec.
+    pub fn retryRetained(self: *Manager) void {
+        if (self.restoring.load(.acquire)) return;
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const aa = arena.allocator();
+
+        self.mutex.lock();
+        var specs: std.ArrayList(state_mod.TransferSpec) = .empty;
+        for (self.retained_specs.items) |s| {
+            const src = aa.dupe(u8, s.source) catch break;
+            specs.append(aa, .{ .kind = s.kind, .source = src, .route = s.route, .nostr = s.nostr }) catch break;
+        }
+        self.mutex.unlock();
+
+        for (specs.items) |t| {
+            const res = switch (t.kind) {
+                .download => self.addTransfer(t.source, t.route, t.nostr),
+                .seed => self.addSeed(t.source, t.route, t.nostr),
+            };
+            if (res) |id| {
+                self.allocator.free(id);
+                log.info("retry: restored '{s}'", .{t.source});
+            } else |e| {
+                log.debug("retry: '{s}' still unavailable: {}", .{ t.source, e });
+            }
+        }
+    }
+
     /// Remove every retained spec whose source matches (the spec became live
     /// again, or the caller is discarding it). Caller must hold `mutex` when the
     /// manager is serving (restore runs single-threaded before that).
@@ -867,8 +981,11 @@ pub const Manager = struct {
             if (mt.is_seed or mt.resolved) continue;
             const blob = mt.session.copyTorrent(self.allocator) orelse continue;
             defer self.allocator.free(blob);
-            // Name the file by info-hash (safe; the display name may contain /).
-            const path = std.fmt.allocPrint(self.allocator, "{s}/{s}.carl.torrent", .{ self.cfg.download_dir, &mt.hash_hex }) catch continue;
+            // Name the file by info-hash (safe; the display name may contain /),
+            // on the seeds shelf so every restart recipe lives in one place.
+            const sdir = self.ensureSeedsDir(self.cfg.download_dir) orelse continue;
+            defer self.allocator.free(sdir);
+            const path = std.fmt.allocPrint(self.allocator, "{s}/{s}.torrent", .{ sdir, &mt.hash_hex }) catch continue;
             var wrote = true;
             {
                 var f = std.fs.cwd().createFile(path, .{ .truncate = true }) catch {

--- a/src/session.zig
+++ b/src/session.zig
@@ -2032,7 +2032,8 @@ test "sampleRate counts block bytes as progress before a piece verifies" {
 /// Re-encode a resolved Metainfo into full `.torrent` bytes: a top-level dict
 /// `{ "announce", "info" }`. The info dict is decoded from `raw_info` and
 /// re-encoded canonically, so the info-hash is preserved. Caller owns the result.
-fn buildTorrentBytes(a: Allocator, meta: metainfo.Metainfo) ![]u8 {
+/// Public so the manager can checkpoint created seeds into the seeds shelf.
+pub fn buildTorrentBytes(a: Allocator, meta: metainfo.Metainfo) ![]u8 {
     const info_val = try bencode.decode(a, meta.raw_info);
     defer info_val.deinit(a);
     const entries = [_]bencode.Value.DictEntry{

--- a/src/workdir.zig
+++ b/src/workdir.zig
@@ -69,11 +69,29 @@ pub fn ensure(a: Allocator) Allocator.Error![]u8 {
     return dir;
 }
 
+/// The restart shelf: `<base>/seeds`, a subdirectory of the work dir holding
+/// everything needed to bring transfers back after a restart — each transfer's
+/// resolved `.torrent`, checkpointed as `<infohash>.torrent`. Keeping the
+/// recipes here (instead of pointing at a magnet source or a user file
+/// elsewhere on disk) means a restart never depends on the original seeder
+/// being online or on a file outside carl's own directory. Shared convention:
+/// the `carl follow` mirror flow checkpoints its torrents the same way.
+/// Caller owns the returned slice; the directory is not created here.
+pub fn seedsDir(a: Allocator, base: []const u8) Allocator.Error![]u8 {
+    return std.fmt.allocPrint(a, "{s}/seeds", .{base});
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 const testing = std.testing;
+
+test "seedsDir: appends the seeds shelf to the base dir" {
+    const dir = try seedsDir(testing.allocator, "/tmp/carl-work");
+    defer testing.allocator.free(dir);
+    try testing.expectEqualStrings("/tmp/carl-work/seeds", dir);
+}
 
 test "isPlaceholder: empty and dot are placeholders" {
     try testing.expect(isPlaceholder(testing.allocator, ""));


### PR DESCRIPTION
## What

Seeding survived daemon restarts only on the happy path. This PR makes it durable and gives all restart state one home: the **seeds shelf**, `<download_dir>/seeds/`.

## The three loss vectors fixed

1. **Downloads added from a local `.torrent`** persisted the *picked file's path* as their restart recipe — a Tauri file-picker temp path or a later-cleaned folder meant the restore silently failed. Now the torrent is pinned (copied) to `<seeds>/<infohash>.torrent` and the copy is persisted instead; a restart never depends on a file outside carl's own directory. (Verified in the demo: delete the picked file, restart, transfer comes back seeding.)
2. **Magnet checkpoints** were written loose into the download dir as `<hash>.carl.torrent`; they now land on the shelf with the same `<infohash>.torrent` convention.
3. **Transports unavailable at restore** (i2p seed restored before the router is up, proxy down, data file on an unmounted disk) kept the transfer as an *invisible* DB row retried only at the next restart — which reads as "I restarted and lost my seed". The daemon's 30s health loop now retries retained specs, so the seed reappears within a tick, no restart needed.

UI-created seeds also write their torrent to the shelf as a stable artifact keyed by info-hash.

## PR #52 synergy

`carl follow` checkpoints `<dir>/<infohash>.follow.torrent` today; the new `workdir.seedsDir()` helper + `<seeds>/<infohash>.torrent` convention gives it a shared home — #52 can adopt it with a two-line change.

## Demo (real binaries, isolated config)

1. UI-path seed (`POST /api/seeds`) + download of a `.torrent` picked from `/tmp` → both `seeding`, shelf holds both `<infohash>.torrent` recipes, DB source points into the shelf.
2. Kill daemon, **delete the picked `.torrent`**, restart → `restored 2 transfer(s)`, both seeding at 100%.
3. Restart with the seed's data file hidden (simulates slow I2P router): transfer absent from the UI, log shows `keeping it for retry`; restore the file → within one 30s tick: `retry: restored '...'` — seed back **without a restart**.

## Test plan
- [x] `zig build test` — 253/253 (new: `workdir.seedsDir` unit test)
- [x] Live daemon demo above (steps 1–3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)