### PR TITLE
Fix magnet link peer discovery — correct left=0, multi-tracker fallback, BEP 15 errors

### DIFF
--- a/src/session.zig
+++ b/src/session.zig
@@ -1569,30 +1569,36 @@ pub const Session = struct {
             .event = event,
         };
 
-        // Try announce-list tiers first (BEP 12)
+        // Try announce-list tiers first (BEP 12).
+        // Standard BEP 12 stops at the first successful response in a tier,
+        // but a 0-peer response is useless — keep trying the next tracker in
+        // the tier so we don't give up when only the first tracker is empty.
         if (self.meta.announce_list) |tiers| {
             for (tiers) |tier| {
                 for (tier) |url| {
                     if (self.tryAnnounceUrl(url, req)) |resp| {
                         self.handleAnnounceResponse(resp);
-                        return;
+                        if (self.peers.items.len > 0) return;
                     }
                 }
             }
         }
 
         // Fall back to primary announce URL
-        if (self.meta.announce.len > 0) {
+        if (self.peers.items.len == 0 and self.meta.announce.len > 0) {
             if (self.tryAnnounceUrl(self.meta.announce, req)) |resp| {
                 self.handleAnnounceResponse(resp);
-                return;
+                if (self.peers.items.len > 0) return;
             }
         }
 
         // Fall back to DHT (BEP 5)
-        self.tryDhtPeerDiscovery() catch {};
-        if (self.peers.items.len > 0) return;
+        if (self.peers.items.len == 0) {
+            self.tryDhtPeerDiscovery() catch {};
+            if (self.peers.items.len > 0) return;
+        }
 
+        if (self.peers.items.len > 0) return;
         return error.TrackerFailed;
     }
 
@@ -1660,6 +1666,9 @@ pub const Session = struct {
     }
 
     fn computeLeft(self: *Session) u64 {
+        // Before metadata is known (magnet link), report non-zero so trackers
+        // treat us as a leecher and return all peer types.
+        if (self.metadata_only and self.num_pieces == 0) return 16384;
         var remaining: u64 = 0;
         for (0..self.num_pieces) |i| {
             if (!self.our_bitfield.hasPiece(@intCast(i))) {

--- a/src/session.zig
+++ b/src/session.zig
@@ -1569,16 +1569,21 @@ pub const Session = struct {
             .event = event,
         };
 
+        // Terminal events (completed/stopped) just need one tracker ack;
+        // discovery events (started/none) need actual peers.
+        const wants_peers = event != .completed and event != .stopped;
+
         // Try announce-list tiers first (BEP 12).
         // Standard BEP 12 stops at the first successful response in a tier,
-        // but a 0-peer response is useless — keep trying the next tracker in
-        // the tier so we don't give up when only the first tracker is empty.
+        // but a 0-peer response is useless for discovery — keep trying the
+        // next tracker in the tier until peers appear.  Terminal events
+        // return after any successful ack.
         if (self.meta.announce_list) |tiers| {
             for (tiers) |tier| {
                 for (tier) |url| {
                     if (self.tryAnnounceUrl(url, req)) |resp| {
                         self.handleAnnounceResponse(resp);
-                        if (self.peers.items.len > 0) return;
+                        if (!wants_peers or self.peers.items.len > 0) return;
                     }
                 }
             }
@@ -1588,17 +1593,16 @@ pub const Session = struct {
         if (self.peers.items.len == 0 and self.meta.announce.len > 0) {
             if (self.tryAnnounceUrl(self.meta.announce, req)) |resp| {
                 self.handleAnnounceResponse(resp);
-                if (self.peers.items.len > 0) return;
+                if (!wants_peers or self.peers.items.len > 0) return;
             }
         }
 
-        // Fall back to DHT (BEP 5)
-        if (self.peers.items.len == 0) {
+        // Fall back to DHT (BEP 5) — only for discovery, not terminal events
+        if (wants_peers and self.peers.items.len == 0) {
             self.tryDhtPeerDiscovery() catch {};
             if (self.peers.items.len > 0) return;
         }
 
-        if (self.peers.items.len > 0) return;
         return error.TrackerFailed;
     }
 

--- a/src/udp_tracker.zig
+++ b/src/udp_tracker.zig
@@ -7,9 +7,12 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const tracker = @import("tracker.zig");
 
+const log = std.log.scoped(.udp_tracker);
+
 const protocol_id: u64 = 0x41727101980; // magic constant per BEP 15
 const action_connect: u32 = 0;
 const action_announce: u32 = 1;
+const action_error: u32 = 3;
 const timeout_ms: u32 = 5000;
 
 pub const UdpTrackerError = error{
@@ -71,10 +74,15 @@ pub fn announce(
     var recv_buf: [8192]u8 = undefined; // 8KB: holds ~1360 peers in compact format
     const connect_len = recvWithTimeout(sock, &recv_buf) catch return error.Timeout;
 
-    if (connect_len < 16) return error.InvalidResponse;
+    if (connect_len < 8) return error.InvalidResponse;
     const resp_action = std.mem.readInt(u32, recv_buf[0..4], .big);
     const resp_txn = std.mem.readInt(u32, recv_buf[4..8], .big);
-    if (resp_action != action_connect or resp_txn != txn_id1) return error.InvalidResponse;
+    if (resp_txn != txn_id1) return error.InvalidResponse;
+    if (resp_action == action_error) {
+        if (connect_len > 8) log.warn("tracker error: {s}", .{recv_buf[8..connect_len]});
+        return error.InvalidResponse;
+    }
+    if (resp_action != action_connect or connect_len < 16) return error.InvalidResponse;
 
     const connection_id = std.mem.readInt(u64, recv_buf[8..16], .big);
 
@@ -100,10 +108,15 @@ pub fn announce(
 
     const ann_len = recvWithTimeout(sock, &recv_buf) catch return error.Timeout;
 
-    if (ann_len < 20) return error.InvalidResponse;
+    if (ann_len < 8) return error.InvalidResponse;
     const ann_action = std.mem.readInt(u32, recv_buf[0..4], .big);
     const ann_txn = std.mem.readInt(u32, recv_buf[4..8], .big);
-    if (ann_action != action_announce or ann_txn != txn_id2) return error.InvalidResponse;
+    if (ann_txn != txn_id2) return error.InvalidResponse;
+    if (ann_action == action_error) {
+        if (ann_len > 8) log.warn("tracker announce error: {s}", .{recv_buf[8..ann_len]});
+        return error.InvalidResponse;
+    }
+    if (ann_action != action_announce or ann_len < 20) return error.InvalidResponse;
 
     const interval = std.mem.readInt(u32, recv_buf[8..12], .big);
     const leechers = std.mem.readInt(u32, recv_buf[12..16], .big);


### PR DESCRIPTION
## Summary

- `computeLeft()` returned 0 for magnet links (before metadata is known), announcing `left=0` to trackers — some trackers only return leechers to seeds, so if no leechers exist the client gets 0 peers. Now returns 16384 while in metadata-only mode.
- BEP 12 multi-tracker announce stopped at the first successful response even with 0 peers, never trying other trackers in the tier. Now continues through the tier until peers are found, then falls back to the primary URL and DHT only if still at 0.
- UDP tracker (BEP 15) error responses (action=3) were silently discarded as `InvalidResponse`. Now logs the tracker's error message via `std.log.scoped(.udp_tracker)`.

Tested with a real magnet link (13 UDP trackers): first tracker timed out, second returned 200 peers / 377 seeders / 78 leechers.

## Test plan

- [x] `zig build` — clean
- [x] `zig build test` — all pass
- [x] Manual: download magnet with multiple UDP trackers over clearnet — peers discovered via tracker fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)