### PR TITLE
Keep slow add/seed requests alive past WKWebView's 60s idle kill

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -250,13 +250,18 @@ fn open_daemon_log() -> SharedLog {
 }
 
 /// Drain one daemon output stream to EOF, teeing lines into the log file.
+///
+/// Byte-oriented on purpose: `read_line` into a String fails the whole drain
+/// loop on the first non-UTF-8 byte (a torrent/peer name logged raw), the
+/// pipe then fills, and the daemon blocks forever on its next stderr write —
+/// the exact "offline daemon" hang this log exists to diagnose.
 fn drain_to_log<R: std::io::Read>(mut reader: BufReader<R>, log: SharedLog) {
-    let mut buf = String::new();
-    while reader.read_line(&mut buf).unwrap_or(0) > 0 {
+    let mut buf: Vec<u8> = Vec::new();
+    while reader.read_until(b'\n', &mut buf).unwrap_or(0) > 0 {
         if let Ok(mut guard) = log.lock() {
             if let Some(f) = guard.as_mut() {
                 use std::io::Write;
-                let _ = f.write_all(buf.as_bytes());
+                let _ = f.write_all(&buf);
             }
         }
         buf.clear();
@@ -314,11 +319,23 @@ fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
         // (not crashed) daemon still reaches stderr EOF and can't leak.
         let _ = child.kill();
         let mut tail = String::new();
-        if let Some(mut err) = child.stderr.take() {
+        if let Some(err) = child.stderr.take() {
             use std::io::Read;
-            let mut all = String::new();
-            let _ = err.read_to_string(&mut all);
-            tail = all.chars().rev().take(2048).collect::<String>().chars().rev().collect();
+            // Cap the read: read_to_end would block until stderr EOF, which a
+            // inherited-fd grandchild could withhold forever. Bytes + lossy
+            // because the daemon's log is not guaranteed UTF-8, and
+            // read_to_string would then discard the tail we came for.
+            let mut all = Vec::new();
+            let _ = err.take(8192).read_to_end(&mut all);
+            let lossy = String::from_utf8_lossy(&all);
+            tail = lossy
+                .chars()
+                .rev()
+                .take(2048)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
         }
         return Err(format!(
             "daemon did not report a token within 10s. daemon log tail:\n{tail}"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -223,6 +223,46 @@ fn uninstall_cli(system: bool) -> Result<(), String> {
     }
 }
 
+/// The daemon log file the shell tees the sidecar's output into:
+/// `<config>/carl/daemon.log`, with the same config-dir resolution the daemon
+/// itself uses (`$XDG_CONFIG_HOME/carl`, else `~/.config/carl`). Rotated to
+/// `daemon.log.old` past 2 MiB so a chatty daemon can't fill the disk.
+/// Returns a shareable handle; None if the file can't be opened (draining
+/// still happens, just discarded, so the pipe never blocks the daemon).
+type SharedLog = std::sync::Arc<std::sync::Mutex<Option<std::fs::File>>>;
+
+fn open_daemon_log() -> SharedLog {
+    let file = (|| -> Option<std::fs::File> {
+        let config = std::env::var("XDG_CONFIG_HOME")
+            .map(std::path::PathBuf::from)
+            .or_else(|_| std::env::var("HOME").map(|h| std::path::PathBuf::from(h).join(".config")))
+            .ok()?;
+        let dir = config.join("carl");
+        std::fs::create_dir_all(&dir).ok()?;
+        let path = dir.join("daemon.log");
+        const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
+        if std::fs::metadata(&path).map(|m| m.len() > MAX_LOG_BYTES).unwrap_or(false) {
+            let _ = std::fs::rename(&path, dir.join("daemon.log.old"));
+        }
+        std::fs::OpenOptions::new().create(true).append(true).open(path).ok()
+    })();
+    std::sync::Arc::new(std::sync::Mutex::new(file))
+}
+
+/// Drain one daemon output stream to EOF, teeing lines into the log file.
+fn drain_to_log<R: std::io::Read>(mut reader: BufReader<R>, log: SharedLog) {
+    let mut buf = String::new();
+    while reader.read_line(&mut buf).unwrap_or(0) > 0 {
+        if let Ok(mut guard) = log.lock() {
+            if let Some(f) = guard.as_mut() {
+                use std::io::Write;
+                let _ = f.write_all(buf.as_bytes());
+            }
+        }
+        buf.clear();
+    }
+}
+
 /// Spawn `carl daemon` and block (with a timeout) until it reports its token.
 fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
     let bin = resolve_carl_bin();
@@ -240,6 +280,10 @@ fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
     cmd.args(["daemon", "--port", &port_s, "--parent-pid", &pid_s]);
     let mut child = cmd
         .stdout(Stdio::piped())
+        // Pipe stderr too so the daemon's log (Zig std.log goes to stderr)
+        // lands in the log file below instead of vanishing when the app is
+        // launched from Finder (no console attached).
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to spawn '{bin}': {e}"))?;
 
@@ -264,16 +308,35 @@ fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
         }
     }
     if token.is_empty() {
-        return Err("daemon did not report a token within 10s".to_string());
+        // Surface the daemon's own log tail — a daemon that won't start is
+        // the top cause of a permanently "offline" GUI, and its reason
+        // otherwise vanishes with the discarded pipes. Kill first so a wedged
+        // (not crashed) daemon still reaches stderr EOF and can't leak.
+        let _ = child.kill();
+        let mut tail = String::new();
+        if let Some(mut err) = child.stderr.take() {
+            use std::io::Read;
+            let mut all = String::new();
+            let _ = err.read_to_string(&mut all);
+            tail = all.chars().rev().take(2048).collect::<String>().chars().rev().collect();
+        }
+        return Err(format!(
+            "daemon did not report a token within 10s. daemon log tail:\n{tail}"
+        ));
     }
 
-    // Keep draining stdout so the daemon's pipe never fills and blocks it.
-    std::thread::spawn(move || {
-        let mut buf = String::new();
-        while reader.read_line(&mut buf).unwrap_or(0) > 0 {
-            buf.clear();
-        }
-    });
+    // Keep draining stdout so the daemon's pipe never fills and blocks it —
+    // and tee it (plus stderr, which carries the daemon's actual log) into
+    // `<config>/carl/daemon.log`. Without this the daemon's output is
+    // discarded entirely, so a crash/wedged daemon in the packaged app leaves
+    // no trace and the GUI's bare "offline" badge is undiagnosable.
+    let log_file = open_daemon_log();
+    let stderr = child.stderr.take();
+    let stdout_log = log_file.clone();
+    std::thread::spawn(move || drain_to_log(reader, stdout_log));
+    if let Some(stderr) = stderr {
+        std::thread::spawn(move || drain_to_log(BufReader::new(stderr), log_file));
+    }
 
     let cfg = DaemonConfig {
         base: format!("http://127.0.0.1:{port}"),

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -321,12 +321,19 @@ fn spawn_daemon(port: u16) -> Result<(Child, DaemonConfig), String> {
         let mut tail = String::new();
         if let Some(err) = child.stderr.take() {
             use std::io::Read;
-            // Cap the read: read_to_end would block until stderr EOF, which a
-            // inherited-fd grandchild could withhold forever. Bytes + lossy
-            // because the daemon's log is not guaranteed UTF-8, and
-            // read_to_string would then discard the tail we came for.
-            let mut all = Vec::new();
-            let _ = err.take(8192).read_to_end(&mut all);
+            // Read on a helper thread with a deadline: a blocking read here
+            // only ends at stderr EOF, which a future grandchild inheriting
+            // the pipe could withhold forever. Bytes + lossy because the
+            // daemon's log is not guaranteed UTF-8, and read_to_string would
+            // then discard the tail we came for. A timed-out read just means
+            // no tail — the kill above already guarantees the daemon is gone.
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let mut all = Vec::new();
+                let _ = err.take(8192).read_to_end(&mut all);
+                let _ = tx.send(all);
+            });
+            let all = rx.recv_timeout(Duration::from_secs(2)).unwrap_or_default();
             let lossy = String::from_utf8_lossy(&all);
             tail = lossy
                 .chars()

--- a/desktop/src/Sidebar.tsx
+++ b/desktop/src/Sidebar.tsx
@@ -86,7 +86,14 @@ export function Sidebar({
           </div>
           <div className="rstat-row">
             <span className="rstat-lbl">Daemon</span>
-            <span className="rstat-relays">
+            <span
+              className="rstat-relays"
+              title={
+                connected
+                  ? "connected to the carl daemon"
+                  : "daemon unreachable — its log is at ~/.config/carl/daemon.log"
+              }
+            >
               <RelayDot state={connected ? "connected" : "unreachable"} />
               <span className="mono" style={{ fontSize: 11 }}>
                 {connected ? "live" : "offline"}

--- a/desktop/src/api/client.ts
+++ b/desktop/src/api/client.ts
@@ -28,7 +28,13 @@ const REQUEST_TIMEOUT_MS = 8000;
  *  daemon's 60s SAM timeout). The 8s read timeout would abort that mid-build —
  *  the transfer/seed never registers and the UI looks like "i2p doesn't work" —
  *  so add/seed get a timeout that comfortably covers session setup. (A bridge
- *  that's actually down still fails fast: connection refused is instant.) */
+ *  that's actually down still fails fast: connection refused is instant.)
+ *
+ *  Note WKWebView itself kills any request idle for ~60s with
+ *  `TypeError: Load failed` — before the daemon sent interim `102 Processing`
+ *  keep-alives, a slow I2P session build (>60s across its SAM round-trips)
+ *  died here with exactly that error even though the daemon was still
+ *  working. The 90s cap below is still a sane upper bound on top. */
 const SESSION_SETUP_TIMEOUT_MS = 90_000;
 
 /** Matches the daemon's body cap (docs/daemon-api.md) — guard before reading the

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -127,6 +127,15 @@ greeting only — no CONNECT, so it opens no upstream connection) and publishes
 Body: `{ "source": "<magnet|.torrent path|http(s) url>", "route": "direct|proxy|tor", "nostr": bool }`.
 Adds and starts a transfer. Returns `{ "id": "t<N>" }`. `400` on a bad source.
 
+**Long-running POSTs (`/api/transfers`, `/api/seeds`, `/api/torrents`)** may
+block for minutes while the daemon builds an anonymized network session (Tor
+hidden service, I2P SAM tunnels) or hashes a large file. While one is in
+flight the daemon emits interim `102 Processing` responses every ~20s before
+the final response — required so WebKit-based clients (the Tauri shell's
+WKWebView kills any request idle for ~60s with `TypeError: Load failed`)
+survive slow session setup. Any compliant HTTP client already ignores 1xx
+interims; curl and the CLI are unaffected.
+
 ### `DELETE /api/transfers/<id>`
 
 Stops and removes a transfer. `204` on success, `404` if unknown.

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -13,7 +13,7 @@ identity/relays/settings read the real config. See **Not yet wired** at the end.
 ## Running
 
 ```sh
-carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor] [--socks url] \
+carl daemon [--port p] [--bt-port p] [--route direct|proxy|tor|i2p] [--socks url] \
             [--download-dir d] [--token tok] [--parent-pid pid] \
             [--tor-control host:port] [--tor-cookie path] [--tor-onion-port p]
 ```
@@ -124,7 +124,7 @@ greeting only — no CONNECT, so it opens no upstream connection) and publishes
 
 ### `POST /api/transfers`
 
-Body: `{ "source": "<magnet|.torrent path|http(s) url>", "route": "direct|proxy|tor", "nostr": bool }`.
+Body: `{ "source": "<magnet|.torrent path|http(s) url>", "route": "direct|proxy|tor|i2p", "nostr": bool }`.
 Adds and starts a transfer. Returns `{ "id": "t<N>" }`. `400` on a bad source.
 
 **Long-running POSTs (`/api/transfers`, `/api/seeds`, `/api/torrents`)** may
@@ -148,7 +148,7 @@ directly); metadata rides in headers:
 
 - `X-Carl-Filename` (required) — the file name (basename only; path components
   are stripped).
-- `X-Carl-Route` — `direct|proxy|tor` (default `tor`).
+- `X-Carl-Route` — `direct|proxy|tor|i2p` (default `tor`).
 - `X-Carl-Nostr` — `true|false`; when true, publishes a NIP-35 torrent event so
   it's discoverable.
 
@@ -199,7 +199,7 @@ Returns `[DiscoverResult]`. Routed through the proxy when the route isn't direct
 
 Body may contain any subset of:
 
-- `"route": "direct|proxy|tor"` — default route for new transfers.
+- `"route": "direct|proxy|tor|i2p"` — default route for new transfers.
 - `"downloadDir": "<path>"` — where new transfers download (created if needed;
   existing transfers keep their directory).
 - `"relays": ["wss://…", "ws://…onion"]` — replaces the relay list, persisted to
@@ -224,7 +224,7 @@ daemon does not read client frames; closing the socket ends the push.
 {
   "id": "t1", "name": "...", "hash": "<40-hex|''>", "magnet": "magnet:?...|''",
   "status": "downloading|seeding|complete|metadata|stalled|connecting|no_peers",
-  "route": "direct|proxy|tor",
+  "route": "direct|proxy|tor|i2p",
   "sources": ["tracker"|"dht"|"nostr", ...],
   "pct": 0-100, "size": <bytes>|null,
   "down": <bytes/s>, "up": <bytes/s>, "eta": "1m 48s|—|stalled",

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -1020,7 +1020,12 @@ const Conn = struct {
             if (waited < interval_ns) continue;
             waited = 0;
             // Hold the mutex across the done re-check so a tick queued behind
-            // the handler's final response can't emit a trailing 102 after it.
+            // the handler's final response almost never emits a trailing 102
+            // after it. A residual window remains (tick acquiring the mutex in
+            // the handoff between the final sendAll's unlock and the defer's
+            // done store); it is harmless because the connection closes right
+            // after a complete, Content-Length-delimited response, and clients
+            // discard trailing bytes on a closing connection.
             self.write_mutex.lock();
             defer self.write_mutex.unlock();
             if (done.load(.acquire)) return;

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -343,6 +343,10 @@ pub const Daemon = struct {
 const Conn = struct {
     daemon: *Daemon,
     stream: std.net.Stream,
+    /// Serializes socket writes so the keep-alive ticker (see `withKeepalive`)
+    /// can't interleave its interim 102 bytes into a response the handler is
+    /// sending. Only contended while a slow POST handler is in flight.
+    write_mutex: std.Thread.Mutex = .{},
 
     fn run(self: *Conn) void {
         const a = self.daemon.allocator;
@@ -412,9 +416,14 @@ const Conn = struct {
             return self.sendStatus(.not_found);
         }
         if (std.mem.eql(u8, req.method, "POST")) {
-            if (std.mem.eql(u8, path, "/api/transfers")) return self.addTransfer(body);
-            if (std.mem.eql(u8, path, "/api/seeds")) return self.createSeed(req, body);
-            if (std.mem.eql(u8, path, "/api/torrents")) return self.createTorrent(body);
+            // The add/seed/torrent endpoints block while the daemon builds an
+            // anonymized network session (Tor hidden service, I2P SAM tunnels)
+            // or hashes a large file — potentially minutes. Run them behind
+            // the keep-alive ticker so the webview's ~60s idle limit can't
+            // kill the request mid-setup (the "TypeError: Load failed" bug).
+            if (std.mem.eql(u8, path, "/api/transfers")) return self.withKeepalive(Conn.addTransferEntry, req, body);
+            if (std.mem.eql(u8, path, "/api/seeds")) return self.withKeepalive(Conn.createSeed, req, body);
+            if (std.mem.eql(u8, path, "/api/torrents")) return self.withKeepalive(Conn.createTorrentEntry, req, body);
             if (std.mem.eql(u8, path, "/api/search")) return self.search(req, body);
             if (std.mem.eql(u8, path, "/api/settings")) return self.updateSettings(body);
             if (std.mem.eql(u8, path, "/api/follows")) return self.addFollow(body);
@@ -951,12 +960,74 @@ const Conn = struct {
     }
 
     fn sendAll(self: *Conn, buf: []const u8) !void {
+        self.write_mutex.lock();
+        defer self.write_mutex.unlock();
         var off: usize = 0;
         while (off < buf.len) {
             const n = posix.send(self.stream.handle, buf[off..], 0) catch return error.SendFailed;
             if (n == 0) return error.Closed;
             off += n;
         }
+    }
+
+    /// Interval between interim `102 Processing` keep-alives on slow POST
+    /// handlers (see `withKeepalive`). Comfortably under the ~60s idle limit
+    /// it defends against.
+    const keepalive_interval_ns = 20 * std.time.ns_per_s;
+
+    /// Run a slow POST handler with an interim-response keep-alive ticker.
+    ///
+    /// The desktop shell's webview (WKWebView / NSURLSession) aborts any
+    /// request whose response takes ~60s+ with zero bytes on the wire, and
+    /// surfaces it to the page as an opaque `TypeError: Load failed` — which
+    /// is what an I2P seed looks like when SESSION CREATE + tunnel build
+    /// outlast that on a cold router (Tor setups finish in seconds, so only
+    /// the i2p route tripped it), and what hashing a multi-GB file into a
+    /// torrent looks like regardless of route. Interim `102 Processing` bytes
+    /// reset that idle timer; every HTTP client consumes 1xx and keeps
+    /// waiting for the final response, so curl and the CLI see no difference.
+    fn withKeepalive(
+        self: *Conn,
+        comptime handler: fn (*Conn, *const http.Request, []const u8) anyerror!void,
+        req: *const http.Request,
+        body: []const u8,
+    ) !void {
+        var done = std.atomic.Value(bool).init(false);
+        const ticker = std.Thread.spawn(.{}, keepaliveLoop, .{ self, &done, keepalive_interval_ns }) catch {
+            return handler(self, req, body); // no ticker — behave as before
+        };
+        defer {
+            done.store(true, .release);
+            ticker.join();
+        }
+        try handler(self, req, body);
+    }
+
+    /// Write an interim `102 Processing` every `interval_ns` until `done`
+    /// flips. A tick racing the handler's final response is harmless: both
+    /// writes are serialized by `write_mutex`, and the connection closes right
+    /// after the response, so a trailing 1xx is never parsed as anything.
+    fn keepaliveLoop(self: *Conn, done: *std.atomic.Value(bool), interval_ns: u64) void {
+        var waited: u64 = 0;
+        while (!done.load(.acquire)) {
+            std.Thread.sleep(100 * std.time.ns_per_ms);
+            waited += 100 * std.time.ns_per_ms;
+            if (waited < interval_ns) continue;
+            waited = 0;
+            self.sendAll("HTTP/1.1 102 Processing\r\n\r\n") catch return;
+        }
+    }
+
+    // `withKeepalive` handlers all take (req, body); these adapt the
+    // body-only endpoints to that shape.
+    fn addTransferEntry(self: *Conn, req: *const http.Request, body: []const u8) !void {
+        _ = req;
+        return self.addTransfer(body);
+    }
+
+    fn createTorrentEntry(self: *Conn, req: *const http.Request, body: []const u8) !void {
+        _ = req;
+        return self.createTorrent(body);
     }
 };
 
@@ -1277,4 +1348,50 @@ test "percentDecode: escapes and plus" {
     const r3 = try percentDecode(a, "%zz");
     defer a.free(r3);
     try testing.expectEqualStrings("%zz", r3);
+}
+
+test "keepaliveLoop: emits interim 102 until done, serialized through sendAll" {
+    // socketpair: the ticker writes on one end, the test reads the other.
+    var fds: [2]posix.fd_t = undefined;
+    {
+        const rc = std.c.socketpair(posix.AF.UNIX, posix.SOCK.STREAM, 0, &fds);
+        try testing.expect(rc == 0);
+    }
+    defer posix.close(fds[1]);
+
+    // The loop only touches the stream + write mutex, never the daemon.
+    var conn = Conn{ .daemon = undefined, .stream = .{ .handle = fds[0] } };
+    var done = std.atomic.Value(bool).init(false);
+    const ticker = try std.Thread.spawn(.{}, Conn.keepaliveLoop, .{ &conn, &done, 60 * std.time.ns_per_ms });
+
+    // Let a few ticks fire, then stop and join before reading (the bytes wait
+    // in the socket buffer).
+    std.Thread.sleep(250 * std.time.ns_per_ms);
+    done.store(true, .release);
+    ticker.join();
+    posix.close(fds[0]);
+
+    // Drain what the ticker sent; expect at least two interim responses and
+    // no interleaved garbage (writes go through the mutex'd sendAll).
+    var buf: [4096]u8 = undefined;
+    var total: usize = 0;
+    while (true) {
+        const n = posix.read(fds[1], buf[total..]) catch |err| switch (err) {
+            error.WouldBlock => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        total += n;
+        if (total == buf.len) break;
+    }
+    const got = buf[0..total];
+    const needle = "HTTP/1.1 102 Processing\r\n\r\n";
+    var count: usize = 0;
+    var it = std.mem.splitSequence(u8, got, needle);
+    while (it.next()) |seg| {
+        // Only whole interim responses on the wire — nothing interleaved.
+        try testing.expectEqual(@as(usize, 0), seg.len);
+        count += 1;
+    }
+    try testing.expect(count - 1 >= 2); // split yields one segment per copy + 1
 }

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -962,6 +962,11 @@ const Conn = struct {
     fn sendAll(self: *Conn, buf: []const u8) !void {
         self.write_mutex.lock();
         defer self.write_mutex.unlock();
+        try self.sendAllLocked(buf);
+    }
+
+    /// Caller must hold `write_mutex` (see `keepaliveLoop`).
+    fn sendAllLocked(self: *Conn, buf: []const u8) !void {
         var off: usize = 0;
         while (off < buf.len) {
             const n = posix.send(self.stream.handle, buf[off..], 0) catch return error.SendFailed;
@@ -1014,7 +1019,12 @@ const Conn = struct {
             waited += 100 * std.time.ns_per_ms;
             if (waited < interval_ns) continue;
             waited = 0;
-            self.sendAll("HTTP/1.1 102 Processing\r\n\r\n") catch return;
+            // Hold the mutex across the done re-check so a tick queued behind
+            // the handler's final response can't emit a trailing 102 after it.
+            self.write_mutex.lock();
+            defer self.write_mutex.unlock();
+            if (done.load(.acquire)) return;
+            self.sendAllLocked("HTTP/1.1 102 Processing\r\n\r\n") catch return;
         }
     }
 


### PR DESCRIPTION
## Summary
- **Symptom 1 — `TypeError: Load failed` when seeding a file over I2P:** the daemon holds `POST /api/seeds` open while it synchronously builds the SAM session (`SESSION CREATE` + tunnel build + `STREAM FORWARD`, each round-trip up to the 60s SAM timeout). WKWebView's NSURLSession aborts any request with zero bytes on the wire for ~60s (`NSURLErrorDomain -1001`), which the page sees as `TypeError: Load failed`. The GUI's own 90s `AbortSignal.timeout` never fires first. Tor setups finish in seconds, so only the i2p route (or hashing a large file) tripped it — the daemon was working fine the whole time. **Fix:** the daemon emits interim `102 Processing` responses every 20s on the long-running POST endpoints (`/api/transfers`, `/api/seeds`, `/api/torrents`) while the handler works, resetting the webview's idle timer. Writes are serialized through a per-connection `write_mutex` so interim bytes can't interleave into the final response. HTTP clients ignore 1xx interims, so curl/CLI/browser behavior is unchanged.
- **Symptom 2 — "daemon looks offline":** could not be reproduced locally (daemon stays alive and the state WebSocket streams ~1 push/s even during a 120s SAM build, client aborts, and dead bridges — verified with curl, Chromium, real WebKit, and a Node WS client). The observability gap is real, though: the Tauri shell drains the sidecar daemon's output into the void, so a crashed/wedged daemon in the app leaves no trace anywhere. **Fix:** the shell now tees the daemon's stdout+stderr into `<config>/carl/daemon.log` (rotated at 2 MiB), the token-startup failure error includes the daemon's stderr tail (and kills the wedged child instead of leaking it), and the sidebar's offline badge tooltip points at the log path. If the offline state reproduces, that log will show why — please capture it.

## Reproduction evidence (symptom 1)
- Baseline (Swift `URLSession`, same stack as WKWebView): 75s-stalled response → `ERROR after 61.0s: NSURLErrorDomain -1001 The request timed out`.
- Controlled `102 Processing` every 20s with the final response at 75s → survives.
- End-to-end against the patched daemon + a fake SAM bridge stalling each round-trip 30s (total ~120s, past the cliff): `SURVIVED 120.0s` with the daemon's real final response.
- Regression: i2p seeds (small + 5 MiB) still succeed from real WebKit and Chromium; fast requests never see a 102; `zig build test` green (incl. new `keepaliveLoop` socketpair test); `tsc --noEmit` green; `cargo build` green; log tee verified end-to-end via `npm run tauri dev` (log fills, token line never hits disk).

## Test plan
- [x] CI passes
- [ ] Seed a file over I2P from the desktop app on a cold/slow I2P router — no more `TypeError: Load failed`; the seed registers after session setup completes
- [ ] If the daemon ever shows "offline" again, `~/.config/carl/daemon.log` contains the reason — attach it here