### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .carl,
-    .version = "0.1.0",
+    .version = "0.2.0",
     .fingerprint = 0x18cf10e1f7c720be,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carl-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Desktop GUI for carl — privacy-first BitTorrent client",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "carl-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carl-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "Desktop GUI for carl — privacy-first BitTorrent client"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "carl",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "org.carl.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Version bump (0.1.0 → 0.2.0) across build.zig.zon, the desktop package, Tauri config, and Cargo manifest, ahead of the v0.2.0 tag.

Release highlights since v0.1.0-rc1: ~16x faster downloads on high-latency links (#54), persistent seeding via the seeds shelf (#55), `carl follow` mirror mode (#52), stalled/downloading status fix (#51), block-request bounds hardening.

## Test plan
- [x] `zig build test` — 261/261

🤖 Generated with [Claude Code](https://claude.com/claude-code)