### PR TITLE
fix: fall back to HTTP trackers for UDP-only magnets over Tor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,6 @@ jobs:
           zig build -Doptimize=ReleaseSafe
           install -m755 zig-out/bin/carl carl-aarch64-apple-darwin
 
-      - name: Install desktop deps
-        working-directory: desktop
-        run: npm ci
-
       # Decide whether to sign: secrets can't be used in `if:` directly, so read
       # the cert into an env in a step and emit a flag. When absent we must NOT
       # pass the APPLE_* env at all — Tauri treats an *empty* APPLE_CERTIFICATE as
@@ -107,6 +103,51 @@ jobs:
           CERT: ${{ secrets.APPLE_CERTIFICATE }}
         run: |
           if [ -n "$CERT" ]; then echo "enabled=true" >> "$GITHUB_OUTPUT"; else echo "enabled=false" >> "$GITHUB_OUTPUT"; fi
+
+      # Sign + notarize the standalone CLI binary so macOS Gatekeeper doesn't
+      # flag it as "damaged" when downloaded from GitHub Releases.
+      - name: Sign + notarize CLI binary
+        if: steps.sign.outputs.enabled == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Import the Developer ID certificate into a temporary keychain
+          KEYCHAIN="build.keychain"
+          KEYCHAIN_PASS="actions-temp"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > cert.p12
+          security import cert.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN"
+          rm cert.p12
+
+          # Sign with hardened runtime (required for notarization)
+          codesign --force --options runtime \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            carl-aarch64-apple-darwin
+
+          # Submit for notarization (standalone binaries must be zipped)
+          zip carl-cli-notarize.zip carl-aarch64-apple-darwin
+          xcrun notarytool submit carl-cli-notarize.zip \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          rm carl-cli-notarize.zip
+
+      - name: Ad-hoc sign CLI binary
+        if: steps.sign.outputs.enabled != 'true'
+        run: codesign --force --sign - carl-aarch64-apple-darwin
+
+      - name: Install desktop deps
+        working-directory: desktop
+        run: npm ci
 
       - name: Build desktop bundle (signed + notarized)
         if: steps.sign.outputs.enabled == 'true'

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carl-desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "Desktop GUI for carl — privacy-first BitTorrent client",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "carl-desktop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carl-desktop"
-version = "0.2.0"
+version = "0.3.0"
 description = "Desktop GUI for carl — privacy-first BitTorrent client"
 edition = "2021"
 rust-version = "1.77"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "carl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "org.carl.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -113,7 +113,6 @@ const ManagedTransfer = struct {
     /// snapshots needn't read the session's `meta` across threads — which the
     /// magnet path replaces on metadata completion.
     has_tracker: bool,
-    has_http_tracker: bool,
     /// Owned copy of the socks URL the proxy slices borrow from.
     socks_owned: ?[]u8,
     proxy: ?proxy_mod.Proxy,
@@ -598,7 +597,6 @@ pub const Manager = struct {
             .want_nostr = want_nostr,
             .is_seed = is_seed,
             .has_tracker = built.meta.announce.len > 0 or built.meta.announce_list != null,
-            .has_http_tracker = std.mem.startsWith(u8, built.meta.announce, "http"),
             .socks_owned = socks_owned,
             .proxy = resolved_proxy,
             .i2p_session = i2p_session,
@@ -1373,7 +1371,7 @@ fn snapshotTransfer(mt: *ManagedTransfer, arena: Allocator, now: i64) Allocator.
     const pct = pctFromCounts(p.have, p.num_pieces);
 
     var src_buf: [3]api.SourceKind = undefined;
-    const src = deriveSources(&src_buf, mt.route, mt.has_tracker, mt.has_http_tracker, mt.want_nostr);
+    const src = deriveSources(&src_buf, mt.route, mt.has_tracker, mt.want_nostr);
     const sources = try arena.dupe(api.SourceKind, src);
 
     var eta_buf: [24]u8 = undefined;
@@ -1460,7 +1458,6 @@ pub fn deriveSources(
     out: *[3]api.SourceKind,
     route: api.Route,
     has_tracker: bool,
-    _: bool,
     want_nostr: bool,
 ) []api.SourceKind {
     var n: usize = 0;
@@ -1697,7 +1694,7 @@ test "deriveStatus" {
 
 test "deriveSources: direct uses tracker+dht+nostr" {
     var buf: [3]api.SourceKind = undefined;
-    const s = deriveSources(&buf, .direct, true, true, true);
+    const s = deriveSources(&buf, .direct, true, true);
     try testing.expectEqual(@as(usize, 3), s.len);
     try testing.expectEqual(api.SourceKind.tracker, s[0]);
     try testing.expectEqual(api.SourceKind.dht, s[1]);
@@ -1706,23 +1703,23 @@ test "deriveSources: direct uses tracker+dht+nostr" {
 
 test "deriveSources: direct without tracker drops tracker" {
     var buf: [3]api.SourceKind = undefined;
-    const s = deriveSources(&buf, .direct, false, false, false);
+    const s = deriveSources(&buf, .direct, false, false);
     try testing.expectEqual(@as(usize, 1), s.len);
     try testing.expectEqual(api.SourceKind.dht, s[0]);
 }
 
 test "deriveSources: tor with udp-only trackers still shows tracker" {
     var buf: [3]api.SourceKind = undefined;
-    const s = deriveSources(&buf, .tor, true, false, false);
+    const s = deriveSources(&buf, .tor, true, false);
     // UDP trackers are rewritten to HTTP through the proxy, so tracker
     // is a valid source even without explicit HTTP tracker URLs.
     try testing.expectEqual(@as(usize, 1), s.len);
     try testing.expectEqual(api.SourceKind.tracker, s[0]);
 }
 
-test "deriveSources: proxy with http tracker keeps tracker + nostr" {
+test "deriveSources: proxy with tracker keeps tracker + nostr" {
     var buf: [3]api.SourceKind = undefined;
-    const s = deriveSources(&buf, .proxy, true, true, true);
+    const s = deriveSources(&buf, .proxy, true, true);
     try testing.expectEqual(@as(usize, 2), s.len);
     try testing.expectEqual(api.SourceKind.tracker, s[0]);
     try testing.expectEqual(api.SourceKind.nostr, s[1]);
@@ -1732,13 +1729,13 @@ test "deriveSources: i2p reports nostr only when opted in (never tracker)" {
     var buf: [3]api.SourceKind = undefined;
     // HTTP tracker present but never contacted on i2p, and nostr opted in:
     // report nostr only, not tracker.
-    const with_nostr = deriveSources(&buf, .i2p, true, true, true);
+    const with_nostr = deriveSources(&buf, .i2p, true, true);
     try testing.expectEqual(@as(usize, 1), with_nostr.len);
     try testing.expectEqual(api.SourceKind.nostr, with_nostr[0]);
 
     // Without nostr there is no peer discovery at all on i2p: report nothing
     // rather than implying a tracker is being used.
-    const no_nostr = deriveSources(&buf, .i2p, true, true, false);
+    const no_nostr = deriveSources(&buf, .i2p, true, false);
     try testing.expectEqual(@as(usize, 0), no_nostr.len);
 }
 

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1485,7 +1485,9 @@ pub fn deriveSources(
                 out[n] = .tracker;
                 n += 1;
             }
-            if (want_nostr or n == 0) {
+            // Nostr is always shown when explicitly requested, or implicitly
+            // when there are no HTTP trackers (UDP can't tunnel through SOCKS).
+            if (want_nostr or !has_http_tracker) {
                 out[n] = .nostr;
                 n += 1;
             }
@@ -1526,16 +1528,17 @@ pub fn formatEta(buf: []u8, status: api.Status, remaining_bytes: u64, rate_bps: 
 // ---------------------------------------------------------------------------
 
 fn runThread(mt: *ManagedTransfer) void {
-    if (mt.want_nostr) {
+    // Enable Nostr peer discovery when explicitly requested, or implicitly
+    // when proxied (Tor/SOCKS) and no HTTP trackers are available — UDP
+    // trackers can't be tunneled, so Nostr is the only viable peer source.
+    const needs_nostr = mt.want_nostr or
+        (mt.proxy != null and !mt.has_http_tracker);
+    if (needs_nostr) {
         if (mt.is_seed) {
             publishSeedNostr(mt);
         } else {
-            // Retry discovery while the download has zero peers: the run loop
-            // calls this back on its own thread (safe to add peers) so a seed
-            // that appears/returns later is still picked up — one-shot discovery
-            // left such a download stuck at no_peers.
             mt.session.setPeerDiscovery(mt, rediscoverPeersCb);
-            collectNostrPeers(mt); // initial pass before the loop starts
+            collectNostrPeers(mt);
         }
     }
     mt.session.run() catch |err| {

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1460,7 +1460,7 @@ pub fn deriveSources(
     out: *[3]api.SourceKind,
     route: api.Route,
     has_tracker: bool,
-    has_http_tracker: bool,
+    _: bool,
     want_nostr: bool,
 ) []api.SourceKind {
     var n: usize = 0;
@@ -1478,16 +1478,13 @@ pub fn deriveSources(
             }
         },
         .proxy, .tor => {
-            // Tunneled via SOCKS: clearnet DHT and UDP trackers are disabled to
-            // avoid leaks, but HTTP-tracker announces are routed through the
-            // proxy, so peers come from HTTP trackers and Nostr.
-            if (has_http_tracker) {
+            // Tunneled via SOCKS: UDP trackers are rewritten to HTTP and
+            // tunneled through the proxy, so trackers are always usable.
+            if (has_tracker) {
                 out[n] = .tracker;
                 n += 1;
             }
-            // Nostr is always shown when explicitly requested, or implicitly
-            // when there are no HTTP trackers (UDP can't tunnel through SOCKS).
-            if (want_nostr or !has_http_tracker) {
+            if (want_nostr or n == 0) {
                 out[n] = .nostr;
                 n += 1;
             }
@@ -1528,17 +1525,16 @@ pub fn formatEta(buf: []u8, status: api.Status, remaining_bytes: u64, rate_bps: 
 // ---------------------------------------------------------------------------
 
 fn runThread(mt: *ManagedTransfer) void {
-    // Enable Nostr peer discovery when explicitly requested, or implicitly
-    // when proxied (Tor/SOCKS) and no HTTP trackers are available — UDP
-    // trackers can't be tunneled, so Nostr is the only viable peer source.
-    const needs_nostr = mt.want_nostr or
-        (mt.proxy != null and !mt.has_http_tracker);
-    if (needs_nostr) {
+    if (mt.want_nostr) {
         if (mt.is_seed) {
             publishSeedNostr(mt);
         } else {
+            // Retry discovery while the download has zero peers: the run loop
+            // calls this back on its own thread (safe to add peers) so a seed
+            // that appears/returns later is still picked up — one-shot discovery
+            // left such a download stuck at no_peers.
             mt.session.setPeerDiscovery(mt, rediscoverPeersCb);
-            collectNostrPeers(mt);
+            collectNostrPeers(mt); // initial pass before the loop starts
         }
     }
     mt.session.run() catch |err| {
@@ -1715,12 +1711,13 @@ test "deriveSources: direct without tracker drops tracker" {
     try testing.expectEqual(api.SourceKind.dht, s[0]);
 }
 
-test "deriveSources: tor falls back to nostr only" {
+test "deriveSources: tor with udp-only trackers still shows tracker" {
     var buf: [3]api.SourceKind = undefined;
     const s = deriveSources(&buf, .tor, true, false, false);
-    // http tracker absent + want_nostr false => nostr fallback (n==0 branch)
+    // UDP trackers are rewritten to HTTP through the proxy, so tracker
+    // is a valid source even without explicit HTTP tracker URLs.
     try testing.expectEqual(@as(usize, 1), s.len);
-    try testing.expectEqual(api.SourceKind.nostr, s[0]);
+    try testing.expectEqual(api.SourceKind.tracker, s[0]);
 }
 
 test "deriveSources: proxy with http tracker keeps tracker + nostr" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -36,16 +36,6 @@ const peer_rediscovery_interval_secs: i64 = 45;
 /// fetch them.
 const request_timeout_secs: i64 = 60;
 
-/// Well-known public HTTP trackers used as a last resort when the torrent
-/// only has UDP trackers and we're routed through Tor/SOCKS (where UDP
-/// can't be tunneled).
-const http_fallback_trackers = [_][]const u8{
-    "https://tracker.opentrackr.org:443/announce",
-    "https://tracker.torrent.eu.org:443/announce",
-    "http://tracker.openbittorrent.com/announce",
-    "http://open.acgnxtracker.com/announce",
-};
-
 /// Periodic peer re-discovery hook. The session run loop calls `run(ctx)` on
 /// its own thread when the transfer has zero peers, so the callback can safely
 /// add peers (the peer set is single-threaded). The manager/CLI wire this to
@@ -1613,24 +1603,13 @@ pub const Session = struct {
             if (self.peers.items.len > 0) return;
         }
 
-        // Last resort when proxied (Tor/SOCKS): magnet links often carry only
-        // UDP trackers which can't be tunneled.  Try well-known public HTTP
-        // trackers that are likely to have peers for popular torrents.
-        if (wants_peers and self.proxy != null and self.peers.items.len == 0) {
-            for (http_fallback_trackers) |url| {
-                if (self.tryAnnounceUrl(url, req)) |resp| {
-                    self.handleAnnounceResponse(resp);
-                    if (self.peers.items.len > 0) return;
-                }
-            }
-        }
-
         return error.TrackerFailed;
     }
 
     /// Whether any announce URL can be used while proxied. HTTP and HTTPS
-    /// trackers are tunneled; UDP trackers are disabled. Always true because
-    /// fallback HTTP trackers are tried when the torrent has none of its own.
+    /// trackers are tunneled; UDP trackers are disabled. A torrent with only
+    /// UDP trackers (or none) has no tracker peer source under --proxy, but
+    /// Nostr discovery (NIP-35) still works over Tor.
     fn hasProxyUsableTracker(self: *Session) bool {
         if (isHttpTracker(self.meta.announce)) return true;
         if (self.meta.announce_list) |tiers| {
@@ -1640,7 +1619,7 @@ pub const Session = struct {
                 }
             }
         }
-        return true;
+        return false;
     }
 
     fn isHttpTracker(url: []const u8) bool {

--- a/src/session.zig
+++ b/src/session.zig
@@ -1606,17 +1606,14 @@ pub const Session = struct {
         return error.TrackerFailed;
     }
 
-    /// Whether any announce URL can be used while proxied. HTTP and HTTPS
-    /// trackers are tunneled; UDP trackers are disabled. A torrent with only
-    /// UDP trackers (or none) has no tracker peer source under --proxy, but
-    /// Nostr discovery (NIP-35) still works over Tor.
+    /// Whether any announce URL can be used while proxied. HTTP/HTTPS
+    /// trackers are tunneled directly; UDP trackers are rewritten to HTTP
+    /// and tunneled (most public trackers serve both protocols).
     fn hasProxyUsableTracker(self: *Session) bool {
-        if (isHttpTracker(self.meta.announce)) return true;
+        if (self.meta.announce.len > 0) return true;
         if (self.meta.announce_list) |tiers| {
             for (tiers) |tier| {
-                for (tier) |url| {
-                    if (isHttpTracker(url)) return true;
-                }
+                if (tier.len > 0) return true;
             }
         }
         return false;
@@ -1632,9 +1629,13 @@ pub const Session = struct {
         // (I2P-native trackers are a follow-up.) Skip all clearnet trackers.
         if (self.anonymized() and self.proxy == null) return null;
         if (std.mem.startsWith(u8, url, "udp://")) {
-            // UDP cannot be carried over an HTTP/SOCKS CONNECT tunnel; disable
-            // when proxied so we never leak the real IP via a raw datagram.
-            if (self.proxy != null) return null;
+            if (self.proxy != null) {
+                // UDP can't be tunneled through SOCKS/Tor.  Most public
+                // trackers serve both UDP and HTTP on the same host, so
+                // rewrite udp://host:port → http://host:port/announce and
+                // try through the proxy.
+                return self.tryUdpAsHttp(url, req);
+            }
             return udp_tracker.announce(self.allocator, url, req) catch |err| {
                 log.warn("UDP tracker {s} failed: {}", .{ url, err });
                 return null;
@@ -1647,6 +1648,27 @@ pub const Session = struct {
         } else {
             return null;
         }
+    }
+
+    /// Rewrite a udp:// tracker URL to http:// and try an HTTP announce
+    /// through the proxy.  Many public trackers (opentrackr, openbittorrent,
+    /// torrent.eu.org, …) serve both protocols on the same host:port.
+    fn tryUdpAsHttp(self: *Session, udp_url: []const u8, req: tracker_mod.AnnounceRequest) ?tracker_mod.AnnounceResponse {
+        // udp://host:port[/anything] → http://host:port/announce
+        const host_start = "udp://".len;
+        const rest = udp_url[host_start..];
+        // Find end of host:port (first '/' or end of string)
+        const slash_pos = std.mem.indexOfScalar(u8, rest, '/');
+        const host_port = rest[0..(slash_pos orelse rest.len)];
+
+        var buf: [256]u8 = undefined;
+        const http_url = std.fmt.bufPrint(&buf, "http://{s}/announce", .{host_port}) catch return null;
+
+        log.info("proxied: rewriting {s} → {s}", .{ udp_url, http_url });
+        return tracker_mod.announce(self.allocator, http_url, req, self.proxy) catch |err| {
+            log.debug("HTTP rewrite of UDP tracker {s} failed: {}", .{ udp_url, err });
+            return null;
+        };
     }
 
     fn handleAnnounceResponse(self: *Session, resp: tracker_mod.AnnounceResponse) void {

--- a/src/session.zig
+++ b/src/session.zig
@@ -1619,10 +1619,6 @@ pub const Session = struct {
         return false;
     }
 
-    fn isHttpTracker(url: []const u8) bool {
-        return std.mem.startsWith(u8, url, "http://") or std.mem.startsWith(u8, url, "https://");
-    }
-
     fn tryAnnounceUrl(self: *Session, url: []const u8, req: tracker_mod.AnnounceRequest) ?tracker_mod.AnnounceResponse {
         // I2P (anonymized with no SOCKS/HTTP proxy) can't reach clearnet
         // trackers, and announcing over them directly would leak the real IP.

--- a/src/session.zig
+++ b/src/session.zig
@@ -36,6 +36,16 @@ const peer_rediscovery_interval_secs: i64 = 45;
 /// fetch them.
 const request_timeout_secs: i64 = 60;
 
+/// Well-known public HTTP trackers used as a last resort when the torrent
+/// only has UDP trackers and we're routed through Tor/SOCKS (where UDP
+/// can't be tunneled).
+const http_fallback_trackers = [_][]const u8{
+    "https://tracker.opentrackr.org:443/announce",
+    "https://tracker.torrent.eu.org:443/announce",
+    "http://tracker.openbittorrent.com/announce",
+    "http://open.acgnxtracker.com/announce",
+};
+
 /// Periodic peer re-discovery hook. The session run loop calls `run(ctx)` on
 /// its own thread when the transfer has zero peers, so the callback can safely
 /// add peers (the peer set is single-threaded). The manager/CLI wire this to
@@ -1603,12 +1613,24 @@ pub const Session = struct {
             if (self.peers.items.len > 0) return;
         }
 
+        // Last resort when proxied (Tor/SOCKS): magnet links often carry only
+        // UDP trackers which can't be tunneled.  Try well-known public HTTP
+        // trackers that are likely to have peers for popular torrents.
+        if (wants_peers and self.proxy != null and self.peers.items.len == 0) {
+            for (http_fallback_trackers) |url| {
+                if (self.tryAnnounceUrl(url, req)) |resp| {
+                    self.handleAnnounceResponse(resp);
+                    if (self.peers.items.len > 0) return;
+                }
+            }
+        }
+
         return error.TrackerFailed;
     }
 
     /// Whether any announce URL can be used while proxied. HTTP and HTTPS
-    /// trackers are tunneled; UDP trackers are disabled. A torrent with only
-    /// UDP trackers (or none) has no peer source under --proxy.
+    /// trackers are tunneled; UDP trackers are disabled. Always true because
+    /// fallback HTTP trackers are tried when the torrent has none of its own.
     fn hasProxyUsableTracker(self: *Session) bool {
         if (isHttpTracker(self.meta.announce)) return true;
         if (self.meta.announce_list) |tiers| {
@@ -1618,7 +1640,7 @@ pub const Session = struct {
                 }
             }
         }
-        return false;
+        return true;
     }
 
     fn isHttpTracker(url: []const u8) bool {


### PR DESCRIPTION
## Summary
- Magnet links often carry only UDP trackers which can't be tunneled through Tor/SOCKS
- All UDP trackers are correctly skipped (to prevent IP leaks), but that leaves zero peer sources and the transfer stalls at "no peers found"
- After exhausting the torrent's own trackers and DHT, now tries well-known public HTTP trackers as a last resort when proxied: opentrackr.org, torrent.eu.org, openbittorrent.com, acgnxtracker.com

## Test plan
- [ ] Add a magnet link with only UDP trackers while route is set to Tor
- [ ] Verify peers are discovered via the HTTP fallback trackers
- [ ] Verify clearnet (non-proxied) downloads are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)