### PR TITLE
fix: clarify supported Zig version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ A BitTorrent client written in pure Zig. The BitTorrent core has zero Zig packag
 
 ## Building
 
-Requires **Zig 0.15+**. The build fetches `libsecp256k1` via `build.zig.zon` on first run; everything else is pure Zig.
+Requires **Zig 0.15.2**, matching the version pinned in CI and `build.zig.zon`.
+Newer Zig releases, including 0.16, are not supported until the codebase is
+ported and CI is updated to pin that version. The build fetches `libsecp256k1`
+via `build.zig.zon` on first run; everything else is pure Zig.
 
 ```sh
 zig build          # compile


### PR DESCRIPTION
Fixes #63

What was broken:
- README said Zig 0.15+, which implied support for newer Zig releases such as 0.16.

Root cause:
- CI and build.zig.zon pin Zig 0.15.2, but the README used an open-ended compatibility claim.

What changed:
- README now states Zig 0.15.2 and explains newer Zig releases need an explicit port and CI pin.

Verified:
- zig build
- zig build test
- zig fmt --check src/