### PR TITLE
feat: multi-file magnet, Tor peer cap, NIP-35 broadcast on complete

### DIFF
--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -49,6 +49,13 @@ const max_body: usize = 256 * 1024 * 1024;
 /// ever show relays as "configured" (never connected).
 const probe_interval_ns: u64 = 30 * std.time.ns_per_s;
 
+/// After this many consecutive all-unreachable probe cycles, the prober
+/// backs off to `backoff_interval_ns` to stop flooding the logs and
+/// wasting Tor circuits. Resets to the normal interval on the first
+/// successful probe.
+const max_consecutive_failures: u8 = 3;
+const backoff_interval_ns: u64 = 5 * 60 * std.time.ns_per_s;
+
 pub const Daemon = struct {
     allocator: Allocator,
     manager: *manager_mod.Manager,
@@ -63,6 +70,8 @@ pub const Daemon = struct {
     proxy_state: proxy_mod.ProxyState = .ok,
     proxy_reply: ?u8 = null,
     proxy_probed: bool = false,
+    /// Consecutive probe cycles where every relay was unreachable.
+    relay_fail_streak: u8 = 0,
 
     /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
     pub fn serve(self: *Daemon, port: u16) !void {
@@ -251,8 +260,12 @@ pub const Daemon = struct {
             // down) so they come back within a tick instead of after the next
             // restart — until now they existed only as invisible DB rows.
             self.manager.retryRetained();
+            const interval = if (self.relay_fail_streak >= max_consecutive_failures)
+                backoff_interval_ns
+            else
+                probe_interval_ns;
             var slept: u64 = 0;
-            while (slept < probe_interval_ns and
+            while (slept < interval and
                 self.running.load(.acquire) and
                 !session_mod.shutdown_requested.load(.acquire)) : (slept += 250 * std.time.ns_per_ms)
             {
@@ -278,6 +291,7 @@ pub const Daemon = struct {
         }
 
         var list: std.ArrayList(api.Relay) = .empty;
+        var any_connected = false;
         for (urls) |url| {
             const onion = std.mem.indexOf(u8, url, ".onion") != null;
             var state: []const u8 = "configured";
@@ -286,6 +300,7 @@ pub const Daemon = struct {
                     var rc = r;
                     rc.deinit();
                     state = "connected";
+                    any_connected = true;
                 } else |_| {
                     state = "unreachable";
                 }
@@ -305,6 +320,17 @@ pub const Daemon = struct {
             list.deinit(a);
             return;
         };
+
+        if (any_connected) {
+            self.relay_fail_streak = 0;
+        } else if (urls.len > 0) {
+            self.relay_fail_streak +|= 1;
+            if (self.relay_fail_streak == max_consecutive_failures) {
+                log.warn("all relays unreachable {d}x in a row, backing off to {d}s interval", .{
+                    max_consecutive_failures, backoff_interval_ns / std.time.ns_per_s,
+                });
+            }
+        }
 
         self.health_mutex.lock();
         const old = self.health;

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -27,6 +27,7 @@ const i2p_sam = @import("i2p_sam.zig");
 const i2p_seed = @import("i2p_seed.zig");
 const extension = @import("extension.zig");
 const relay_mod = @import("relay.zig");
+const nip35 = @import("nip35.zig");
 const peer_announce = @import("peer_announce.zig");
 const seeding = @import("seeding.zig");
 const tor_control = @import("tor_control.zig");
@@ -1526,16 +1527,67 @@ fn runThread(mt: *ManagedTransfer) void {
         if (mt.is_seed) {
             publishSeedNostr(mt);
         } else {
-            // Retry discovery while the download has zero peers: the run loop
-            // calls this back on its own thread (safe to add peers) so a seed
-            // that appears/returns later is still picked up — one-shot discovery
-            // left such a download stuck at no_peers.
             mt.session.setPeerDiscovery(mt, rediscoverPeersCb);
-            collectNostrPeers(mt); // initial pass before the loop starts
+            mt.session.setOnComplete(mt, onDownloadCompleteCb);
+            collectNostrPeers(mt);
         }
     }
     mt.session.run() catch |err| {
         log.err("transfer {s}: session error: {}", .{ mt.id, err });
+    };
+}
+
+/// `Session.OnComplete` callback: broadcast the completed torrent on Nostr
+/// (NIP-35 kind-2003) if no event for this info-hash exists on the configured
+/// relays yet. Runs on the session thread after all pieces are verified.
+fn onDownloadCompleteCb(ctx: *anyopaque) void {
+    const mt: *ManagedTransfer = @ptrCast(@alignCast(ctx));
+    broadcastIfNew(mt);
+}
+
+/// Query relays for existing kind-2003 events matching this info-hash. If none
+/// are found, publish a new NIP-35 torrent event so the Nostr collection grows
+/// organically as users complete downloads.
+fn broadcastIfNew(mt: *ManagedTransfer) void {
+    const a = mt.allocator;
+    const relay_urls = nostr_config.readRelays(a) catch return;
+    defer nostr_config.freeRelays(a, relay_urls);
+
+    var ih_hex: [40]u8 = undefined;
+    secp.toHex(&mt.info_hash, &ih_hex);
+
+    const filter: nostr_mod.Filter = .{
+        .kinds = &.{nip35.kind_torrent},
+        .tags = &.{.{ .letter = 'x', .values = &.{&ih_hex} }},
+        .limit = 1,
+    };
+
+    for (relay_urls) |url| {
+        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
+        defer r.deinit();
+        const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
+            .timeout_ms = 8_000,
+            .max_events = 1,
+        }) catch continue;
+        defer {
+            for (events) |e| e.deinit(a);
+            a.free(events);
+        }
+        if (events.len > 0) {
+            log.info("transfer {s}: torrent already on nostr, skipping broadcast", .{mt.id});
+            return;
+        }
+    }
+
+    log.info("transfer {s}: broadcasting torrent to nostr (NIP-35)", .{mt.id});
+    const ann: seeding.Announce = if (mt.hidden) |h|
+        .{ .onion = .{ .host = h.onion_host, .port = h.onion_port } }
+    else if (mt.i2p_host) |host|
+        .{ .i2p = .{ .host = host, .port = 0 } }
+    else
+        .none;
+    seeding.publish(a, mt.meta, mt.info_hash, ann, "", mt.proxy) catch |err| {
+        log.warn("transfer {s}: nostr broadcast failed: {}", .{ mt.id, err });
     };
 }
 

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -567,7 +567,7 @@ fn readSocks5Reply(stream: std.net.Stream) ProxyError!void {
     if (head[1] != 0x00) {
         // REP != succeeded: log the reason (0x05 refused, 0x04 host unreachable,
         // 0x02 not allowed by ruleset, ...) so proxy failures are debuggable.
-        log.warn("SOCKS5 CONNECT rejected: REP=0x{x:0>2}", .{head[1]});
+        log.debug("SOCKS5 CONNECT rejected: REP=0x{x:0>2}", .{head[1]});
         return error.HandshakeFailed;
     }
 

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -34,7 +34,7 @@ pub const Relay = struct {
         // relay; Tor secures it), `wss://` runs cert-verified TLS on top of the
         // proxied stream (the proxy only ever sees ciphertext).
         const conn = ws.Conn.connect(allocator, url, .{ .proxy = proxy }) catch |err| {
-            log.warn("relay connect to {s} failed: {}", .{ url, err });
+            log.debug("relay connect to {s} failed: {}", .{ url, err });
             return error.ConnectFailed;
         };
         return .{ .allocator = allocator, .url = url, .conn = conn };

--- a/src/session.zig
+++ b/src/session.zig
@@ -45,6 +45,14 @@ pub const PeerDiscovery = struct {
     run: *const fn (ctx: *anyopaque) void,
 };
 
+/// Fired once when a download completes (all pieces verified). Runs on the
+/// session thread, so it can read session state safely. The manager wires
+/// this to publish the torrent on Nostr (NIP-35) if not already present.
+pub const OnComplete = struct {
+    ctx: *anyopaque,
+    run: *const fn (ctx: *anyopaque) void,
+};
+
 /// Global flag for graceful shutdown on SIGINT. Atomic because it's
 /// written from a signal handler and read from event loop / test threads.
 pub var shutdown_requested = std.atomic.Value(bool).init(false);
@@ -199,6 +207,9 @@ pub const Session = struct {
     peer_discovery: ?PeerDiscovery = null,
     /// Timestamp of the last peer re-discovery, to rate-limit retries.
     last_peer_discovery_s: i64 = 0,
+    /// Fired once when a download completes. The manager uses this to broadcast
+    /// the torrent on Nostr (NIP-35) if not already present on relays.
+    on_complete: ?OnComplete = null,
 
     // Progress tracking
     start_time: i64,
@@ -455,6 +466,10 @@ pub const Session = struct {
         self.peer_discovery = .{ .ctx = ctx, .run = run_fn };
     }
 
+    pub fn setOnComplete(self: *Session, ctx: *anyopaque, run_fn: *const fn (ctx: *anyopaque) void) void {
+        self.on_complete = .{ .ctx = ctx, .run = run_fn };
+    }
+
     pub fn run(self: *Session) !void {
         const stdout = std.fs.File.stdout().deprecatedWriter();
         const stderr = std.fs.File.stderr().deprecatedWriter();
@@ -493,7 +508,7 @@ pub const Session = struct {
             }
             self.doMultiTrackerAnnounce(.started) catch |err| {
                 if (has_trackers) {
-                    stderr.print("all trackers failed: {}\n", .{err}) catch {};
+                    log.debug("all trackers failed: {}", .{err});
                 }
             };
         } else {
@@ -506,6 +521,7 @@ pub const Session = struct {
             if (self.mode == .download and !self.metadata_only and self.num_pieces > 0 and self.our_bitfield.isComplete()) {
                 stdout.print("\ndownload complete!\n", .{}) catch {};
                 self.doMultiTrackerAnnounce(.completed) catch {};
+                if (self.on_complete) |cb| cb.run(cb.ctx);
 
                 // By default `download` is done now -- stop the loop and let the
                 // process exit instead of lingering as a seeder forever (which,
@@ -1011,11 +1027,49 @@ pub const Session = struct {
         const pieces_val = info_val.dictGet("pieces") orelse return error.InvalidMetadata;
         const pieces_str = pieces_val.asString() orelse return error.InvalidMetadata;
 
-        // Build file list
-        const files = if (info_val.dictGet("files")) |_|
-            // Multi-file magnet torrents not yet supported
-            return error.InvalidMetadata
-        else blk: {
+        // Build file list (single-file or multi-file)
+        const files = if (info_val.dictGet("files")) |files_val| blk: {
+            const file_list = files_val.asList() orelse return error.InvalidMetadata;
+            var files_arr: std.ArrayList(metainfo.FileInfo) = .empty;
+            errdefer {
+                for (files_arr.items) |fi| {
+                    for (fi.path) |comp| self.allocator.free(comp);
+                    self.allocator.free(fi.path);
+                }
+                files_arr.deinit(self.allocator);
+            }
+            for (file_list) |file_val| {
+                const fl_val = file_val.dictGet("length") orelse continue;
+                const fl: u64 = std.math.cast(u64, fl_val.asInt() orelse continue) orelse continue;
+                const fp_val = file_val.dictGet("path") orelse continue;
+                const fp_list = fp_val.asList() orelse continue;
+                var path_arr: std.ArrayList([]const u8) = .empty;
+                errdefer {
+                    for (path_arr.items) |comp| self.allocator.free(comp);
+                    path_arr.deinit(self.allocator);
+                }
+                for (fp_list) |comp_val| {
+                    const cs = comp_val.asString() orelse continue;
+                    const comp = self.allocator.dupe(u8, cs) catch return error.OutOfMemory;
+                    path_arr.append(self.allocator, comp) catch {
+                        self.allocator.free(comp);
+                        return error.OutOfMemory;
+                    };
+                }
+                if (path_arr.items.len == 0) {
+                    path_arr.deinit(self.allocator);
+                    continue;
+                }
+                const fi_path = path_arr.toOwnedSlice(self.allocator) catch return error.OutOfMemory;
+                files_arr.append(self.allocator, .{ .length = fl, .path = fi_path }) catch {
+                    for (fi_path) |comp| self.allocator.free(comp);
+                    self.allocator.free(fi_path);
+                    return error.OutOfMemory;
+                };
+            }
+            if (files_arr.items.len == 0) return error.InvalidMetadata;
+            break :blk @as([]const metainfo.FileInfo, files_arr.toOwnedSlice(self.allocator) catch return error.OutOfMemory);
+        } else blk: {
             const length_val = info_val.dictGet("length") orelse return error.InvalidMetadata;
             const length = std.math.cast(u64, length_val.asInt() orelse return error.InvalidMetadata) orelse return error.InvalidMetadata;
 
@@ -1660,11 +1714,12 @@ pub const Session = struct {
         var buf: [256]u8 = undefined;
         const http_url = std.fmt.bufPrint(&buf, "http://{s}/announce", .{host_port}) catch return null;
 
-        log.info("proxied: rewriting {s} → {s}", .{ udp_url, http_url });
-        return tracker_mod.announce(self.allocator, http_url, req, self.proxy) catch |err| {
+        const resp = tracker_mod.announce(self.allocator, http_url, req, self.proxy) catch |err| {
             log.debug("HTTP rewrite of UDP tracker {s} failed: {}", .{ udp_url, err });
             return null;
         };
+        log.info("proxied: rewriting {s} → {s}", .{ udp_url, http_url });
+        return resp;
     }
 
     fn handleAnnounceResponse(self: *Session, resp: tracker_mod.AnnounceResponse) void {
@@ -1702,8 +1757,24 @@ pub const Session = struct {
     }
 
     fn connectToPeers(self: *Session, peer_list: []const tracker_mod.Peer) !void {
-        for (peer_list) |tracker_peer| {
+        // Each proxied connection attempt takes ~10s through Tor (SOCKS
+        // handshake + circuit). Trying all 50 peers serially would block
+        // the session thread for minutes. Cap attempts per call; the
+        // tracker re-announce cycle gradually fills the peer pool.
+        const max_attempts: usize = if (self.proxy != null) 10 else 50;
+        var attempts: usize = 0;
+
+        // Rotate start offset so repeated announces don't always retry
+        // the same failing peers at the front of the list.
+        const offset = if (peer_list.len > 0)
+            std.crypto.random.intRangeAtMost(usize, 0, peer_list.len - 1)
+        else
+            0;
+
+        for (0..peer_list.len) |i| {
+            const tracker_peer = peer_list[(i + offset) % peer_list.len];
             if (self.peers.items.len >= max_peers) break;
+            if (attempts >= max_attempts) break;
 
             const addr = std.net.Address.initIp4(tracker_peer.ip, tracker_peer.port);
             var already = false;
@@ -1714,6 +1785,8 @@ pub const Session = struct {
                 }
             }
             if (already) continue;
+
+            attempts += 1;
 
             const p = self.allocator.create(peer_mod.PeerConnection) catch continue;
             p.* = peer_mod.PeerConnection.init(self.allocator, addr);

--- a/src/tracker.zig
+++ b/src/tracker.zig
@@ -236,7 +236,7 @@ pub fn announce(
 /// nothing is ever sent directly.
 fn announceThroughProxy(allocator: Allocator, proxy: proxy_mod.Proxy, url: []const u8) TrackerError!AnnounceResponse {
     const body = proxy_mod.httpGet(allocator, proxy, url, null) catch |err| {
-        log.warn("proxied tracker announce failed: {}", .{err});
+        log.debug("proxied tracker announce failed: {}", .{err});
         return error.HttpError;
     };
     defer allocator.free(body);

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -166,7 +166,7 @@ pub const Conn = struct {
             // never learns our IP -- the whole connection rides the proxy/Tor.
             if (options.proxy) |px| {
                 const stream = proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
-                    log.warn("wss proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                    log.debug("wss proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
                     return error.ConnectFailed;
                 };
                 var conn = Conn{
@@ -229,7 +229,7 @@ pub const Conn = struct {
         // top -- no redundant TLS layer needed.
         const stream = if (options.proxy) |px|
             proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
-                log.warn("ws proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                log.debug("ws proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
                 return error.ConnectFailed;
             }
         else


### PR DESCRIPTION
## Summary
- Parse multi-file torrents in `onMetadataComplete` (BEP 3 `files` key) — previously returned `error.InvalidMetadata`
- Cap proxied peer connection attempts to 10/cycle with random offset rotation — prevents blocking session thread 500s+ through Tor
- Broadcast completed downloads to Nostr (NIP-35 kind-2003) if not already present on relays
- Relay health probe backoff: 30s → 5min after 3 consecutive all-unreachable cycles
- Downgrade expected proxy/relay/tracker failures from `warn` to `debug`
- Log UDP→HTTP rewrite only on success

## Test plan
- [x] `zig build test` passes
- [x] Multi-file magnet tested with 4 Harry Potter torrents — all resolved metadata correctly
- [x] Tor download reached endgame mode with peer connect cap active
- [x] Persistence survives daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)