### PR TITLE
fix: sign + notarize macOS CLI binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,6 @@ jobs:
           zig build -Doptimize=ReleaseSafe
           install -m755 zig-out/bin/carl carl-aarch64-apple-darwin
 
-      - name: Install desktop deps
-        working-directory: desktop
-        run: npm ci
-
       # Decide whether to sign: secrets can't be used in `if:` directly, so read
       # the cert into an env in a step and emit a flag. When absent we must NOT
       # pass the APPLE_* env at all — Tauri treats an *empty* APPLE_CERTIFICATE as
@@ -107,6 +103,51 @@ jobs:
           CERT: ${{ secrets.APPLE_CERTIFICATE }}
         run: |
           if [ -n "$CERT" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"; else echo "enabled=false" >> "$GITHUB_OUTPUT"; fi
+
+      # Sign + notarize the standalone CLI binary so macOS Gatekeeper doesn't
+      # flag it as "damaged" when downloaded from GitHub Releases.
+      - name: Sign + notarize CLI binary
+        if: steps.sign.outputs.enabled == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Import the Developer ID certificate into a temporary keychain
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASS="actions-temp"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > cert.p12
+          security import cert.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
+          rm cert.p12
+
+          # Sign with hardened runtime (required for notarization)
+          codesign --force --options runtime \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            carl-aarch64-apple-darwin
+
+          # Submit for notarization (standalone binaries must be zipped)
+          zip carl-cli-notarize.zip carl-aarch64-apple-darwin
+          xcrun notarytool submit carl-cli-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          rm carl-cli-notarize.zip
+
+      - name: Ad-hoc sign CLI binary
+        if: steps.sign.outputs.enabled != 'true'
+        run: codesign --force --sign - carl-aarch64-apple-darwin
+
+      - name: Install desktop deps
+        working-directory: desktop
+        run: npm ci
 
       - name: Build desktop bundle (signed + notarized)
         if: steps.sign.outputs.enabled == 'true'


### PR DESCRIPTION
## Summary
- The standalone `carl` CLI binary was never signed/notarized, causing macOS Gatekeeper to show "damaged and can't be opened" on download
- Added signing with Developer ID + hardened runtime and notarization via `notarytool` in the release workflow
- Falls back to ad-hoc signing when Apple secrets aren't configured

## Test plan
- [ ] Merge and re-run release workflow for `v0.3.0`
- [ ] Download `carl-aarch64-apple-darwin` from the updated release
- [ ] Verify it runs without Gatekeeper errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)