### PR TITLE
perf: 3.7x throughput, 8x lower startup latency, and peer-discovery fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,17 @@
 - BIP-340 (Schnorr): https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 - RFC 6455 (WebSocket): https://datatracker.ietf.org/doc/html/rfc6455
 
+## Reference implementation
+
+qBittorrent (https://github.com/qbittorrent/qBittorrent) is the reference
+implementation for client behavior. Its transfer engine is libtorrent-rasterbar
+(https://github.com/arvidn/libtorrent), so engine-level behavior — peer
+management, connection limits, request pipelining, choking/unchoking, piece
+picking, tracker/DHT retry policy — should be checked against libtorrent's
+implementation and defaults; UI/UX conventions against qBittorrent itself.
+When tuning constants (timeouts, backoff schedules, queue depths, peer caps),
+prefer values justified by what libtorrent/qBittorrent ships over invented ones.
+
 ## Build
 
 - Language: Zig 0.15

--- a/scripts/bench_loopback.sh
+++ b/scripts/bench_loopback.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Loopback throughput benchmark: one carl seeds, another carl leeches, both on
+# 127.0.0.1, peers introduced by a stub HTTP tracker. Loopback removes the
+# internet from the measurement, so the number that comes out is carl's own
+# ceiling -- the seeder's upload path and the leecher's download path together,
+# with no swarm, ISP, or web-seed variance in the way.
+#
+# Use it to compare a change against a baseline: run it on the base commit,
+# run it again on the branch, and diff the MB/s.
+#
+#   SIZE_MB     test payload size in MiB          (default 256)
+#   PIECE_LEN   piece length in bytes             (default 262144)
+#   TIMEOUT     seconds to allow the transfer     (default 600)
+#   CARL        path to the carl binary           (default ./zig-out/bin/carl)
+#   KEEP        set to 1 to keep the work dir
+#
+# Exit status: 0 when the leecher's bytes match the seeder's, non-zero otherwise.
+set -euo pipefail
+
+CARL=${CARL:-./zig-out/bin/carl}
+SIZE_MB=${SIZE_MB:-256}
+PIECE_LEN=${PIECE_LEN:-262144}
+TIMEOUT=${TIMEOUT:-600}
+KEEP=${KEEP:-0}
+
+TRACKER_PORT=${TRACKER_PORT:-16969}
+SEED_PORT=${SEED_PORT:-16881}
+LEECH_PORT=${LEECH_PORT:-16882}
+
+command -v python3 >/dev/null || { echo "python3 required" >&2; exit 1; }
+[ -x "$CARL" ] || { echo "carl binary not found at $CARL (run: zig build -Doptimize=ReleaseSafe)" >&2; exit 1; }
+
+WORK=$(mktemp -d)
+cleanup() {
+  [ -n "${TRACKER_PID:-}" ] && kill "$TRACKER_PID" 2>/dev/null || true
+  [ -n "${SEED_PID:-}" ] && kill "$SEED_PID" 2>/dev/null || true
+  [ -n "${LEECH_PID:-}" ] && kill "$LEECH_PID" 2>/dev/null || true
+  if [ "$KEEP" = "1" ]; then echo "work dir kept: $WORK"; else rm -rf "$WORK"; fi
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK/seed" "$WORK/dl"
+
+# --- stub tracker -----------------------------------------------------------
+# Answers every announce with a single compact peer: the seeder on loopback.
+# Compact format (BEP 23) is 6 bytes per peer: 4-byte IPv4 + 2-byte big-endian
+# port. Nothing else about the announce matters for a two-node benchmark.
+cat > "$WORK/tracker.py" <<PYEOF
+import http.server, socket, struct, sys
+SEED_PORT = int(sys.argv[1])
+PORT = int(sys.argv[2])
+peer = socket.inet_aton("127.0.0.1") + struct.pack(">H", SEED_PORT)
+body = b"d8:intervali60e5:peers" + str(len(peer)).encode() + b":" + peer + b"e"
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a):
+        pass
+
+http.server.HTTPServer(("127.0.0.1", PORT), H).serve_forever()
+PYEOF
+
+python3 "$WORK/tracker.py" "$SEED_PORT" "$TRACKER_PORT" &
+TRACKER_PID=$!
+sleep 1
+
+# --- payload + torrent ------------------------------------------------------
+echo "creating ${SIZE_MB}MiB payload..."
+dd if=/dev/urandom of="$WORK/seed/payload.bin" bs=1m count="$SIZE_MB" 2>/dev/null
+"$CARL" create "$WORK/seed/payload.bin" -o "$WORK/payload.torrent" \
+  -t "http://127.0.0.1:${TRACKER_PORT}/announce" --piece-length "$PIECE_LEN" >/dev/null
+
+# --- seed -------------------------------------------------------------------
+"$CARL" seed "$WORK/payload.torrent" "$WORK/seed" --port "$SEED_PORT" > "$WORK/seed.log" 2>&1 &
+SEED_PID=$!
+sleep 2
+kill -0 "$SEED_PID" 2>/dev/null || { echo "seeder died:"; cat "$WORK/seed.log"; exit 1; }
+
+# --- leech + measure --------------------------------------------------------
+echo "downloading..."
+START=$(python3 -c 'import time; print(time.time())')
+"$CARL" download "$WORK/payload.torrent" --output-dir "$WORK/dl" --port "$LEECH_PORT" \
+  > "$WORK/leech.log" 2>&1 &
+LEECH_PID=$!
+
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+while kill -0 "$LEECH_PID" 2>/dev/null; do
+  [ "$(date +%s)" -gt "$DEADLINE" ] && { echo "TIMEOUT after ${TIMEOUT}s"; tail -5 "$WORK/leech.log"; exit 1; }
+  sleep 1
+done
+END=$(python3 -c 'import time; print(time.time())')
+
+# --- verify -----------------------------------------------------------------
+SRC_HASH=$(shasum -a 256 "$WORK/seed/payload.bin" | cut -d' ' -f1)
+DST_HASH=$(shasum -a 256 "$WORK/dl/payload.bin" 2>/dev/null | cut -d' ' -f1 || echo "MISSING")
+if [ "$SRC_HASH" != "$DST_HASH" ]; then
+  echo "FAIL: hash mismatch (src=$SRC_HASH dst=$DST_HASH)"
+  tail -10 "$WORK/leech.log"
+  exit 1
+fi
+
+python3 - "$START" "$END" "$SIZE_MB" <<'PYEOF'
+import sys
+start, end, size_mb = float(sys.argv[1]), float(sys.argv[2]), float(sys.argv[3])
+secs = end - start
+print(f"OK  {size_mb:.0f} MiB in {secs:.1f}s = {size_mb/secs:.1f} MiB/s")
+PYEOF

--- a/scripts/bench_loopback.sh
+++ b/scripts/bench_loopback.sh
@@ -68,6 +68,9 @@ PYEOF
 
 python3 "$WORK/tracker.py" "$SEED_PORT" "$TRACKER_PORT" &
 TRACKER_PID=$!
+# Detach from job control so the shell doesn't print a "Terminated" notice for
+# it when the cleanup trap fires.
+disown "$TRACKER_PID" 2>/dev/null || true
 sleep 1
 
 # --- payload + torrent ------------------------------------------------------

--- a/scripts/bench_loopback.sh
+++ b/scripts/bench_loopback.sh
@@ -14,6 +14,12 @@
 #   TIMEOUT     seconds to allow the transfer     (default 600)
 #   CARL        path to the carl binary           (default ./zig-out/bin/carl)
 #   KEEP        set to 1 to keep the work dir
+#   DEAD_PEERS  blackhole peers the tracker lists BEFORE the real seeder
+#               (default 0). This is the swarm case that matters: a tracker
+#               hands back mostly-unreachable addresses. With serial blocking
+#               dials, 40 dead peers x a 5s connect timeout meant the transfer
+#               could not finish at all; they must be dialed concurrently and
+#               timed out off the event loop.
 #
 # Exit status: 0 when the leecher's bytes match the seeder's, non-zero otherwise.
 set -euo pipefail
@@ -23,6 +29,7 @@ SIZE_MB=${SIZE_MB:-256}
 PIECE_LEN=${PIECE_LEN:-262144}
 TIMEOUT=${TIMEOUT:-600}
 KEEP=${KEEP:-0}
+DEAD_PEERS=${DEAD_PEERS:-0}
 
 TRACKER_PORT=${TRACKER_PORT:-16969}
 SEED_PORT=${SEED_PORT:-16881}
@@ -50,7 +57,14 @@ cat > "$WORK/tracker.py" <<PYEOF
 import http.server, socket, struct, sys
 SEED_PORT = int(sys.argv[1])
 PORT = int(sys.argv[2])
-peer = socket.inet_aton("127.0.0.1") + struct.pack(">H", SEED_PORT)
+DEAD = int(sys.argv[3])
+# TEST-NET-2 (RFC 5737) is reserved for documentation and is not routed, so
+# these connects hang until they time out -- the point of the exercise.
+peer = b"".join(
+    socket.inet_aton("198.51.100.%d" % (i % 254 + 1)) + struct.pack(">H", 6881)
+    for i in range(DEAD)
+)
+peer += socket.inet_aton("127.0.0.1") + struct.pack(">H", SEED_PORT)
 body = b"d8:intervali60e5:peers" + str(len(peer)).encode() + b":" + peer + b"e"
 
 class H(http.server.BaseHTTPRequestHandler):
@@ -66,7 +80,7 @@ class H(http.server.BaseHTTPRequestHandler):
 http.server.HTTPServer(("127.0.0.1", PORT), H).serve_forever()
 PYEOF
 
-python3 "$WORK/tracker.py" "$SEED_PORT" "$TRACKER_PORT" &
+python3 "$WORK/tracker.py" "$SEED_PORT" "$TRACKER_PORT" "$DEAD_PEERS" &
 TRACKER_PID=$!
 # Detach from job control so the shell doesn't print a "Terminated" notice for
 # it when the cleanup trap fires.

--- a/scripts/bench_upload.sh
+++ b/scripts/bench_upload.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Upload fan-out benchmark: one carl seeds, N carls leech it concurrently, all
+# on 127.0.0.1 with a stub tracker. Where bench_loopback.sh measures a single
+# peer-to-peer stream, this measures the seeder's *aggregate* upload path --
+# the send buffers, the choke/unchoke slots, and the poll loop's fairness when
+# several peers all want data at once.
+#
+#   SIZE_MB     payload size in MiB                (default 512)
+#   LEECHERS    concurrent downloaders             (default 4)
+#   TIMEOUT     seconds to allow the transfers     (default 600)
+#   CARL        path to the carl binary            (default ./zig-out/bin/carl)
+#   KEEP        set to 1 to keep the work dir
+#
+# Exit status: 0 only when every leecher's bytes match the seeder's.
+set -euo pipefail
+
+CARL=${CARL:-./zig-out/bin/carl}
+SIZE_MB=${SIZE_MB:-512}
+LEECHERS=${LEECHERS:-4}
+TIMEOUT=${TIMEOUT:-600}
+KEEP=${KEEP:-0}
+
+TRACKER_PORT=${TRACKER_PORT:-18200}
+SEED_PORT=${SEED_PORT:-18201}
+LEECH_PORT_BASE=${LEECH_PORT_BASE:-18210}
+
+command -v python3 >/dev/null || { echo "python3 required" >&2; exit 1; }
+[ -x "$CARL" ] || { echo "carl binary not found at $CARL (run: zig build -Doptimize=ReleaseSafe)" >&2; exit 1; }
+
+WORK=$(mktemp -d)
+TAG=$(basename "$WORK")
+cleanup() {
+  [ -n "${TRACKER_PID:-}" ] && kill "$TRACKER_PID" 2>/dev/null || true
+  [ -n "${SEED_PID:-}" ] && kill "$SEED_PID" 2>/dev/null || true
+  pkill -f "download .*${TAG}" 2>/dev/null || true
+  if [ "$KEEP" = "1" ]; then echo "work dir kept: $WORK"; else rm -rf "$WORK"; fi
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK/seed"
+
+cat > "$WORK/tracker.py" <<PYEOF
+import http.server, socket, struct, sys
+peer = socket.inet_aton("127.0.0.1") + struct.pack(">H", ${SEED_PORT})
+body = b"d8:intervali60e5:peers" + str(len(peer)).encode() + b":" + peer + b"e"
+
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a):
+        pass
+
+http.server.HTTPServer(("127.0.0.1", ${TRACKER_PORT}), H).serve_forever()
+PYEOF
+
+python3 "$WORK/tracker.py" &
+TRACKER_PID=$!
+# Detach from job control so the shell doesn't print a "Terminated" notice for
+# it when the cleanup trap fires.
+disown "$TRACKER_PID" 2>/dev/null || true
+sleep 1
+
+echo "creating ${SIZE_MB}MiB payload..."
+dd if=/dev/urandom of="$WORK/seed/payload.bin" bs=1m count="$SIZE_MB" 2>/dev/null
+"$CARL" create "$WORK/seed/payload.bin" -o "$WORK/payload.torrent" \
+  -t "http://127.0.0.1:${TRACKER_PORT}/announce" >/dev/null
+
+"$CARL" seed "$WORK/payload.torrent" "$WORK/seed" --port "$SEED_PORT" > "$WORK/seed.log" 2>&1 &
+SEED_PID=$!
+# The seeder hashes the payload before it will answer requests; starting the
+# leechers mid-verify would bill that time to the transfer.
+sleep 3
+kill -0 "$SEED_PID" 2>/dev/null || { echo "seeder died:"; cat "$WORK/seed.log"; exit 1; }
+
+echo "starting ${LEECHERS} leechers..."
+START=$(python3 -c 'import time; print(time.time())')
+i=1
+while [ "$i" -le "$LEECHERS" ]; do
+  mkdir -p "$WORK/dl$i"
+  "$CARL" download "$WORK/payload.torrent" --output-dir "$WORK/dl$i" \
+    --port $((LEECH_PORT_BASE + i)) > "$WORK/leech$i.log" 2>&1 &
+  i=$((i + 1))
+done
+
+# Poll rather than `wait`: bare `wait` would also block on the tracker and
+# seeder, which never exit, and zsh does not word-split an unquoted PID list.
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+while pgrep -f "download .*${TAG}" >/dev/null; do
+  [ "$(date +%s)" -gt "$DEADLINE" ] && { echo "TIMEOUT after ${TIMEOUT}s"; exit 1; }
+  sleep 1
+done
+END=$(python3 -c 'import time; print(time.time())')
+
+SRC_HASH=$(shasum -a 256 "$WORK/seed/payload.bin" | cut -d' ' -f1)
+ok=0
+i=1
+while [ "$i" -le "$LEECHERS" ]; do
+  h=$(shasum -a 256 "$WORK/dl$i/payload.bin" 2>/dev/null | cut -d' ' -f1 || echo MISSING)
+  if [ "$h" = "$SRC_HASH" ]; then ok=$((ok + 1)); else echo "leecher $i MISMATCH ($h)"; fi
+  i=$((i + 1))
+done
+
+python3 - "$START" "$END" "$SIZE_MB" "$LEECHERS" "$ok" <<'PYEOF'
+import sys
+start, end, size_mb, n, ok = (float(sys.argv[1]), float(sys.argv[2]),
+                              float(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5]))
+secs = end - start
+total = size_mb * n
+status = "OK " if ok == n else "FAIL"
+print(f"{status} {n} leechers x {size_mb:.0f} MiB = {total:.0f} MiB in {secs:.1f}s "
+      f"= {total/secs:.1f} MiB/s aggregate upload  (verified {ok}/{n})")
+sys.exit(0 if ok == n else 1)
+PYEOF

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -765,14 +765,21 @@ const Conn = struct {
                 if (dir.len > 0) self.daemon.manager.setDownloadDir(dir) catch {};
             }
             // Relays: a JSON array of strings, persisted to the config file so
-            // the prober, search, and the CLI all pick them up.
+            // the prober, search, and the CLI all pick them up. Normalize each
+            // entry (https:// → wss://, bare host → wss://host, …) so the
+            // persisted file is canonical; entries that can't be a websocket
+            // relay are dropped rather than written for connect loops to spin
+            // on.
             if (obj.get("relays")) |v| {
                 if (v == .array) {
                     var list: std.ArrayList([]const u8) = .empty;
                     for (v.array.items) |item| {
                         if (item == .string) {
-                            const t = std.mem.trim(u8, item.string, " \t\r\n");
-                            if (t.len > 0) try list.append(aa, t);
+                            if (try nostr_config.normalizeRelayUrl(aa, item.string)) |url| {
+                                try list.append(aa, url);
+                            } else {
+                                log.warn("settings: dropping invalid relay URL '{s}'", .{item.string});
+                            }
                         }
                     }
                     nostr_config.writeRelays(a, list.items) catch {};

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -47,14 +47,14 @@ const max_body: usize = 256 * 1024 * 1024;
 /// How often the background prober refreshes relay reachability. The daemon
 /// holds no persistent relay connections, so without this the UI could only
 /// ever show relays as "configured" (never connected).
+///
+/// A relay that fails is *not* re-dialed every tick: the shared per-relay
+/// health table (`relay.HealthTable`) backs it off individually, 30s doubling
+/// to 5 minutes, so a permanently-503 relay costs one dial per backoff window
+/// instead of one every 30s. This replaced a global "all relays down N cycles
+/// in a row" streak, which a single healthy relay reset forever — the daemon
+/// then hammered the dead one indefinitely.
 const probe_interval_ns: u64 = 30 * std.time.ns_per_s;
-
-/// After this many consecutive all-unreachable probe cycles, the prober
-/// backs off to `backoff_interval_ns` to stop flooding the logs and
-/// wasting Tor circuits. Resets to the normal interval on the first
-/// successful probe.
-const max_consecutive_failures: u8 = 3;
-const backoff_interval_ns: u64 = 5 * 60 * std.time.ns_per_s;
 
 pub const Daemon = struct {
     allocator: Allocator,
@@ -70,8 +70,6 @@ pub const Daemon = struct {
     proxy_state: proxy_mod.ProxyState = .ok,
     proxy_reply: ?u8 = null,
     proxy_probed: bool = false,
-    /// Consecutive probe cycles where every relay was unreachable.
-    relay_fail_streak: u8 = 0,
 
     /// Bind to 127.0.0.1:`port` and serve until `running` is cleared. Blocking.
     pub fn serve(self: *Daemon, port: u16) !void {
@@ -260,12 +258,8 @@ pub const Daemon = struct {
             // down) so they come back within a tick instead of after the next
             // restart — until now they existed only as invisible DB rows.
             self.manager.retryRetained();
-            const interval = if (self.relay_fail_streak >= max_consecutive_failures)
-                backoff_interval_ns
-            else
-                probe_interval_ns;
             var slept: u64 = 0;
-            while (slept < interval and
+            while (slept < probe_interval_ns and
                 self.running.load(.acquire) and
                 !session_mod.shutdown_requested.load(.acquire)) : (slept += 250 * std.time.ns_per_ms)
             {
@@ -291,16 +285,19 @@ pub const Daemon = struct {
         }
 
         var list: std.ArrayList(api.Relay) = .empty;
-        var any_connected = false;
         for (urls) |url| {
             const onion = std.mem.indexOf(u8, url, ".onion") != null;
             var state: []const u8 = "configured";
             if (!(onion and proxy == null)) {
-                if (relay_mod.Relay.connect(a, url, proxy)) |r| {
+                // `.honor`: a relay we already know is failing is not dialed
+                // again until its backoff expires. `error.Skipped` therefore
+                // means "still down as far as we know", which is what the UI
+                // showed for it last cycle anyway — backoff only ever starts
+                // after a real failure.
+                if (relay_mod.dial(a, url, proxy, .honor)) |r| {
                     var rc = r;
                     rc.deinit();
                     state = "connected";
-                    any_connected = true;
                 } else |_| {
                     state = "unreachable";
                 }
@@ -320,17 +317,6 @@ pub const Daemon = struct {
             list.deinit(a);
             return;
         };
-
-        if (any_connected) {
-            self.relay_fail_streak = 0;
-        } else if (urls.len > 0) {
-            self.relay_fail_streak +|= 1;
-            if (self.relay_fail_streak == max_consecutive_failures) {
-                log.warn("all relays unreachable {d}x in a row, backing off to {d}s interval", .{
-                    max_consecutive_failures, backoff_interval_ns / std.time.ns_per_s,
-                });
-            }
-        }
 
         self.health_mutex.lock();
         const old = self.health;
@@ -1184,9 +1170,18 @@ fn percentDecode(arena: Allocator, s: []const u8) ![]u8 {
 // ===========================================================================
 
 fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
-    // Use the prober's health view: skip relays already known unreachable so a
-    // dead relay's connect timeout doesn't stall the whole search.
+    // The prober's snapshot is only the *list*; whether each relay is dialable
+    // right now comes from the shared health table, which every subsystem
+    // feeds (so a relay the prober found dead 10s ago isn't re-dialed here).
     const health = daemon.healthSnapshot(arena) catch &.{};
+
+    // A search is user-initiated and one-shot: prefer healthy relays, but if
+    // every relay happens to be backing off, dial them all anyway rather than
+    // hand back an empty result list the user can't explain. One extra dial
+    // per search is a price worth paying; a silent no-op isn't.
+    const urls = try arena.alloc([]const u8, health.len);
+    for (health, 0..) |r, i| urls[i] = r.url;
+    const gate = relay_mod.oneShotGate(urls);
 
     // Match the route the manager is configured for, so search over Tor/proxy
     // doesn't leak the real IP. The i2p route's `socks` is a SAM endpoint, not a
@@ -1208,9 +1203,8 @@ fn runSearch(arena: Allocator, daemon: *Daemon, query: []const u8) ![]u8 {
 
     for (health) |relay| {
         if (results.items.len >= 50) break;
-        if (std.mem.eql(u8, relay.state, "unreachable")) continue;
         const url = relay.url;
-        var r = relay_mod.Relay.connect(arena, url, proxy) catch continue;
+        var r = relay_mod.dial(arena, url, proxy, gate) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(arena, &r, filter, .{
             .timeout_ms = 7_000,

--- a/src/follow.zig
+++ b/src/follow.zig
@@ -391,7 +391,10 @@ fn pollOnce(mirror: *Mirror) void {
     var started: usize = 0;
     for (relay_urls) |url| {
         if (mirror.stopping()) return;
-        var r = relay_mod.Relay.connect(a, url, null) catch |err| {
+        // The poller runs on a timer, so it honors the shared per-relay
+        // backoff: a relay that is down stays skipped until its window
+        // expires instead of being re-dialed every sweep.
+        var r = relay_mod.dial(a, url, null, .honor) catch |err| {
             log.debug("relay {s}: {}", .{ url, err });
             continue;
         };
@@ -752,9 +755,12 @@ fn publishAnnounce(a: Allocator, info_hash: [20]u8, endpoint: AnnounceEndpoint) 
     const relay_urls = nostr_config.readRelays(a) catch return;
     defer nostr_config.freeRelays(a, relay_urls);
 
+    // One-shot publish: honor the backoff while some relay is dialable, else
+    // try them all -- an announce nobody hears makes the mirror undiscoverable.
+    const gate = relay_mod.oneShotGate(relay_urls);
     var acks: usize = 0;
     for (relay_urls) |url| {
-        var r = relay_mod.Relay.connect(a, url, null) catch continue;
+        var r = relay_mod.dial(a, url, null, gate) catch continue;
         defer r.deinit();
         if (relay_mod.publishAndWait(a, &r, ev, 5_000)) acks += 1;
     }
@@ -790,7 +796,8 @@ fn discoverPeers(a: Allocator, info_hash: [20]u8, session: *session_mod.Session)
     var added: usize = 0;
     for (relay_urls) |url| {
         if (!session.running or session_mod.shutdown_requested.load(.acquire)) return;
-        var r = relay_mod.Relay.connect(a, url, null) catch continue;
+        // Re-runs whenever the transfer has no peers, so honor the backoff.
+        var r = relay_mod.dial(a, url, null, .honor) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
             .timeout_ms = 10_000,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -5,6 +5,7 @@ pub const udp_tracker = @import("udp_tracker.zig");
 pub const wire = @import("wire.zig");
 pub const piece = @import("piece.zig");
 pub const storage = @import("storage.zig");
+pub const resume_data = @import("resume_data.zig");
 pub const peer = @import("peer.zig");
 pub const session = @import("session.zig");
 pub const magnet = @import("magnet.zig");
@@ -40,6 +41,7 @@ test {
     _ = wire;
     _ = piece;
     _ = storage;
+    _ = resume_data;
     _ = peer;
     _ = session;
     _ = magnet;

--- a/src/main.zig
+++ b/src/main.zig
@@ -1156,7 +1156,10 @@ fn cmdDaemon(allocator: std.mem.Allocator, stdout: anytype, extra: []const [:0]u
     try stdout.print("carl daemon\n", .{});
     try stdout.print("listen: http://127.0.0.1:{d}\n", .{port});
     try stdout.print("token: {s}\n", .{token});
-    try stdout.print("route: {s}\n", .{route_str});
+    // `restoreSettings` above may have replaced the route with the persisted
+    // (GUI-set) one, so print the EFFECTIVE route — the flag default here was
+    // a misleading "direct" whenever the user had picked another route.
+    try stdout.print("route: {s}\n", .{@tagName(mgr.cfg.route)});
 
     // On a proxy/tor route, check the SOCKS proxy up front and say clearly why
     // it's unreachable (the daemon keeps running and the GUI shows live health).

--- a/src/main.zig
+++ b/src/main.zig
@@ -75,6 +75,7 @@ pub fn main() !void {
         const port = parsePort(args[3..]);
         const want_nostr = parseFlagPresent(args[3..], "--nostr");
         const want_seed = parseFlagPresent(args[3..], "--seed");
+        if (parseFlagPresent(args[3..], "--verify")) carl.session.force_verify = true;
         try cmdDownload(allocator, source, output_dir, port, parseProxy(args[3..]), want_nostr, want_seed);
     } else if (std.mem.eql(u8, command, "seed")) {
         if (args.len < 3) {
@@ -94,6 +95,7 @@ pub fn main() !void {
         };
         const port = parsePort(flag_args);
         const want_nostr = parseFlagPresent(flag_args, "--nostr");
+        if (parseFlagPresent(flag_args, "--verify")) carl.session.force_verify = true;
         const tor_seed = parseFlagPresent(flag_args, "--tor-seed");
         const external_ip = parseFlag(flag_args, "--external-ip");
         const description = parseFlag(flag_args, "--description") orelse "";
@@ -149,12 +151,14 @@ fn printUsage() void {
         \\commands:
         \\  info <file.torrent>                              show torrent metadata
         \\  announce <file.torrent> [--proxy url]            query tracker for peers
-        \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr] [--seed]
+        \\  download <source> [--output-dir d] [--port p] [--proxy url] [--nostr] [--seed] [--verify]
         \\           source: file.torrent, magnet:?..., or http(s):// URL
         \\           --output-dir: defaults to the carl work dir (see below)
         \\           --nostr: also subscribe to nostr peer-announce events
         \\           --seed: keep seeding after the download completes
         \\                   (default: exit once the download is done)
+        \\           --verify: re-hash existing data instead of trusting the
+        \\                     saved resume state (use if a file looks corrupt)
         \\  seed <file.torrent> [data-dir] [--port p] [--proxy url] [--nostr] [--external-ip <ip>]
         \\           [--tor-seed] [--tor-control host:port] [--tor-cookie path]
         \\           [--tor-onion-port p] [--tor-socks url]
@@ -165,6 +169,8 @@ fn printUsage() void {
         \\           --tor-seed: hidden service via Tor ControlPort; requires --nostr
         \\           --i2p-seed: inbound I2P seed via SAM (stable .b32.i2p); requires
         \\                       --nostr. SAM bridge from --i2p-sam (default 127.0.0.1:7656)
+        \\           --verify: re-hash the data instead of trusting the saved
+        \\                     resume state (use if a file looks corrupt)
         \\  create <file-or-dir> [-o out.torrent] [-t tracker]... [--comment "..."] [--piece-length bytes]
         \\           build a .torrent from a file or directory (multi-file).
         \\           -t may repeat; trackers are optional (Nostr/DHT discovery).

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1270,7 +1270,11 @@ pub const Manager = struct {
         defer ml.deinit(self.allocator);
         const a = self.allocator;
 
-        const mi = try buildMagnetMetainfo(a, ml);
+        // On i2p the defaults are pointless (clearnet trackers are skipped
+        // entirely by the session); everywhere else a tracker-less magnet gets
+        // the well-known public tier so DHT isn't the sole — or on tor, a
+        // nonexistent — peer source.
+        const mi = try buildMagnetMetainfo(a, ml, i2p == null);
         errdefer mi.deinit(a);
 
         const session = a.create(session_mod.Session) catch return error.OutOfMemory;
@@ -1287,11 +1291,33 @@ pub const Manager = struct {
     }
 };
 
+/// Well-known public trackers injected (as one BEP 12 tier) into a magnet that
+/// carries no `tr=` params, so such magnets have a peer source beyond DHT —
+/// which is the sole source on `direct` and doesn't exist at all when
+/// anonymized. On proxy/tor routes the session rewrites these udp:// URLs to
+/// http:// and tunnels them (see `Session.tryUdpAsHttp`). Not used on i2p,
+/// where clearnet trackers are unreachable by design.
+pub const default_trackers = [_][]const u8{
+    "udp://tracker.opentrackr.org:1337/announce",
+    "udp://open.demonii.com:1337/announce",
+    "udp://tracker.torrent.eu.org:451/announce",
+    "udp://exodus.desync.com:6969/announce",
+};
+
 /// Construct a fully-owned placeholder `Metainfo` from a magnet link. On any
 /// failure all partial allocations are freed; on success ownership transfers to
 /// the returned value (free it via `Metainfo.deinit`). Kept free-standing so
 /// its errdefers never overlap a caller's `mi.deinit` (which would double-free).
-fn buildMagnetMetainfo(a: Allocator, ml: magnet_mod.MagnetLink) Allocator.Error!metainfo.Metainfo {
+/// With `use_default_trackers`, a magnet with no `tr=` params gets the
+/// `default_trackers` tier instead of zero trackers.
+fn buildMagnetMetainfo(a: Allocator, ml: magnet_mod.MagnetLink, use_default_trackers: bool) Allocator.Error!metainfo.Metainfo {
+    const trackers: []const []const u8 = if (ml.trackers.len > 0)
+        ml.trackers
+    else if (use_default_trackers)
+        &default_trackers
+    else
+        &.{};
+
     const name = try a.dupe(u8, ml.name orelse "unknown");
     errdefer a.free(name);
 
@@ -1312,8 +1338,8 @@ fn buildMagnetMetainfo(a: Allocator, ml: magnet_mod.MagnetLink) Allocator.Error!
         }
         a.free(tiers);
     };
-    if (ml.trackers.len > 0) {
-        const tier = try a.alloc([]const u8, ml.trackers.len);
+    if (trackers.len > 0) {
+        const tier = try a.alloc([]const u8, trackers.len);
         // Scoped to this block: covers the window before `announce_list` (and
         // its function-scope errdefer) takes ownership.
         var filled: usize = 0;
@@ -1321,15 +1347,15 @@ fn buildMagnetMetainfo(a: Allocator, ml: magnet_mod.MagnetLink) Allocator.Error!
             for (tier[0..filled]) |t| a.free(t);
             a.free(tier);
         }
-        while (filled < ml.trackers.len) : (filled += 1) {
-            tier[filled] = try a.dupe(u8, ml.trackers[filled]);
+        while (filled < trackers.len) : (filled += 1) {
+            tier[filled] = try a.dupe(u8, trackers[filled]);
         }
         const tiers = try a.alloc([]const []const u8, 1);
         tiers[0] = tier;
         announce_list = tiers;
     }
 
-    const announce = try a.dupe(u8, if (ml.trackers.len > 0) ml.trackers[0] else "");
+    const announce = try a.dupe(u8, if (trackers.len > 0) trackers[0] else "");
     errdefer a.free(announce);
 
     return metainfo.Metainfo{
@@ -1838,4 +1864,48 @@ test "Manager: init/deinit with config defaults" {
     try testing.expectEqual(@as(usize, 0), snap.len);
     m.setRoute(.tor);
     try testing.expectEqual(api.Route.tor, m.cfg.route);
+}
+
+test "buildMagnetMetainfo: tracker-less magnet gets the default tracker tier" {
+    const a = testing.allocator;
+    const ml = try magnet_mod.parse(a, "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&dn=test");
+    defer ml.deinit(a);
+
+    const mi = try buildMagnetMetainfo(a, ml, true);
+    defer mi.deinit(a);
+
+    try testing.expectEqualStrings(default_trackers[0], mi.announce);
+    const tiers = mi.announce_list orelse return error.TestExpectedTrackers;
+    try testing.expectEqual(@as(usize, 1), tiers.len);
+    try testing.expectEqual(default_trackers.len, tiers[0].len);
+    for (default_trackers, tiers[0]) |want, got| {
+        try testing.expectEqualStrings(want, got);
+    }
+}
+
+test "buildMagnetMetainfo: no default trackers on i2p (use_default_trackers=false)" {
+    const a = testing.allocator;
+    const ml = try magnet_mod.parse(a, "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&dn=test");
+    defer ml.deinit(a);
+
+    const mi = try buildMagnetMetainfo(a, ml, false);
+    defer mi.deinit(a);
+
+    try testing.expectEqualStrings("", mi.announce);
+    try testing.expectEqual(@as(?[]const []const []const u8, null), mi.announce_list);
+}
+
+test "buildMagnetMetainfo: magnet's own trackers win over the defaults" {
+    const a = testing.allocator;
+    const ml = try magnet_mod.parse(a, "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&tr=udp%3A%2F%2Fmine.example.com%3A6969");
+    defer ml.deinit(a);
+
+    const mi = try buildMagnetMetainfo(a, ml, true);
+    defer mi.deinit(a);
+
+    try testing.expectEqualStrings("udp://mine.example.com:6969", mi.announce);
+    const tiers = mi.announce_list orelse return error.TestExpectedTrackers;
+    try testing.expectEqual(@as(usize, 1), tiers.len);
+    try testing.expectEqual(@as(usize, 1), tiers[0].len);
+    try testing.expectEqualStrings("udp://mine.example.com:6969", tiers[0][0]);
 }

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1588,8 +1588,13 @@ fn broadcastIfNew(mt: *ManagedTransfer) void {
         .limit = 1,
     };
 
+    // This query is the precondition for a one-shot publish, so it uses the
+    // same gate: honor the per-relay backoff while any relay is dialable, and
+    // if none is, ask anyway rather than broadcast blind (a duplicate kind-2003
+    // is exactly what gets a client rate-limited).
+    const gate = relay_mod.oneShotGate(relay_urls);
     for (relay_urls) |url| {
-        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
+        var r = relay_mod.dial(a, url, mt.proxy, gate) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
             .timeout_ms = 8_000,
@@ -1666,7 +1671,10 @@ fn collectNostrPeers(mt: *ManagedTransfer) void {
     var added: usize = 0;
     for (relay_urls) |url| {
         if (!mt.session.running) return;
-        var r = relay_mod.Relay.connect(a, url, mt.proxy) catch continue;
+        // Periodic (fires whenever a transfer stalls), so `.honor`: a relay in
+        // backoff is skipped outright. The next stall re-runs this anyway, and
+        // dialing a known-dead relay only delays the ones that answer.
+        var r = relay_mod.dial(a, url, mt.proxy, .honor) catch continue;
         defer r.deinit();
         const events = relay_mod.subscribeAndCollect(a, &r, filter, .{
             .timeout_ms = 10_000,

--- a/src/nostr_config.zig
+++ b/src/nostr_config.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const secp = @import("secp.zig");
 const nip19 = @import("nip19.zig");
+const ws = @import("ws.zig");
 
 const log = std.log.scoped(.config);
 
@@ -133,11 +134,68 @@ pub fn readRelays(allocator: Allocator) ![][]const u8 {
     while (it.next()) |line| {
         const t = std.mem.trim(u8, line, " \t");
         if (t.len == 0 or t[0] == '#') continue;
-        const dup = try allocator.dupe(u8, t);
-        try list.append(allocator, dup);
+        const url = (try normalizeRelayUrl(allocator, t)) orelse {
+            // Warn once here at read time instead of returning the entry to
+            // connect loops that would retry (and log) it forever.
+            log.warn("ignoring invalid relay URL in config: '{s}'", .{t});
+            continue;
+        };
+        try list.append(allocator, url);
     }
     if (list.items.len == 0) return dupeDefaults(allocator);
     return list.toOwnedSlice(allocator);
+}
+
+/// Normalize a user-entered relay URL into the canonical `ws://`/`wss://`
+/// form that `ws.parseUrl` accepts. A wss endpoint IS an https endpoint
+/// pre-upgrade, so users routinely write `https://relay.example`; map
+/// `https://` → `wss://` and `http://` → `ws://`, and treat a bare host with
+/// no scheme at all as `wss://<host>`. A trailing `/` on a bare root path is
+/// dropped so `wss://host/` and `wss://host` normalize identically (parseUrl
+/// treats both as path "/"); deeper paths are kept verbatim. Returns null for
+/// entries that still aren't valid ws/wss relays after normalization
+/// (unknown scheme, empty host, embedded whitespace, bad port) — callers
+/// skip those instead of feeding them to connect loops. Caller owns the
+/// returned slice.
+pub fn normalizeRelayUrl(allocator: Allocator, raw: []const u8) !?[]u8 {
+    const t = std.mem.trim(u8, raw, " \t\r\n");
+
+    var scheme: []const u8 = "wss://";
+    var rest: []const u8 = t;
+    if (std.mem.startsWith(u8, t, "wss://")) {
+        rest = t["wss://".len..];
+    } else if (std.mem.startsWith(u8, t, "ws://")) {
+        scheme = "ws://";
+        rest = t["ws://".len..];
+    } else if (std.mem.startsWith(u8, t, "https://")) {
+        rest = t["https://".len..];
+    } else if (std.mem.startsWith(u8, t, "http://")) {
+        scheme = "ws://";
+        rest = t["http://".len..];
+    } else if (std.mem.indexOf(u8, t, "://") != null) {
+        return null; // Unknown scheme — can't be a websocket relay.
+    }
+
+    // A URL never contains raw whitespace; a "bare host" with a space in it
+    // is a garbage line, not a relay.
+    if (std.mem.indexOfAny(u8, rest, " \t") != null) return null;
+
+    // Drop a single trailing '/' when it's just the root path.
+    if (rest.len > 0 and rest[rest.len - 1] == '/' and
+        std.mem.indexOfScalar(u8, rest[0 .. rest.len - 1], '/') == null)
+    {
+        rest = rest[0 .. rest.len - 1];
+    }
+    if (rest.len == 0) return null; // Empty host (e.g. a lone "https://").
+
+    const url = try std.mem.concat(allocator, u8, &.{ scheme, rest });
+    // Final gate: whatever we hand out must be accepted by the websocket
+    // client, or the connect loop will spin on error.InvalidUrl forever.
+    _ = ws.parseUrl(url) catch {
+        allocator.free(url);
+        return null;
+    };
+    return url;
 }
 
 fn dupeDefaults(allocator: Allocator) ![][]const u8 {
@@ -230,4 +288,59 @@ test "parseNsecFile: rejects a non-nsec bech32 entity" {
 test "parseNsecFile: rejects garbage" {
     try std.testing.expectError(error.BadKeyFile, parseNsecFile("not bech32"));
     try std.testing.expectError(error.BadKeyFile, parseNsecFile(""));
+}
+
+fn expectNormalized(expected: []const u8, raw: []const u8) !void {
+    const allocator = std.testing.allocator;
+    const got = (try normalizeRelayUrl(allocator, raw)) orelse return error.TestUnexpectedResult;
+    defer allocator.free(got);
+    try std.testing.expectEqualStrings(expected, got);
+}
+
+fn expectRejected(raw: []const u8) !void {
+    const allocator = std.testing.allocator;
+    if (try normalizeRelayUrl(allocator, raw)) |got| {
+        allocator.free(got);
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "normalizeRelayUrl: https becomes wss" {
+    // The live-daemon spam case: user entered the relay as an https URL.
+    try expectNormalized("wss://nostr.relay.hedwig.sh", "https://nostr.relay.hedwig.sh/");
+    try expectNormalized("wss://relay.damus.io", "https://relay.damus.io");
+}
+
+test "normalizeRelayUrl: http becomes ws" {
+    try expectNormalized("ws://localhost:7777", "http://localhost:7777");
+}
+
+test "normalizeRelayUrl: bare host gets wss" {
+    try expectNormalized("wss://relay.damus.io", "relay.damus.io");
+    try expectNormalized("wss://localhost:7777", "localhost:7777");
+}
+
+test "normalizeRelayUrl: ws and wss pass through" {
+    try expectNormalized("wss://relay.damus.io", "wss://relay.damus.io");
+    try expectNormalized("ws://127.0.0.1:8080", "ws://127.0.0.1:8080");
+}
+
+test "normalizeRelayUrl: root trailing slash is stripped, deeper paths kept" {
+    try expectNormalized("wss://relay.damus.io", "wss://relay.damus.io/");
+    try expectNormalized("wss://relay.example/nostr", "wss://relay.example/nostr");
+    try expectNormalized("wss://relay.example/nostr/", "wss://relay.example/nostr/");
+}
+
+test "normalizeRelayUrl: trims surrounding whitespace" {
+    try expectNormalized("wss://relay.damus.io", "  https://relay.damus.io/ \t");
+}
+
+test "normalizeRelayUrl: garbage is rejected" {
+    try expectRejected("ftp://relay.example"); // unknown scheme
+    try expectRejected("https://"); // empty host
+    try expectRejected("wss://"); // empty host
+    try expectRejected("not a url"); // embedded whitespace
+    try expectRejected("wss://relay.example:notaport"); // parseUrl rejects the port
+    try expectRejected("");
+    try expectRejected("/");
 }

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -91,6 +91,10 @@ pub const PeerConnection = struct {
     /// last sample, both owned by `updatePipelineLimit`.
     down_rate: u64 = 0,
     rate_last_bytes: u64 = 0,
+    /// Whether O_NONBLOCK has been set on `stream`. Streams reach us from four
+    /// places (direct connect, SOCKS proxy, I2P SAM, and inbound accept), so
+    /// rather than have every producer remember, the first read/write flips it.
+    nonblocking: bool = false,
 
     // Stats for choking algorithm
     bytes_downloaded: u64,
@@ -248,8 +252,8 @@ pub const PeerConnection = struct {
         // macOS, so a dead or filtered peer (e.g. a stale nostr peer-announce)
         // could block the whole session in connect() for the OS default ~75 s.
         // Use a non-blocking connect + poll(POLLOUT) so connect_timeout_secs is
-        // a real upper bound on every platform, then restore blocking mode for
-        // the session's normal poll-driven I/O.
+        // a real upper bound on every platform. The socket then stays
+        // non-blocking for the session's poll-driven I/O (see below).
         const flags = std.posix.fcntl(sock, std.posix.F.GETFL, 0) catch {
             self.state = .disconnected;
             return error.ConnectionFailed;
@@ -288,10 +292,13 @@ pub const PeerConnection = struct {
             },
         };
 
-        // Back to blocking: the session multiplexes peers with poll() and then
-        // does blocking reads/writes on ready sockets.
-        o.NONBLOCK = false;
-        _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+        // Stay non-blocking. A blocking socket caps each peer at ONE buffer per
+        // poll wake (a second read would stall every other peer), which made
+        // peer throughput `peers x 64 KiB x loop_rate` — measured at 384 KB/s on
+        // a 50-peer swarm. Non-blocking lets `readIncoming`/`flushSend` drain to
+        // EAGAIN, and stops a slow leecher's large piece send from freezing the
+        // whole session mid-write.
+        self.nonblocking = true;
 
         self.stream = .{ .handle = sock };
         setNoDelay(self.stream.?);
@@ -318,17 +325,44 @@ pub const PeerConnection = struct {
         self.send_buf.appendSlice(self.allocator, serialized) catch return error.OutOfMemory;
     }
 
-    /// Flush send buffer to socket. Returns bytes written.
+    /// Ensure the socket is non-blocking. Idempotent; see the `nonblocking`
+    /// field for why this is done lazily at the I/O sites.
+    fn ensureNonBlocking(self: *PeerConnection) void {
+        if (self.nonblocking) return;
+        const s = self.stream orelse return;
+        const flags = std.posix.fcntl(s.handle, std.posix.F.GETFL, 0) catch return;
+        var o: std.posix.O = @bitCast(@as(u32, @truncate(flags)));
+        o.NONBLOCK = true;
+        _ = std.posix.fcntl(s.handle, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch return;
+        self.nonblocking = true;
+    }
+
+    /// Flush the send buffer, writing until the socket says EAGAIN or the
+    /// buffer empties. A single write() left the rest queued until the next
+    /// poll wake, which delayed every `interested`/`request`/`piece` by a full
+    /// loop iteration; on a blocking socket it could also stall the session
+    /// inside one large piece send. Returns total bytes written.
     pub fn flushSend(self: *PeerConnection) !usize {
         const s = self.stream orelse return 0;
-        const remaining = self.send_buf.items[self.send_pos..];
-        if (remaining.len == 0) return 0;
+        self.ensureNonBlocking();
 
-        const written = s.write(remaining) catch {
-            self.state = .disconnected;
-            return error.IoError;
-        };
-        self.send_pos += written;
+        var written: usize = 0;
+        while (self.send_pos < self.send_buf.items.len) {
+            const remaining = self.send_buf.items[self.send_pos..];
+            const n = s.write(remaining) catch |err| switch (err) {
+                // Kernel buffer full: keep the remainder queued for the next
+                // POLLOUT rather than treating backpressure as a failure.
+                error.WouldBlock => break,
+                else => {
+                    self.state = .disconnected;
+                    return error.IoError;
+                },
+            };
+            if (n == 0) break;
+            self.send_pos += n;
+            written += n;
+        }
+        if (written == 0) return 0;
         self.last_send_time = std.time.timestamp();
 
         // Compact send buffer when half consumed
@@ -342,23 +376,45 @@ pub const PeerConnection = struct {
         return written;
     }
 
-    /// Read available data from socket into recv_buf. The buffer is sized to
-    /// drain several piece messages per poll wake — a 16 KiB read forced one
-    /// syscall + poll round per block.
+    /// Largest amount `readIncoming` will drain from one peer in one call.
+    /// Without a bound, a peer that streams faster than we process could hold
+    /// the loop indefinitely and starve the others; poll reports the socket
+    /// readable again next iteration, so nothing is lost by stopping here.
+    const max_read_per_call: usize = 1 << 20;
+
+    /// Read available data from socket into recv_buf, draining until the socket
+    /// reports EAGAIN (or `max_read_per_call`). Reading a single buffer per poll
+    /// wake capped each peer at 64 KiB per loop iteration — the dominant limit
+    /// on peer throughput. Returns total bytes read.
     pub fn readIncoming(self: *PeerConnection) !usize {
         const s = self.stream orelse return 0;
+        self.ensureNonBlocking();
+
         var buf: [65536]u8 = undefined;
-        const n = s.read(&buf) catch {
-            self.state = .disconnected;
-            return error.IoError;
-        };
-        if (n == 0) {
-            self.state = .disconnected;
-            return 0;
+        var total: usize = 0;
+        while (total < max_read_per_call) {
+            const n = s.read(&buf) catch |err| switch (err) {
+                // Socket drained; what we already appended still counts.
+                error.WouldBlock => break,
+                else => {
+                    self.state = .disconnected;
+                    return error.IoError;
+                },
+            };
+            if (n == 0) {
+                // Orderly EOF: the peer closed. Report the disconnect, but keep
+                // any bytes read in this call — they may hold whole messages.
+                self.state = .disconnected;
+                break;
+            }
+            self.recv_buf.appendSlice(self.allocator, buf[0..n]) catch return error.OutOfMemory;
+            total += n;
+            // A short read means the socket is drained; another read would only
+            // return EAGAIN.
+            if (n < buf.len) break;
         }
-        self.recv_buf.appendSlice(self.allocator, buf[0..n]) catch return error.OutOfMemory;
-        self.last_recv_time = std.time.timestamp();
-        return n;
+        if (total > 0) self.last_recv_time = std.time.timestamp();
+        return total;
     }
 
     /// Drop consumed bytes from the front of recv_buf. Amortized: a no-op

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -95,6 +95,10 @@ pub const PeerConnection = struct {
     /// places (direct connect, SOCKS proxy, I2P SAM, and inbound accept), so
     /// rather than have every producer remember, the first read/write flips it.
     nonblocking: bool = false,
+    /// Wall-clock second at which `startConnect` issued the non-blocking
+    /// connect(). The session enforces `connect_timeout_secs` against this in
+    /// its maintenance tick instead of blocking inside connect().
+    connect_started_at: i64 = 0,
 
     // Stats for choking algorithm
     bytes_downloaded: u64,
@@ -199,7 +203,83 @@ pub const PeerConnection = struct {
         ) catch {};
     }
 
-    /// Initiate TCP connection with a timeout.
+    /// Start a plain-TCP connect WITHOUT waiting for it to complete: create a
+    /// non-blocking socket, issue connect(), and leave the peer in `.connecting`
+    /// for the session's poll loop to finish via `completeConnect`.
+    ///
+    /// The blocking `connect` below waits up to `connect_timeout_secs` inside
+    /// its own poll(); doing that for every tracker peer serialized the dials
+    /// (20 dead peers x 5 s = ~100 s with the event loop frozen) and, because
+    /// the run loop was not yet turning, meant peers dialed early sat with an
+    /// open socket and zero handshake bytes on it until the loop got around to
+    /// them — long past the 10 s handshake timeout real clients enforce.
+    /// Only for the direct route; proxy/SAM dials keep their blocking handshake.
+    pub fn startConnect(self: *PeerConnection) !void {
+        const sock = std.posix.socket(
+            std.posix.AF.INET,
+            std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
+            std.posix.IPPROTO.TCP,
+        ) catch {
+            self.state = .disconnected;
+            return error.ConnectionFailed;
+        };
+        // `stream` is only adopted on the success path below, so the socket is
+        // ours to close until then (and never double-closed by `deinit`).
+        var adopted = false;
+        defer if (!adopted) {
+            std.posix.close(sock);
+            self.state = .disconnected;
+        };
+
+        const flags = std.posix.fcntl(sock, std.posix.F.GETFL, 0) catch
+            return error.ConnectionFailed;
+        var o: std.posix.O = @bitCast(@as(u32, @truncate(flags)));
+        o.NONBLOCK = true;
+        _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+        std.posix.connect(sock, &self.address.any, @sizeOf(std.posix.sockaddr.in)) catch |err| switch (err) {
+            // EINPROGRESS is the expected outcome: the handshake runs in the
+            // kernel and poll(POLLOUT) reports the result.
+            error.WouldBlock => {},
+            else => return error.ConnectionFailed,
+        };
+
+        adopted = true;
+        self.stream = .{ .handle = sock };
+        self.nonblocking = true;
+        setNoDelay(self.stream.?);
+        self.connect_started_at = std.time.timestamp();
+        // Even a connect() that completed inline (loopback) goes through
+        // `completeConnect`, so there is exactly one path to `.handshaking`.
+        self.state = .connecting;
+    }
+
+    /// Finish a `.connecting` socket after poll reported it writable (or in
+    /// error). SO_ERROR carries the asynchronous outcome — a refused or
+    /// unreachable peer also makes the socket "ready".
+    pub fn completeConnect(self: *PeerConnection) !void {
+        const s = self.stream orelse {
+            self.state = .disconnected;
+            return error.ConnectionFailed;
+        };
+        std.posix.getsockoptError(s.handle) catch {
+            self.state = .disconnected;
+            return error.ConnectionFailed;
+        };
+        self.state = .handshaking;
+    }
+
+    /// True when a `.connecting` peer has outlived `connect_timeout_secs`.
+    /// Checked from the session's maintenance tick, so the deadline costs
+    /// nothing while the loop keeps serving every other peer.
+    pub fn connectTimedOut(self: PeerConnection, now: i64) bool {
+        if (self.state != .connecting) return false;
+        return now - self.connect_started_at >= connect_timeout_secs;
+    }
+
+    /// Initiate a connection and BLOCK until it is established (or times out).
+    /// Still used by the proxy/SOCKS and I2P/SAM routes, whose own handshakes
+    /// are synchronous. The direct route uses `startConnect` instead.
     pub fn connect(self: *PeerConnection) !void {
         // Native I2P: open a SAM stream to the destination. Synchronous, so on
         // success the stream is ready for the BT handshake (like the proxy path).
@@ -609,6 +689,76 @@ test "peer enqueue and send buffer" {
     try peer.enqueueMessage(.choke);
     try std.testing.expect(peer.wantsSend());
     try std.testing.expectEqual(@as(usize, 5), peer.send_buf.items.len); // 4 + 1
+}
+
+test "startConnect leaves the peer in .connecting and finishes via poll" {
+    const allocator = std.testing.allocator;
+
+    // Ephemeral loopback listener: something must accept, or the connect
+    // completes with ECONNREFUSED instead.
+    const listen_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var server = try listen_addr.listen(.{ .reuse_address = true });
+    defer server.deinit();
+    const port = server.listen_address.getPort();
+
+    var peer = PeerConnection.init(allocator, std.net.Address.initIp4(.{ 127, 0, 0, 1 }, port));
+    defer peer.deinit();
+
+    try peer.startConnect();
+    // The whole point: the call returned without waiting for the handshake.
+    try std.testing.expect(peer.stream != null);
+    try std.testing.expect(peer.nonblocking);
+    try std.testing.expectEqual(PeerState.connecting, peer.state);
+
+    var pfd = [_]std.posix.pollfd{.{ .fd = peer.fd(), .events = std.posix.POLL.OUT, .revents = 0 }};
+    const ready = try std.posix.poll(&pfd, 2000);
+    try std.testing.expect(ready == 1);
+
+    try peer.completeConnect();
+    try std.testing.expectEqual(PeerState.handshaking, peer.state);
+
+    var accepted = try server.accept();
+    accepted.stream.close();
+}
+
+test "a refused async connect ends disconnected, never established" {
+    const allocator = std.testing.allocator;
+
+    // Bind then release a port so (almost certainly) nothing is listening on it.
+    const probe_addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0);
+    var probe = try probe_addr.listen(.{ .reuse_address = true });
+    const dead_port = probe.listen_address.getPort();
+    probe.deinit();
+
+    var peer = PeerConnection.init(allocator, std.net.Address.initIp4(.{ 127, 0, 0, 1 }, dead_port));
+    defer peer.deinit();
+
+    // Loopback may refuse inside connect() (macOS) or asynchronously via
+    // SO_ERROR; both must land on `.disconnected`, never `.handshaking`.
+    if (peer.startConnect()) {
+        var pfd = [_]std.posix.pollfd{.{ .fd = peer.fd(), .events = std.posix.POLL.OUT, .revents = 0 }};
+        _ = try std.posix.poll(&pfd, 2000);
+        try std.testing.expectError(error.ConnectionFailed, peer.completeConnect());
+    } else |err| {
+        try std.testing.expectEqual(error.ConnectionFailed, err);
+    }
+    try std.testing.expectEqual(PeerState.disconnected, peer.state);
+}
+
+test "connectTimedOut only fires for a stalled .connecting peer" {
+    const allocator = std.testing.allocator;
+    const addr = std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 6881);
+    var peer = PeerConnection.init(allocator, addr);
+    defer peer.deinit();
+
+    peer.state = .connecting;
+    peer.connect_started_at = 1000;
+    try std.testing.expect(!peer.connectTimedOut(1000 + PeerConnection.connect_timeout_secs - 1));
+    try std.testing.expect(peer.connectTimedOut(1000 + PeerConnection.connect_timeout_secs));
+
+    // An established peer is never reaped by the connect deadline.
+    peer.state = .active;
+    try std.testing.expect(!peer.connectTimedOut(1_000_000));
 }
 
 test "peer handshake serialization" {

--- a/src/piece.zig
+++ b/src/piece.zig
@@ -10,12 +10,19 @@ pub const block_size: u32 = 16384;
 pub const Bitfield = struct {
     bytes: []u8,
     num_pieces: u32,
+    /// Number of set bits within `num_pieces`, maintained incrementally.
+    /// The session's poll loop asks `isComplete()` on every wake and reports
+    /// `count()` on every completed piece; recomputing either from the bytes
+    /// is O(num_pieces), which on a 10k-piece torrent burns real CPU for an
+    /// answer that only changes when a bit changes. Every mutation path in
+    /// this struct keeps this field in sync, so both are O(1).
+    have_count: u32,
 
     pub fn init(allocator: Allocator, num_pieces: u32) error{OutOfMemory}!Bitfield {
         const byte_count = (num_pieces + 7) / 8;
         const bytes = allocator.alloc(u8, byte_count) catch return error.OutOfMemory;
         @memset(bytes, 0);
-        return .{ .bytes = bytes, .num_pieces = num_pieces };
+        return .{ .bytes = bytes, .num_pieces = num_pieces, .have_count = 0 };
     }
 
     pub fn deinit(self: Bitfield, allocator: Allocator) void {
@@ -33,26 +40,35 @@ pub const Bitfield = struct {
         if (index >= self.num_pieces) return;
         const byte_idx = index / 8;
         const bit_idx: u3 = @intCast(7 - (index % 8));
-        self.bytes[byte_idx] |= @as(u8, 1) << bit_idx;
+        const mask = @as(u8, 1) << bit_idx;
+        // Only move the cached count when the bit actually flips, so repeated
+        // `have` messages for the same piece can't inflate it.
+        if (self.bytes[byte_idx] & mask == 0) self.have_count += 1;
+        self.bytes[byte_idx] |= mask;
     }
 
     pub fn clearPiece(self: *Bitfield, index: u32) void {
         if (index >= self.num_pieces) return;
         const byte_idx = index / 8;
         const bit_idx: u3 = @intCast(7 - (index % 8));
-        self.bytes[byte_idx] &= ~(@as(u8, 1) << bit_idx);
+        const mask = @as(u8, 1) << bit_idx;
+        if (self.bytes[byte_idx] & mask != 0) self.have_count -= 1;
+        self.bytes[byte_idx] &= ~mask;
     }
 
     pub fn count(self: Bitfield) u32 {
-        var n: u32 = 0;
-        for (0..self.num_pieces) |i| {
-            if (self.hasPiece(@intCast(i))) n += 1;
-        }
-        return n;
+        return self.have_count;
     }
 
     pub fn isComplete(self: Bitfield) bool {
-        return self.count() == self.num_pieces;
+        return self.have_count == self.num_pieces;
+    }
+
+    /// Recompute the set-bit count from the bytes. Only used when a bitfield
+    /// is built from raw bytes (and by the tests, to prove the incremental
+    /// count never drifts from the truth).
+    fn recount(self: Bitfield) u32 {
+        return popCountPrefix(self.bytes, self.num_pieces);
     }
 
     pub fn rawBytes(self: Bitfield) []const u8 {
@@ -64,9 +80,74 @@ pub const Bitfield = struct {
         if (raw.len != expected) return error.InvalidLength;
         const bytes = allocator.alloc(u8, expected) catch return error.OutOfMemory;
         @memcpy(bytes, raw);
-        return .{ .bytes = bytes, .num_pieces = num_pieces };
+        // The peer's spare bits (past `num_pieces`) are theirs to get wrong;
+        // popCountPrefix ignores them, matching `hasPiece`, which refuses any
+        // index at or past `num_pieces`.
+        return .{ .bytes = bytes, .num_pieces = num_pieces, .have_count = popCountPrefix(bytes, num_pieces) };
     }
 };
+
+/// Count set bits among the first `num_bits` bits of `bytes`, in BEP 3 order
+/// (bit 7 of byte 0 is bit 0). Whole 64-bit words go through `@popCount` --
+/// one instruction per 64 pieces instead of one branch per piece -- and the
+/// trailing partial byte is masked so bits past `num_bits` never count.
+fn popCountPrefix(bytes: []const u8, num_bits: u32) u32 {
+    const full_bytes = num_bits / 8;
+    var n: u32 = 0;
+    var i: usize = 0;
+    while (i + 8 <= full_bytes) : (i += 8) {
+        // Bit order within the word is irrelevant to a population count, so
+        // the raw byte-array reinterpretation is fine (and alignment-safe).
+        const word: u64 = @bitCast(bytes[i..][0..8].*);
+        n += @popCount(word);
+    }
+    while (i < full_bytes) : (i += 1) n += @popCount(bytes[i]);
+
+    const rem = num_bits % 8;
+    if (rem != 0) {
+        const shift: u3 = @intCast(8 - rem);
+        n += @popCount(bytes[full_bytes] & (@as(u8, 0xFF) << shift));
+    }
+    return n;
+}
+
+/// Index of the first bit that is set in neither `primary` nor `in_flight`,
+/// limited to `num_bits`, or null when every bit is covered. Scanning 64 bits
+/// at a time with `@clz` keeps the scheduler's per-block "what's next" lookup
+/// off the one-branch-per-block path; `in_flight` is null for callers that
+/// only care about what has actually arrived.
+fn firstMissingBit(primary: []const u8, in_flight: ?[]const u8, num_bits: u32) ?u32 {
+    const all_ones = ~@as(u64, 0);
+    const full_words = num_bits / 64;
+
+    var w: usize = 0;
+    while (w < full_words) : (w += 1) {
+        const off = w * 8;
+        // Big-endian read so the word's most significant bit is the lowest
+        // block index -- that is what makes `@clz` the missing bit's index.
+        var word = std.mem.readInt(u64, primary[off..][0..8], .big);
+        if (in_flight) |f| word |= std.mem.readInt(u64, f[off..][0..8], .big);
+        if (word != all_ones) return @intCast(w * 64 + @clz(~word));
+    }
+
+    var base: u32 = @intCast(full_words * 64);
+    var byte_idx: usize = full_words * 8;
+    while (base < num_bits) : ({
+        base += 8;
+        byte_idx += 1;
+    }) {
+        var b = primary[byte_idx];
+        if (in_flight) |f| b |= f[byte_idx];
+        if (b != 0xFF) {
+            const idx = base + @clz(~b);
+            // Only reachable in the trailing partial byte: its spare bits read
+            // as missing, but there is no such block.
+            if (idx >= num_bits) return null;
+            return idx;
+        }
+    }
+    return null;
+}
 
 /// Tracks received blocks for a single in-progress piece.
 pub const PieceProgress = struct {
@@ -141,18 +222,12 @@ pub const PieceProgress = struct {
     }
 
     pub fn isComplete(self: PieceProgress) bool {
-        for (0..self.num_blocks) |i| {
-            if (!self.hasBlock(@intCast(i))) return false;
-        }
-        return true;
+        return firstMissingBit(self.received, null, self.num_blocks) == null;
     }
 
     /// Return the next un-received block index, or null.
     pub fn nextMissingBlock(self: PieceProgress) ?u32 {
-        for (0..self.num_blocks) |i| {
-            if (!self.hasBlock(@intCast(i))) return @intCast(i);
-        }
-        return null;
+        return firstMissingBit(self.received, null, self.num_blocks);
     }
 
     pub fn isRequested(self: PieceProgress, block_idx: u32) bool {
@@ -182,11 +257,7 @@ pub const PieceProgress = struct {
     /// This is what the scheduler uses; `nextMissingBlock` (received-only) is
     /// for completeness checks where in-flight state must not hide a block.
     pub fn nextUnrequestedBlock(self: PieceProgress) ?u32 {
-        for (0..self.num_blocks) |i| {
-            const idx: u32 = @intCast(i);
-            if (!self.hasBlock(idx) and !self.isRequested(idx)) return idx;
-        }
-        return null;
+        return firstMissingBit(self.received, self.requested, self.num_blocks);
     }
 
     /// Compute begin offset and length for a given block index.
@@ -303,6 +374,93 @@ test "bitfield fromRaw roundtrip" {
     try std.testing.expect(!bf2.hasPiece(1));
 }
 
+test "bitfield count ignores spare bits in the trailing byte" {
+    const allocator = std.testing.allocator;
+    // 12 pieces occupy 1.5 bytes: a peer that sets the 4 spare bits (or just
+    // sends 0xFF padding) must not read as 16 pieces, and must not read as
+    // complete before we actually have all 12.
+    const raw = [_]u8{ 0xFF, 0xFF };
+    var bf = try Bitfield.fromRaw(allocator, &raw, 12);
+    defer bf.deinit(allocator);
+    try std.testing.expectEqual(@as(u32, 12), bf.count());
+    try std.testing.expectEqual(bf.recount(), bf.count());
+    try std.testing.expect(bf.isComplete());
+    try std.testing.expect(!bf.hasPiece(12));
+
+    // The same shape from the other direction: a partial trailing byte where
+    // only some live bits are set.
+    const partial = [_]u8{ 0b1010_0000, 0b1100_1111 };
+    var bf2 = try Bitfield.fromRaw(allocator, &partial, 12);
+    defer bf2.deinit(allocator);
+    try std.testing.expectEqual(@as(u32, 4), bf2.count()); // 2 + 2, spare bits dropped
+    try std.testing.expectEqual(bf2.recount(), bf2.count());
+    try std.testing.expect(!bf2.isComplete());
+}
+
+test "bitfield cached count survives every mutation path" {
+    const allocator = std.testing.allocator;
+    // Not a multiple of 8, and larger than one 64-bit word, so the word-at-a-
+    // time popcount and the masked tail are both exercised.
+    const num_pieces: u32 = 3020;
+    var bf = try Bitfield.init(allocator, num_pieces);
+    defer bf.deinit(allocator);
+    try std.testing.expectEqual(bf.recount(), bf.count());
+
+    // set: including a repeat (a duplicate `have`) and an out-of-range index,
+    // neither of which may move the count.
+    var i: u32 = 0;
+    while (i < num_pieces) : (i += 3) bf.setPiece(i);
+    bf.setPiece(0);
+    bf.setPiece(num_pieces);
+    bf.setPiece(num_pieces + 1000);
+    try std.testing.expectEqual(bf.recount(), bf.count());
+
+    // clear: same deal in reverse.
+    i = 0;
+    while (i < num_pieces) : (i += 7) bf.clearPiece(i);
+    bf.clearPiece(7);
+    bf.clearPiece(num_pieces);
+    try std.testing.expectEqual(bf.recount(), bf.count());
+
+    // fromRaw: a bitfield rebuilt from the wire agrees with the original.
+    var bf2 = try Bitfield.fromRaw(allocator, bf.rawBytes(), num_pieces);
+    defer bf2.deinit(allocator);
+    try std.testing.expectEqual(bf.count(), bf2.count());
+    try std.testing.expectEqual(bf2.recount(), bf2.count());
+
+    // ...and filling it completely lands exactly on num_pieces.
+    i = 0;
+    while (i < num_pieces) : (i += 1) bf2.setPiece(i);
+    try std.testing.expectEqual(num_pieces, bf2.count());
+    try std.testing.expectEqual(bf2.recount(), bf2.count());
+    try std.testing.expect(bf2.isComplete());
+
+    // A single clear anywhere makes it incomplete again.
+    bf2.clearPiece(num_pieces - 1);
+    try std.testing.expect(!bf2.isComplete());
+    try std.testing.expectEqual(num_pieces - 1, bf2.count());
+}
+
+test "bitfield count at every length around a byte boundary" {
+    const allocator = std.testing.allocator;
+    // Lengths 0..17 cover empty, sub-byte, exact-byte and multi-byte cases.
+    for (0..18) |n| {
+        const num_pieces: u32 = @intCast(n);
+        var bf = try Bitfield.init(allocator, num_pieces);
+        defer bf.deinit(allocator);
+        try std.testing.expectEqual(@as(u32, 0), bf.count());
+        try std.testing.expectEqual(num_pieces == 0, bf.isComplete());
+
+        var i: u32 = 0;
+        while (i < num_pieces) : (i += 1) {
+            bf.setPiece(i);
+            try std.testing.expectEqual(i + 1, bf.count());
+            try std.testing.expectEqual(bf.recount(), bf.count());
+        }
+        try std.testing.expect(bf.isComplete());
+    }
+}
+
 test "piece progress block assembly" {
     const allocator = std.testing.allocator;
     // 32KB piece = 2 blocks of 16KB
@@ -371,6 +529,59 @@ test "piece progress requested tracking" {
     // reset() clears in-flight state too.
     pp.reset();
     try std.testing.expectEqual(@as(?u32, 0), pp.nextUnrequestedBlock());
+}
+
+test "piece progress scans agree with a per-block reference" {
+    const allocator = std.testing.allocator;
+    // 100 blocks: more than one 64-bit word, and not a multiple of 8, so the
+    // word scan and the masked tail byte both get hit.
+    const num_blocks: u32 = 100;
+    var pp = try PieceProgress.init(allocator, 0, num_blocks * block_size);
+    defer pp.deinit(allocator);
+    try std.testing.expectEqual(num_blocks, pp.num_blocks);
+
+    const ref = struct {
+        fn firstMissing(p: PieceProgress) ?u32 {
+            for (0..p.num_blocks) |i| {
+                if (!p.hasBlock(@intCast(i))) return @intCast(i);
+            }
+            return null;
+        }
+        fn firstUnrequested(p: PieceProgress) ?u32 {
+            for (0..p.num_blocks) |i| {
+                const idx: u32 = @intCast(i);
+                if (!p.hasBlock(idx) and !p.isRequested(idx)) return idx;
+            }
+            return null;
+        }
+    };
+
+    // Walk a mixed state: some blocks received, some only in flight, in an
+    // order that leaves holes in the middle of words and in the tail byte.
+    var seed: u32 = 12345;
+    var step: u32 = 0;
+    while (step < num_blocks * 2) : (step += 1) {
+        seed = seed *% 1664525 +% 1013904223;
+        const idx = seed % num_blocks;
+        if (seed & 1 == 0) {
+            pp.markRequested(idx);
+        } else {
+            pp.markRequested(idx);
+            _ = pp.addBlock(idx * block_size, &([_]u8{0} ** block_size));
+        }
+        try std.testing.expectEqual(ref.firstMissing(pp), pp.nextMissingBlock());
+        try std.testing.expectEqual(ref.firstUnrequested(pp), pp.nextUnrequestedBlock());
+        try std.testing.expectEqual(ref.firstMissing(pp) == null, pp.isComplete());
+    }
+
+    // Finish it off: only the very last block missing, then none.
+    var i: u32 = 0;
+    while (i < num_blocks - 1) : (i += 1) _ = pp.addBlock(i * block_size, &([_]u8{0} ** block_size));
+    try std.testing.expectEqual(@as(?u32, num_blocks - 1), pp.nextMissingBlock());
+    try std.testing.expect(!pp.isComplete());
+    _ = pp.addBlock((num_blocks - 1) * block_size, &([_]u8{0} ** block_size));
+    try std.testing.expectEqual(@as(?u32, null), pp.nextMissingBlock());
+    try std.testing.expect(pp.isComplete());
 }
 
 test "piece progress block spec" {

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -17,6 +17,12 @@
 /// SO_RCVTIMEO), matching the blocking-connect model in peer.zig: by the time
 /// `connectThroughProxyAddr` returns, the stream is a transparent tunnel to the
 /// target and is ready for the BitTorrent handshake.
+///
+/// This module also owns the small blocking HTTP/1.1 client used for tracker
+/// announces (`httpGet` proxied, `httpGetDirect` not). Both share one request
+/// builder, TLS layer and response parser -- they differ only in how the stream
+/// is obtained -- so the direct path cannot drift out of sync with the proxied
+/// one, and in particular is bounded by the same timeouts.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const tls = std.crypto.tls;
@@ -84,7 +90,12 @@ pub const Header = struct {
 
 /// Connect + handshake timeout for proxy operations, in seconds.
 const proxy_timeout_secs: u32 = 10;
-/// Longer timeout for tracker GETs, which traverse the proxy to a remote host.
+/// Longer timeout for tracker GETs, which reach a remote host (through the
+/// proxy, or directly). It bounds the connect *and* every read/write, because a
+/// black-holed tracker -- common now that tracker-less magnets fall back to a
+/// tier of public trackers -- would otherwise park the caller for the OS TCP
+/// default (~75 s on the connect alone, minutes in total). Announces run on the
+/// session's event-loop thread, so that stalls every peer connection with them.
 const http_get_timeout_secs: u32 = 20;
 /// Cap on a single proxied HTTP response body (trackers are small).
 const max_response_bytes: usize = 4 * 1024 * 1024;
@@ -231,6 +242,30 @@ pub fn httpGet(allocator: Allocator, proxy: Proxy, url: []const u8, extra_header
     var stream = try connectThroughProxyHost(allocator, proxy, u.host, u.port);
     defer stream.close();
 
+    return httpExchange(allocator, stream, u, extra_headers);
+}
+
+/// Perform an HTTP(S) GET straight to the origin (no proxy) and return the
+/// response body (owned by the caller). Same request/TLS/parse path as
+/// `httpGet` -- only the stream differs -- so `https://` is never silently
+/// downgraded and both routes get the same `http_get_timeout_secs` bound.
+///
+/// We do not use `std.http.Client` here: in 0.15 it exposes no timeout knobs,
+/// so a dead tracker hangs the caller for the OS TCP default instead of failing
+/// fast enough for the announce backoff to take over. (DNS resolution is still
+/// the resolver's own affair; only the connect and the socket I/O are bounded.)
+pub fn httpGetDirect(allocator: Allocator, url: []const u8, extra_headers: ?[]const Header) ProxyError![]u8 {
+    const u = parseHttpUrl(url) orelse return error.InvalidUrl;
+
+    var stream = try dialDirect(allocator, u.host, u.port, http_get_timeout_secs);
+    defer stream.close();
+
+    return httpExchange(allocator, stream, u, extra_headers);
+}
+
+/// Send the GET for `u` over an already-connected `stream` and return the parsed
+/// body. Shared by the proxied and direct entry points.
+fn httpExchange(allocator: Allocator, stream: std.net.Stream, u: HttpUrl, extra_headers: ?[]const Header) ProxyError![]u8 {
     // Build the request by appending directly (tracker paths can be long --
     // info_hash, peer_id, and private-tracker passkeys -- so avoid fixed buffers).
     var req: std.ArrayList(u8) = .empty;
@@ -352,21 +387,60 @@ fn contentLength(head: []const u8) ?usize {
 
 fn dialProxy(allocator: Allocator, proxy: Proxy, timeout_secs: u32) ProxyError!std.net.Stream {
     const proxy_addr = try resolveIp4(allocator, proxy.host, proxy.port);
+    return connectWithTimeout(proxy_addr, timeout_secs);
+}
 
+/// Open a direct TCP connection to `host:port`, bounded by `timeout_secs`.
+/// Used by `httpGetDirect` when no proxy is configured.
+fn dialDirect(allocator: Allocator, host: []const u8, port: u16, timeout_secs: u32) ProxyError!std.net.Stream {
+    const addr = try resolveHost(allocator, host, port);
+    return connectWithTimeout(addr, timeout_secs);
+}
+
+/// Connect to `addr` with a hard upper bound on the connect *and* on every
+/// subsequent blocking read/write.
+///
+/// SO_SNDTIMEO does not bound connect() (notably on macOS), so we do a
+/// non-blocking connect + poll(POLLOUT) -- the same pattern peer.zig uses for
+/// peer dials -- then restore blocking mode and set SO_SNDTIMEO/SO_RCVTIMEO so
+/// a host that accepts and then goes silent cannot hang us either.
+fn connectWithTimeout(addr: std.net.Address, timeout_secs: u32) ProxyError!std.net.Stream {
     const sock = std.posix.socket(
-        std.posix.AF.INET,
+        addr.any.family,
         std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
         std.posix.IPPROTO.TCP,
     ) catch return error.SocketFailed;
     errdefer std.posix.close(sock);
 
-    // Bound both directions so a malicious/broken proxy cannot hang us forever.
+    const flags = std.posix.fcntl(sock, std.posix.F.GETFL, 0) catch return error.SocketFailed;
+    var o: std.posix.O = @bitCast(@as(u32, @truncate(flags)));
+    o.NONBLOCK = true;
+    _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
+
+    // poll() takes an i32 millisecond timeout; clamp so a pathological
+    // `timeout_secs` can't overflow the cast (callers pass small values).
+    const timeout_ms: i32 = if (timeout_secs > 600) 600_000 else @intCast(timeout_secs * 1000);
+
+    std.posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        // EINPROGRESS: wait for the socket to become writable (success) or to
+        // error out, bounded by our timeout.
+        error.WouldBlock => {
+            var pfd = [_]std.posix.pollfd{.{ .fd = sock, .events = std.posix.POLL.OUT, .revents = 0 }};
+            const ready = std.posix.poll(&pfd, timeout_ms) catch return error.ConnectFailed;
+            if (ready == 0) return error.ConnectFailed; // timed out
+            // Surface the asynchronous connect result (refused, unreachable, …)
+            // instead of treating a writable socket as connected.
+            std.posix.getsockoptError(sock) catch return error.ConnectFailed;
+        },
+        else => return error.ConnectFailed,
+    };
+
+    // Back to blocking, with both directions bounded.
+    o.NONBLOCK = false;
+    _ = std.posix.fcntl(sock, std.posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
     const tv = std.posix.timeval{ .sec = @intCast(timeout_secs), .usec = 0 };
     std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&tv)) catch {};
     std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
-
-    std.posix.connect(sock, &proxy_addr.any, proxy_addr.getOsSockLen()) catch
-        return error.ConnectFailed;
 
     return std.net.Stream{ .handle = sock };
 }
@@ -377,6 +451,20 @@ fn resolveIp4(allocator: Allocator, host: []const u8, port: u16) ProxyError!std.
     for (list.addrs) |a| {
         if (a.any.family == std.posix.AF.INET) return a;
     }
+    return error.DnsResolveFailed;
+}
+
+/// Resolve `host` for a direct connection: prefer IPv4 (what the swarm and
+/// nearly every tracker speak), but fall back to whatever the resolver returned
+/// so an IPv6-only tracker still works -- unlike the proxy paths, nothing here
+/// requires an IPv4 literal.
+fn resolveHost(allocator: Allocator, host: []const u8, port: u16) ProxyError!std.net.Address {
+    const list = std.net.getAddressList(allocator, host, port) catch return error.DnsResolveFailed;
+    defer list.deinit();
+    for (list.addrs) |a| {
+        if (a.any.family == std.posix.AF.INET) return a;
+    }
+    if (list.addrs.len > 0) return list.addrs[0];
     return error.DnsResolveFailed;
 }
 
@@ -997,6 +1085,89 @@ test "classifySocks5: non-SOCKS5 version => rejected" {
     const probe = classifySocks5(a, .{ .scheme = .socks5, .host = "127.0.0.1", .port = port }, 2);
     try std.testing.expectEqual(ProxyState.rejected, probe.state);
     try std.testing.expectEqual(@as(?u8, 0x04), probe.reply);
+}
+
+// --- httpGetDirect against a mock origin server ---
+
+const MockHttp = struct {
+    server: *std.net.Server,
+    stop: std.atomic.Value(bool),
+    response: []const u8,
+    request: [1024]u8 = undefined,
+    request_len: usize = 0,
+};
+
+fn mockHttpRun(ctx: *MockHttp) void {
+    // Poll-with-timeout accept so the thread can observe `stop` and exit.
+    var pfd = [_]std.posix.pollfd{.{ .fd = ctx.server.stream.handle, .events = std.posix.POLL.IN, .revents = 0 }};
+    while (!ctx.stop.load(.acquire)) {
+        const ready = std.posix.poll(&pfd, 200) catch 0;
+        if (ready == 0) continue;
+        const conn = ctx.server.accept() catch continue;
+        defer conn.stream.close();
+        while (ctx.request_len < ctx.request.len) {
+            const n = conn.stream.read(ctx.request[ctx.request_len..]) catch break;
+            if (n == 0) break;
+            ctx.request_len += n;
+            if (std.mem.indexOf(u8, ctx.request[0..ctx.request_len], "\r\n\r\n") != null) break;
+        }
+        var sent: usize = 0;
+        while (sent < ctx.response.len) {
+            const n = conn.stream.write(ctx.response[sent..]) catch break;
+            if (n == 0) break;
+            sent += n;
+        }
+    }
+}
+
+test "httpGetDirect fetches a body and sends an origin-form request" {
+    const a = std.testing.allocator;
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+
+    const ctx = try a.create(MockHttp);
+    ctx.* = .{
+        .server = &server,
+        .stop = std.atomic.Value(bool).init(false),
+        .response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nd1:xe",
+    };
+    const thread = try std.Thread.spawn(.{}, mockHttpRun, .{ctx});
+    defer {
+        server.deinit();
+        a.destroy(ctx);
+    }
+
+    const url = try std.fmt.allocPrint(a, "http://127.0.0.1:{d}/announce?info_hash=x", .{port});
+    defer a.free(url);
+    const body = try httpGetDirect(a, url, null);
+    defer a.free(body);
+
+    ctx.stop.store(true, .release);
+    thread.join();
+
+    try std.testing.expectEqualStrings("d1:xe", body);
+    const req = ctx.request[0..ctx.request_len];
+    try std.testing.expect(std.mem.startsWith(u8, req, "GET /announce?info_hash=x HTTP/1.1\r\n"));
+    // Non-default port must appear in Host, per RFC 9110.
+    var host_buf: [64]u8 = undefined;
+    const host_hdr = try std.fmt.bufPrint(&host_buf, "Host: 127.0.0.1:{d}\r\n", .{port});
+    try std.testing.expect(std.mem.indexOf(u8, req, host_hdr) != null);
+}
+
+test "httpGetDirect surfaces a refused connect instead of hanging" {
+    const a = std.testing.allocator;
+    // Bind to grab a free port, then close it so the connect is refused.
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    server.deinit();
+
+    const url = try std.fmt.allocPrint(a, "http://127.0.0.1:{d}/announce", .{port});
+    defer a.free(url);
+    try std.testing.expectError(error.ConnectFailed, httpGetDirect(a, url, null));
+}
+
+test "httpGetDirect rejects a non-HTTP url" {
+    try std.testing.expectError(error.InvalidUrl, httpGetDirect(std.testing.allocator, "udp://tracker:6969", null));
 }
 
 test "redactUrl masks SOCKS credentials" {

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -19,8 +19,240 @@ pub const Error = error{
     PublishFailed,
     SubscribeFailed,
     NotConnected,
+    /// The shared health table says this relay is in backoff (or its URL is
+    /// unusable), so the dial was never attempted. Callers skip to the next one.
+    Skipped,
     OutOfMemory,
 } || ws.Error || nostr.Error;
+
+// ===========================================================================
+// Per-relay connect health
+// ===========================================================================
+// Every subsystem that dials relays (the daemon's prober, the GUI search, the
+// manager's peer discovery and completion broadcast, `seeding.publish`, the
+// follow poller) shares one table keyed by relay URL. A relay that fails is
+// backed off individually, so a permanently-503 relay stops being hammered
+// even while its neighbours answer fine -- the exact hole in the old global
+// "were ALL relays down this cycle?" streak, which a single healthy relay
+// reset forever.
+
+/// Why a relay is not dialable right now.
+pub const Skip = enum {
+    /// Dialable.
+    none,
+    /// Recent transient failure(s); wait out the backoff.
+    backoff,
+    /// The URL itself is unusable (won't parse). Permanent until the config
+    /// changes -- retrying can only ever fail the same way.
+    invalid,
+};
+
+/// How a dial ended, from the health table's point of view.
+pub const Failure = enum {
+    /// DNS/TCP/TLS/handshake failure, a 503 from the CDN in front of the
+    /// relay, ... -- it may well work later, so back off and retry.
+    transient,
+    /// The URL can't be dialed at all. No amount of retrying helps.
+    invalid,
+};
+
+/// First backoff step after a failed dial, and the ceiling it doubles to.
+pub const backoff_base_ms: i64 = 30 * std.time.ms_per_s;
+pub const backoff_max_ms: i64 = 5 * 60 * std.time.ms_per_s;
+
+/// Backoff for the `fails`th consecutive failure: 30s, 60s, 120s, 240s, then
+/// 300s forever (the cap). Zero failures means "dial now".
+pub fn backoffMs(fails: u32) i64 {
+    if (fails == 0) return 0;
+    // Clamp the shift well before it could overflow the i64; the cap below
+    // makes anything past the 4th step identical anyway.
+    const shift: u6 = @intCast(@min(fails - 1, 8));
+    return @min(backoff_base_ms << shift, backoff_max_ms);
+}
+
+/// The state machine for one relay. Default = healthy, dial away.
+pub const RelayHealth = struct {
+    /// Consecutive transient failures since the last success.
+    fails: u32 = 0,
+    /// Wall-clock ms before which the relay is skipped. 0 = dialable now.
+    until_ms: i64 = 0,
+    /// URL is structurally unusable; skip until the config changes.
+    invalid: bool = false,
+
+    pub fn skip(self: RelayHealth, now_ms: i64) Skip {
+        if (self.invalid) return .invalid;
+        if (now_ms < self.until_ms) return .backoff;
+        return .none;
+    }
+
+    /// A successful dial clears everything, including the `invalid` flag (the
+    /// config must have changed for the dial to have worked at all).
+    pub fn onSuccess(self: *RelayHealth) void {
+        self.* = .{};
+    }
+
+    pub fn onFailure(self: *RelayHealth, now_ms: i64, class: Failure) void {
+        switch (class) {
+            .invalid => {
+                self.invalid = true;
+                self.fails = 0;
+                self.until_ms = 0;
+            },
+            .transient => {
+                self.fails +|= 1;
+                self.until_ms = now_ms + backoffMs(self.fails);
+            },
+        }
+    }
+};
+
+/// Health for every relay URL carl has dialed. Guarded by its own mutex: the
+/// prober, the session threads, and the daemon's request threads all touch it.
+pub const HealthTable = struct {
+    allocator: Allocator,
+    mutex: std.Thread.Mutex = .{},
+    map: std.StringHashMapUnmanaged(RelayHealth) = .empty,
+
+    /// Upper bound on tracked relays. The configured set is a handful of URLs;
+    /// the cap just keeps a pathological config (or a churn of edited relay
+    /// lists) from growing the table without limit. Past it, new relays are
+    /// simply untracked (always dialable) rather than evicting live state.
+    const max_entries: usize = 64;
+
+    pub fn deinit(self: *HealthTable) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        var it = self.map.keyIterator();
+        while (it.next()) |k| self.allocator.free(k.*);
+        self.map.deinit(self.allocator);
+        self.map = .empty;
+    }
+
+    pub fn skipAt(self: *HealthTable, url: []const u8, now_ms: i64) Skip {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const e = self.map.get(url) orelse return .none;
+        return e.skip(now_ms);
+    }
+
+    pub fn skip(self: *HealthTable, url: []const u8) Skip {
+        return self.skipAt(url, std.time.milliTimestamp());
+    }
+
+    /// Clear this relay's backoff. Untracked relays are healthy by definition,
+    /// so a success on one allocates nothing.
+    pub fn recordSuccess(self: *HealthTable, url: []const u8) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        const e = self.map.getPtr(url) orelse return;
+        // Say so when a relay comes back, otherwise recovery is invisible in
+        // the log (successes are silent) and a later first-failure line looks
+        // like the backoff forgot its history.
+        if (e.fails > 0 or e.invalid) log.info("relay {s}: reachable again", .{url});
+        e.onSuccess();
+    }
+
+    pub fn recordFailureAt(self: *HealthTable, url: []const u8, class: Failure, now_ms: i64) void {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        var e: RelayHealth = self.map.get(url) orelse blk: {
+            if (self.map.count() >= max_entries) return;
+            break :blk .{};
+        };
+        const first = e.fails == 0 and !e.invalid;
+        e.onFailure(now_ms, class);
+
+        const key = self.map.getKey(url) orelse (self.allocator.dupe(u8, url) catch return);
+        self.map.put(self.allocator, key, e) catch {
+            // Only reachable when the key was freshly duped and the put OOM'd.
+            if (self.map.getKey(url) == null) self.allocator.free(key);
+            return;
+        };
+
+        // Log the transition once, then stay quiet: a relay that is down for an
+        // hour should cost a handful of lines, not one per attempt.
+        if (first) {
+            switch (class) {
+                .invalid => log.warn("relay {s}: unusable URL, not dialing again until the config changes", .{url}),
+                .transient => log.info("relay {s}: unreachable, backing off {d}s", .{ url, @divTrunc(backoffMs(e.fails), std.time.ms_per_s) }),
+            }
+        } else {
+            log.debug("relay {s}: still failing, backing off {d}s", .{ url, @divTrunc(backoffMs(e.fails), std.time.ms_per_s) });
+        }
+    }
+
+    pub fn recordFailure(self: *HealthTable, url: []const u8, class: Failure) void {
+        self.recordFailureAt(url, class, std.time.milliTimestamp());
+    }
+};
+
+/// The process-wide table. One instance so a failure observed by the prober
+/// also holds back peer discovery, publishing, and the follow poller. Keys are
+/// duped from the page allocator and live for the process; the set is bounded
+/// by `HealthTable.max_entries`.
+var global_health: HealthTable = .{ .allocator = std.heap.page_allocator };
+
+pub fn health() *HealthTable {
+    return &global_health;
+}
+
+/// Whether a caller honors the health table.
+pub const Gate = enum {
+    /// Background/periodic caller (the prober, peer re-discovery, the follow
+    /// poller): honor the skip list. These run again on their own schedule, so
+    /// skipping a relay costs nothing but the politeness it buys.
+    honor,
+    /// One-shot operation whose only alternative is doing nothing at all (an
+    /// explicit publish, a user's search when every relay happens to be backed
+    /// off): dial anyway. The outcome is still recorded.
+    force,
+};
+
+/// Gate for a one-shot operation over `urls`: honor the skip list as long as it
+/// leaves at least one relay to talk to, otherwise force the dial. This is what
+/// keeps the skip list from silently turning a publish or a search into a
+/// no-op when every relay happens to be in backoff.
+pub fn oneShotGate(urls: []const []const u8) Gate {
+    return gateFor(health(), urls, std.time.milliTimestamp());
+}
+
+fn gateFor(table: *HealthTable, urls: []const []const u8, now_ms: i64) Gate {
+    for (urls) |u| {
+        if (table.skipAt(u, now_ms) == .none) return .honor;
+    }
+    return .force;
+}
+
+/// `Relay.connect` behind the shared health gate. Returns `error.Skipped`
+/// without touching the network when `gate` is `.honor` and the relay is
+/// backing off (or its URL is unusable).
+pub fn dial(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy, gate: Gate) Error!Relay {
+    if (gate == .honor) {
+        switch (health().skip(url)) {
+            .none => {},
+            .backoff => {
+                log.debug("relay {s}: skipped, backing off", .{url});
+                return error.Skipped;
+            },
+            .invalid => {
+                log.debug("relay {s}: skipped, unusable URL", .{url});
+                return error.Skipped;
+            },
+        }
+    }
+    return Relay.connect(allocator, url, proxy);
+}
+
+/// A URL we can't even parse will never work until the config changes;
+/// everything else (DNS, TCP, TLS, a 503 from the CDN in front of the relay)
+/// might come back.
+fn classify(err: ws.Error) Failure {
+    return switch (err) {
+        error.InvalidUrl => .invalid,
+        else => .transient,
+    };
+}
 
 /// One relay connection.
 pub const Relay = struct {
@@ -28,6 +260,9 @@ pub const Relay = struct {
     url: []const u8, // borrowed
     conn: ws.Conn,
 
+    /// Dial `url`, recording the outcome in the shared health table. This is
+    /// the unconditional dial; `dial()` above adds the skip gate on top. Both
+    /// record, so even the CLI's one-shot commands teach the table.
     pub fn connect(allocator: Allocator, url: []const u8, proxy: ?proxy_mod.Proxy) Error!Relay {
         // Relay traffic is tunneled through `--proxy` so the relay never sees our
         // real IP -- `ws://` rides the SOCKS tunnel directly (e.g. an onion
@@ -35,8 +270,10 @@ pub const Relay = struct {
         // proxied stream (the proxy only ever sees ciphertext).
         const conn = ws.Conn.connect(allocator, url, .{ .proxy = proxy }) catch |err| {
             log.debug("relay connect to {s} failed: {}", .{ url, err });
+            health().recordFailure(url, classify(err));
             return error.ConnectFailed;
         };
+        health().recordSuccess(url);
         return .{ .allocator = allocator, .url = url, .conn = conn };
     }
 
@@ -109,8 +346,8 @@ pub fn subscribeAndCollect(
     // Tighten the underlying socket's recv timeout so opts.timeout_ms is a
     // true upper bound, not just a soft per-iteration check. Without this,
     // a relay that opens then goes silent could keep us inside a single
-    // recv() up to ws.Conn's default 30 s, even when the caller asked for
-    // a shorter budget.
+    // recv() for ws.Conn's whole default recv timeout (20-30 s), even when the
+    // caller asked for a shorter budget.
     if (opts.timeout_ms > 0) {
         const tv: std.posix.timeval = .{
             .sec = @intCast(opts.timeout_ms / 1000),
@@ -258,6 +495,139 @@ pub const default_relays: []const []const u8 = &.{
 test "default_relays is non-empty and all wss://" {
     try std.testing.expect(default_relays.len >= 1);
     for (default_relays) |r| try std.testing.expect(std.mem.startsWith(u8, r, "wss://"));
+}
+
+test "backoffMs: 30s doubling, capped at 5 minutes" {
+    try std.testing.expectEqual(@as(i64, 0), backoffMs(0));
+    try std.testing.expectEqual(@as(i64, 30_000), backoffMs(1));
+    try std.testing.expectEqual(@as(i64, 60_000), backoffMs(2));
+    try std.testing.expectEqual(@as(i64, 120_000), backoffMs(3));
+    try std.testing.expectEqual(@as(i64, 240_000), backoffMs(4));
+    // 5th step would be 480s; the cap holds it at 300s from here on.
+    try std.testing.expectEqual(backoff_max_ms, backoffMs(5));
+    try std.testing.expectEqual(backoff_max_ms, backoffMs(1000));
+}
+
+test "RelayHealth: fresh relay is dialable" {
+    const h: RelayHealth = .{};
+    try std.testing.expectEqual(Skip.none, h.skip(0));
+    try std.testing.expectEqual(Skip.none, h.skip(1_000_000));
+}
+
+test "RelayHealth: transient failure backs off, then becomes dialable again" {
+    var h: RelayHealth = .{};
+    h.onFailure(1_000, .transient);
+    try std.testing.expectEqual(Skip.backoff, h.skip(1_000));
+    try std.testing.expectEqual(Skip.backoff, h.skip(30_999));
+    // The deadline itself is not "before", so the relay is dialable again.
+    try std.testing.expectEqual(Skip.none, h.skip(31_000));
+
+    // Second consecutive failure doubles the wait.
+    h.onFailure(31_000, .transient);
+    try std.testing.expectEqual(@as(u32, 2), h.fails);
+    try std.testing.expectEqual(Skip.backoff, h.skip(90_999));
+    try std.testing.expectEqual(Skip.none, h.skip(91_000));
+}
+
+test "RelayHealth: success resets the backoff immediately" {
+    var h: RelayHealth = .{};
+    h.onFailure(0, .transient);
+    h.onFailure(30_000, .transient);
+    h.onFailure(90_000, .transient);
+    try std.testing.expectEqual(Skip.backoff, h.skip(90_001));
+    h.onSuccess();
+    try std.testing.expectEqual(Skip.none, h.skip(90_001));
+    try std.testing.expectEqual(@as(u32, 0), h.fails);
+    // ...and the next failure starts again at the first step, not the cap.
+    h.onFailure(90_001, .transient);
+    try std.testing.expectEqual(@as(i64, 90_001 + 30_000), h.until_ms);
+}
+
+test "RelayHealth: invalid is permanent until the config changes" {
+    var h: RelayHealth = .{};
+    h.onFailure(0, .invalid);
+    try std.testing.expectEqual(Skip.invalid, h.skip(0));
+    // No deadline can expire it -- a year later it is still skipped.
+    try std.testing.expectEqual(Skip.invalid, h.skip(365 * 24 * 3600 * 1000));
+    // A dial that somehow succeeds (the user fixed the URL) clears it.
+    h.onSuccess();
+    try std.testing.expectEqual(Skip.none, h.skip(0));
+}
+
+test "RelayHealth: invalid wins over a pending backoff" {
+    var h: RelayHealth = .{};
+    h.onFailure(0, .transient);
+    h.onFailure(0, .invalid);
+    try std.testing.expectEqual(Skip.invalid, h.skip(10_000_000));
+}
+
+test "classify: only an unparseable URL is permanent" {
+    try std.testing.expectEqual(Failure.invalid, classify(error.InvalidUrl));
+    try std.testing.expectEqual(Failure.transient, classify(error.ConnectFailed));
+    try std.testing.expectEqual(Failure.transient, classify(error.HandshakeFailed)); // the 503-from-Cloudflare case
+    try std.testing.expectEqual(Failure.transient, classify(error.DnsResolveFailed));
+    try std.testing.expectEqual(Failure.transient, classify(error.Timeout));
+}
+
+test "HealthTable: tracks relays independently" {
+    var t: HealthTable = .{ .allocator = std.testing.allocator };
+    defer t.deinit();
+
+    // One relay 503s forever while its neighbour answers: the healthy one must
+    // not reset the failing one's backoff (the bug this whole thing fixes).
+    t.recordFailureAt("wss://relay.damus.io", .transient, 0);
+    t.recordSuccess("wss://nos.lol");
+    try std.testing.expectEqual(Skip.backoff, t.skipAt("wss://relay.damus.io", 0));
+    try std.testing.expectEqual(Skip.none, t.skipAt("wss://nos.lol", 0));
+
+    // Repeated failures keep growing that one relay's wait.
+    t.recordFailureAt("wss://relay.damus.io", .transient, 30_000);
+    try std.testing.expectEqual(Skip.backoff, t.skipAt("wss://relay.damus.io", 89_999));
+    try std.testing.expectEqual(Skip.none, t.skipAt("wss://relay.damus.io", 90_000));
+
+    // And a success wipes it.
+    t.recordSuccess("wss://relay.damus.io");
+    try std.testing.expectEqual(Skip.none, t.skipAt("wss://relay.damus.io", 0));
+}
+
+test "HealthTable: unknown relays are dialable and cost nothing" {
+    var t: HealthTable = .{ .allocator = std.testing.allocator };
+    defer t.deinit();
+    try std.testing.expectEqual(Skip.none, t.skipAt("wss://never.seen", 0));
+    t.recordSuccess("wss://never.seen"); // must not allocate an entry
+    try std.testing.expectEqual(@as(usize, 0), t.map.count());
+}
+
+test "HealthTable: invalid URLs stay skipped" {
+    var t: HealthTable = .{ .allocator = std.testing.allocator };
+    defer t.deinit();
+    t.recordFailureAt("ftp://nope", .invalid, 0);
+    try std.testing.expectEqual(Skip.invalid, t.skipAt("ftp://nope", 0));
+    try std.testing.expectEqual(Skip.invalid, t.skipAt("ftp://nope", backoff_max_ms * 100));
+}
+
+test "gateFor: honors the skip list until it would silence every relay" {
+    var t: HealthTable = .{ .allocator = std.testing.allocator };
+    defer t.deinit();
+    const urls = [_][]const u8{ "wss://relay.damus.io", "wss://nos.lol" };
+
+    // All healthy -> honor.
+    try std.testing.expectEqual(Gate.honor, gateFor(&t, &urls, 0));
+
+    // One backing off, one fine -> still honor (the publish reaches nos.lol).
+    t.recordFailureAt("wss://relay.damus.io", .transient, 0);
+    try std.testing.expectEqual(Gate.honor, gateFor(&t, &urls, 0));
+
+    // Every relay unusable -> force, so a one-shot publish/search still tries
+    // instead of silently doing nothing.
+    t.recordFailureAt("wss://nos.lol", .invalid, 0);
+    try std.testing.expectEqual(Gate.force, gateFor(&t, &urls, 0));
+
+    // Once the backoff expires the healthy-again relay pulls it back to honor.
+    try std.testing.expectEqual(Gate.honor, gateFor(&t, &urls, 30_000));
+
+    // An empty relay list has nothing to protect; force is the harmless answer.
+    try std.testing.expectEqual(Gate.force, gateFor(&t, &.{}, 0));
 }
 
 test "SearchOptions defaults are sensible" {

--- a/src/resume_data.zig
+++ b/src/resume_data.zig
@@ -1,0 +1,882 @@
+//! Persisted verified-piece bitfield ("resume data"), so restarting a transfer
+//! doesn't have to re-hash every byte already on disk.
+//!
+//! `Session.init` used to SHA-1 every existing piece before it could do
+//! anything else: seconds for a 755 MB torrent, minutes for a multi-GB one,
+//! all on the thread that added the transfer (which is what the desktop's 60s
+//! keepalive was papering over). Resuming a mostly-complete torrent should be
+//! instant, so the bitfield the scan produced is written next to the payload
+//! and read back on the next start.
+//!
+//! The rule everywhere below: this record is a CACHE of a hash check, never the
+//! truth. A wrongly-set bit means serving corrupt data to peers and calling a
+//! broken download complete — far worse than the seconds a re-verify costs. So
+//! every check is a reason to REJECT the record and fall back to the full
+//! verify, and anything unexpected (unknown format, bad checksum, changed
+//! size/mtime, different geometry, a failed spot check) resolves that way.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const piece_mod = @import("piece.zig");
+const storage_mod = @import("storage.zig");
+
+const log = std.log.scoped(.resume_data);
+
+/// Records live in `<output_dir>/.carl-resume/<infohash-hex>.resume`, i.e. next
+/// to the data they describe rather than in the daemon's config dir. The data
+/// directory is what the record is *about*: seed dirs are user-chosen and the
+/// CLI, the daemon, and `carl follow` all point at different ones, so keying
+/// the location off the payload is the only placement where every frontend
+/// finds the same record. Hidden and per-info-hash so several torrents can
+/// share one directory without colliding or cluttering it.
+pub const dir_name = ".carl-resume";
+
+/// Layout version, carried in the magic. A record written by another version
+/// fails the magic check and is re-verified instead of being misread.
+const format_version: u8 = 1;
+const magic = [8]u8{ 'C', 'A', 'R', 'L', 'R', 'S', 'M', format_version };
+
+/// magic + info_hash + piece_length + total_length + num_pieces + num_files
+/// + saved_at.
+const header_len = 8 + 20 + 8 + 8 + 4 + 4 + 8;
+/// Per payload file: size + mtime (nanoseconds).
+const stamp_len = 8 + 16;
+/// CRC-32 over everything preceding it.
+const trailer_len = 4;
+
+/// Refuse to allocate for anything absurd: 64 MiB of record describes ~500M
+/// pieces, orders of magnitude past any real torrent.
+const max_record_bytes: usize = 64 * 1024 * 1024;
+
+/// How many of the pieces a record claims are re-hashed before it is believed.
+/// Size and mtime can only prove that *something* changed; they cannot prove
+/// nothing did (coarse filesystem timestamps, a same-size in-place rewrite, a
+/// restore from backup that preserved mtime, silent corruption). Four pieces
+/// is a few tens of milliseconds even at a 4 MiB piece size — nothing against
+/// a multi-GB re-hash — and it catches every wholesale divergence, which is
+/// what the failure mode actually looks like in practice.
+const spot_checks: usize = 4;
+
+/// Seconds between periodic saves while pieces are arriving. A crash can lose
+/// at most this much verified progress (it costs a re-verify, never
+/// correctness), and each save fsyncs the payload, so it must not be hot.
+pub const save_interval_secs: i64 = 20;
+
+/// Size + last-modification time of a payload file at save time. Reused from
+/// storage so both sides of the comparison are literally the same type.
+pub const FileStamp = storage_mod.FileStat;
+
+/// The torrent geometry a record must match exactly to be usable. Anything
+/// that changes the meaning of a bit lives here.
+pub const Key = struct {
+    info_hash: [20]u8,
+    piece_length: u64,
+    total_length: u64,
+    num_pieces: u32,
+    num_files: u32,
+
+    pub fn eql(a: Key, b: Key) bool {
+        return std.mem.eql(u8, &a.info_hash, &b.info_hash) and
+            a.piece_length == b.piece_length and
+            a.total_length == b.total_length and
+            a.num_pieces == b.num_pieces and
+            a.num_files == b.num_files;
+    }
+};
+
+pub const DecodeError = error{ BadMagic, BadLength, BadChecksum };
+
+/// A parsed record. Borrows the caller's buffer: the stamps and the bitfield
+/// are read out of it in place, so nothing here allocates.
+pub const Record = struct {
+    key: Key,
+    saved_at: i64,
+    buf: []const u8,
+
+    pub fn stamp(self: Record, index: u32) FileStamp {
+        const off = header_len + @as(usize, index) * stamp_len;
+        return .{
+            .size = std.mem.readInt(u64, self.buf[off..][0..8], .little),
+            .mtime_ns = std.mem.readInt(i128, self.buf[off + 8 ..][0..16], .little),
+        };
+    }
+
+    pub fn bits(self: Record) []const u8 {
+        const off = header_len + @as(usize, self.key.num_files) * stamp_len;
+        return self.buf[off .. self.buf.len - trailer_len];
+    }
+};
+
+/// Serialize a record. Caller owns the result.
+pub fn encode(
+    a: Allocator,
+    key: Key,
+    stamps: []const FileStamp,
+    saved_at: i64,
+    bits: []const u8,
+) Allocator.Error![]u8 {
+    const total = header_len + stamps.len * stamp_len + bits.len + trailer_len;
+    const buf = try a.alloc(u8, total);
+    errdefer a.free(buf);
+
+    @memcpy(buf[0..8], &magic);
+    @memcpy(buf[8..28], &key.info_hash);
+    std.mem.writeInt(u64, buf[28..36], key.piece_length, .little);
+    std.mem.writeInt(u64, buf[36..44], key.total_length, .little);
+    std.mem.writeInt(u32, buf[44..48], key.num_pieces, .little);
+    std.mem.writeInt(u32, buf[48..52], key.num_files, .little);
+    std.mem.writeInt(i64, buf[52..60], saved_at, .little);
+
+    var w: usize = header_len;
+    for (stamps) |s| {
+        std.mem.writeInt(u64, buf[w..][0..8], s.size, .little);
+        std.mem.writeInt(i128, buf[w + 8 ..][0..16], s.mtime_ns, .little);
+        w += stamp_len;
+    }
+    @memcpy(buf[w..][0..bits.len], bits);
+    w += bits.len;
+
+    std.mem.writeInt(u32, buf[w..][0..4], std.hash.Crc32.hash(buf[0..w]), .little);
+    return buf;
+}
+
+/// Parse a record without trusting any of it. The length is recomputed from
+/// the header and must match the buffer exactly, so a truncated (crash
+/// mid-write, full disk) or over-long record is rejected before any field is
+/// used; the CRC then rejects bit rot. Counts are widened to u64 first so a
+/// corrupt `num_files` can't wrap the size arithmetic into a valid-looking one.
+pub fn decode(buf: []const u8) DecodeError!Record {
+    if (buf.len < header_len + trailer_len) return error.BadLength;
+    if (!std.mem.eql(u8, buf[0..8], &magic)) return error.BadMagic;
+
+    var key: Key = undefined;
+    @memcpy(&key.info_hash, buf[8..28]);
+    key.piece_length = std.mem.readInt(u64, buf[28..36], .little);
+    key.total_length = std.mem.readInt(u64, buf[36..44], .little);
+    key.num_pieces = std.mem.readInt(u32, buf[44..48], .little);
+    key.num_files = std.mem.readInt(u32, buf[48..52], .little);
+    const saved_at = std.mem.readInt(i64, buf[52..60], .little);
+
+    const bits_len = (@as(u64, key.num_pieces) + 7) / 8;
+    const expected = @as(u64, header_len) +
+        @as(u64, key.num_files) * stamp_len + bits_len + trailer_len;
+    if (expected != buf.len) return error.BadLength;
+
+    const stored = std.mem.readInt(u32, buf[buf.len - trailer_len ..][0..4], .little);
+    if (stored != std.hash.Crc32.hash(buf[0 .. buf.len - trailer_len])) return error.BadChecksum;
+
+    return .{ .key = key, .saved_at = saved_at, .buf = buf };
+}
+
+/// Longest path we ever build: `<dir>/<40 hex>.resume` plus the `.tmp` suffix
+/// the atomic save writes through.
+const path_max = dir_name.len + 1 + 40 + ".resume".len + ".tmp".len;
+
+/// Build the record's path inside the output dir. Formatted into a
+/// caller-provided buffer rather than stored, so `Resume` stays a plain value
+/// that survives being copied (`Session` is returned by value from its init).
+fn recordPath(buf: *[path_max]u8, info_hash: [20]u8, tmp: bool) []const u8 {
+    const hex = std.fmt.bytesToHex(info_hash, .lower);
+    return std.fmt.bufPrint(buf, "{s}/{s}.resume{s}", .{
+        dir_name,
+        &hex,
+        if (tmp) ".tmp" else "",
+    }) catch unreachable; // path_max is sized for exactly this
+}
+
+/// The session's handle on its record: which torrent it describes, and whether
+/// the in-memory bitfield has moved since the last save.
+pub const Resume = struct {
+    info_hash: [20]u8,
+    /// Set when a piece was gained or lost since the last successful save.
+    /// Nothing is written while this is false: the record on disk still
+    /// describes the payload exactly, and rewriting it would only cost an
+    /// fsync.
+    dirty: bool = false,
+    /// Wall-clock second of the last successful save; gates `maybeSave`.
+    last_save_s: i64 = 0,
+
+    pub fn markDirty(self: *Resume) void {
+        self.dirty = true;
+    }
+
+    /// Restore the verified bitfield without hashing anything, or return null —
+    /// which always means "re-verify from the bytes on disk". Null covers a
+    /// missing, unreadable, stale, corrupt, or spot-check-failing record; the
+    /// caller cannot tell them apart and must not care.
+    ///
+    /// Caller owns the returned bitfield.
+    pub fn load(
+        self: *Resume,
+        a: Allocator,
+        store: *storage_mod.Storage,
+        key: Key,
+        pieces: []const u8,
+    ) ?piece_mod.Bitfield {
+        // A magnet whose metadata hasn't landed has no geometry to match yet.
+        if (key.num_pieces == 0 or key.num_files == 0) return null;
+
+        var pb: [path_max]u8 = undefined;
+        const path = recordPath(&pb, self.info_hash, false);
+
+        const raw = store.dir.readFileAlloc(a, path, max_record_bytes) catch return null;
+        defer a.free(raw);
+
+        const rec = decode(raw) catch |err| {
+            log.debug("resume: unusable record ({t}); verifying from disk", .{err});
+            return null;
+        };
+
+        // Same torrent, same piece geometry, same file count — otherwise a bit
+        // in the record doesn't refer to the piece we'd apply it to.
+        if (!rec.key.eql(key)) {
+            log.debug("resume: record geometry differs; verifying from disk", .{});
+            return null;
+        }
+
+        // Every payload file must be exactly as it was when the record was
+        // written. The stat goes through the handle we will actually read
+        // pieces from (`fstat`, not a path lookup), so a file swapped out
+        // between the check and the reads can't slip past it.
+        for (0..key.num_files) |i| {
+            const idx: u32 = @intCast(i);
+            const cur = store.statFile(idx) catch return null;
+            const rec_stamp = rec.stamp(idx);
+            if (cur.size != rec_stamp.size or cur.mtime_ns != rec_stamp.mtime_ns) {
+                log.debug("resume: file {d} changed since save; verifying from disk", .{idx});
+                return null;
+            }
+            // ...and it must still be the size the torrent says. A record
+            // written against a half-allocated file is not a resume point.
+            if (cur.size != store.file_map.file_lengths[i]) return null;
+        }
+
+        // Spare bits past `num_pieces` are ours, unlike a peer's bitfield: if
+        // any is set the record wasn't written by us as we write it, so it is
+        // not a record we understand.
+        if (!spareBitsClear(rec.bits(), key.num_pieces)) {
+            log.debug("resume: record has junk past the last piece; verifying from disk", .{});
+            return null;
+        }
+
+        var bf = piece_mod.Bitfield.fromRaw(a, rec.bits(), key.num_pieces) catch return null;
+        if (!self.spotCheck(a, store, bf, key, pieces)) {
+            bf.deinit(a);
+            return null;
+        }
+
+        // The record still describes the payload exactly; nothing to write
+        // until a piece moves.
+        self.dirty = false;
+        self.last_save_s = std.time.timestamp();
+        return bf;
+    }
+
+    /// Re-hash a few of the pieces the record claims. The two ends are always
+    /// picked (truncation and partial rewrites show up there first) plus random
+    /// interior ones, so nothing about the file layout can systematically dodge
+    /// the check. Any miss discards the WHOLE record: one wrong bit means the
+    /// record's provenance is unknown, and a partially-trusted bitfield is the
+    /// exact thing this module must never produce.
+    fn spotCheck(
+        self: *Resume,
+        a: Allocator,
+        store: *storage_mod.Storage,
+        bf: piece_mod.Bitfield,
+        key: Key,
+        pieces: []const u8,
+    ) bool {
+        _ = self;
+        const have = bf.count();
+        if (have == 0) return true; // nothing claimed, nothing to disprove
+
+        var picks: [spot_checks]u32 = undefined;
+        var n: usize = 0;
+        picks[n] = nthSetPiece(bf, 0) orelse return false;
+        n += 1;
+        if (have > 1) {
+            picks[n] = nthSetPiece(bf, have - 1) orelse return false;
+            n += 1;
+        }
+        while (n < picks.len and have > 2) : (n += 1) {
+            const ord = std.crypto.random.intRangeLessThan(u32, 0, have);
+            picks[n] = nthSetPiece(bf, ord) orelse return false;
+        }
+
+        for (picks[0..n]) |idx| {
+            const plen = piece_mod.pieceLength(idx, key.piece_length, key.total_length);
+            if (plen == 0) return false;
+            const data = store.readPiece(a, idx, plen) catch return false;
+            defer a.free(data);
+            const hash = piece_mod.pieceHash(pieces, idx) orelse return false;
+            if (!piece_mod.verifyPiece(data, hash)) {
+                log.warn(
+                    "resume: piece {d} does not match its hash; re-verifying the whole payload",
+                    .{idx},
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// Write the current bitfield out, atomically. Best-effort by design: a
+    /// failed save costs a re-verify on the next start, never correctness, so
+    /// no error is propagated to the session.
+    pub fn save(
+        self: *Resume,
+        a: Allocator,
+        store: *storage_mod.Storage,
+        key: Key,
+        bf: piece_mod.Bitfield,
+    ) void {
+        // Never write a record we can't stand behind: a magnet still fetching
+        // metadata has no geometry, and a 0-piece record here would clobber a
+        // real one left by a previous run of the same torrent.
+        if (key.num_pieces == 0 or key.num_files == 0) return;
+        if (bf.num_pieces != key.num_pieces) return;
+        if (store.files_closed) return;
+
+        // Get the payload durable BEFORE the record that vouches for it.
+        // Without this ordering a power cut can leave a record claiming pieces
+        // whose bytes never left the page cache — the trusted-but-wrong state
+        // everything else here exists to prevent.
+        store.syncAll();
+
+        const stamps = a.alloc(FileStamp, key.num_files) catch return;
+        defer a.free(stamps);
+        for (stamps, 0..) |*s, i| s.* = store.statFile(@intCast(i)) catch return;
+
+        const blob = encode(a, key, stamps, std.time.timestamp(), bf.rawBytes()) catch return;
+        defer a.free(blob);
+
+        store.dir.makePath(dir_name) catch {};
+
+        var tb: [path_max]u8 = undefined;
+        const tmp = recordPath(&tb, self.info_hash, true);
+        {
+            const f = store.dir.createFile(tmp, .{}) catch return;
+            defer f.close();
+            f.writeAll(blob) catch {
+                store.dir.deleteFile(tmp) catch {};
+                return;
+            };
+            // Flush before the rename: the rename is what publishes the record,
+            // and a record published ahead of its own bytes is exactly the
+            // corrupt-but-trusted file this is meant to rule out.
+            f.sync() catch {};
+        }
+
+        var db: [path_max]u8 = undefined;
+        const dst = recordPath(&db, self.info_hash, false);
+        store.dir.rename(tmp, dst) catch {
+            store.dir.deleteFile(tmp) catch {};
+            return;
+        };
+
+        self.dirty = false;
+        self.last_save_s = std.time.timestamp();
+    }
+
+    /// Periodic save while pieces are arriving: only when something changed and
+    /// at most every `save_interval_secs`.
+    pub fn maybeSave(
+        self: *Resume,
+        a: Allocator,
+        store: *storage_mod.Storage,
+        key: Key,
+        bf: piece_mod.Bitfield,
+        now: i64,
+    ) void {
+        if (!self.dirty) return;
+        if (now - self.last_save_s < save_interval_secs) return;
+        self.save(a, store, key, bf);
+    }
+};
+
+/// Index of the `ord`-th set piece (0-based), or null if there aren't that
+/// many. O(num_pieces) and only ever run `spot_checks` times at startup.
+fn nthSetPiece(bf: piece_mod.Bitfield, ord: u32) ?u32 {
+    var seen: u32 = 0;
+    var i: u32 = 0;
+    while (i < bf.num_pieces) : (i += 1) {
+        if (!bf.hasPiece(i)) continue;
+        if (seen == ord) return i;
+        seen += 1;
+    }
+    return null;
+}
+
+/// True when the bits past `num_pieces` in the trailing byte are all zero.
+fn spareBitsClear(bits: []const u8, num_pieces: u32) bool {
+    const rem = num_pieces % 8;
+    if (rem == 0) return true;
+    const last = bits[bits.len - 1];
+    const shift: u3 = @intCast(8 - rem);
+    return (last & ~(@as(u8, 0xFF) << shift)) == 0;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+const testing = std.testing;
+const metainfo = @import("metainfo.zig");
+
+const test_piece_len: u64 = 16384;
+const test_pieces: u32 = 4;
+const test_total: u64 = test_piece_len * test_pieces;
+
+/// A payload of `test_pieces` distinct pieces plus the matching hash blob, so
+/// the tests exercise the real verify path rather than a stubbed one.
+const Fixture = struct {
+    data: [test_total]u8,
+    hashes: [test_pieces * 20]u8,
+
+    fn make() Fixture {
+        var f: Fixture = undefined;
+        for (&f.data, 0..) |*b, i| b.* = @truncate(i *% 31 +% 7);
+        var p: u32 = 0;
+        while (p < test_pieces) : (p += 1) {
+            const start = p * test_piece_len;
+            std.crypto.hash.Sha1.hash(
+                f.data[start .. start + test_piece_len],
+                f.hashes[p * 20 ..][0..20],
+                .{},
+            );
+        }
+        return f;
+    }
+
+    fn meta(self: *const Fixture, files: []const metainfo.FileInfo) metainfo.Metainfo {
+        return .{
+            .announce = "",
+            .announce_list = null,
+            .name = "test",
+            .piece_length = test_piece_len,
+            .pieces = &self.hashes,
+            .files = files,
+            .comment = null,
+            .creation_date = null,
+            .created_by = null,
+            .raw_info = &.{},
+            .url_list = null,
+        };
+    }
+};
+
+const test_info_hash: [20]u8 = .{0xAB} ** 20;
+
+fn testKey(num_files: u32) Key {
+    return .{
+        .info_hash = test_info_hash,
+        .piece_length = test_piece_len,
+        .total_length = test_total,
+        .num_pieces = test_pieces,
+        .num_files = num_files,
+    };
+}
+
+/// Lay the fixture payload down in `dir_path` and hand back an open store.
+fn openStore(a: Allocator, fx: *const Fixture, dir_path: []const u8, files: []const metainfo.FileInfo) !storage_mod.Storage {
+    var store = try storage_mod.Storage.init(a, fx.meta(files), dir_path, true);
+    errdefer store.deinit();
+    var p: u32 = 0;
+    while (p < test_pieces) : (p += 1) {
+        try store.writePiece(p, fx.data[p * test_piece_len ..][0..test_piece_len]);
+    }
+    return store;
+}
+
+const single_file = [_]metainfo.FileInfo{
+    .{ .length = test_total, .path = &.{"payload.bin"} },
+};
+
+test "resume: round-trips a saved bitfield and skips the re-hash" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    bf.setPiece(0);
+    bf.setPiece(2);
+    bf.setPiece(3);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+
+    var r2: Resume = .{ .info_hash = test_info_hash };
+    var loaded = r2.load(a, &store, testKey(1), &fx.hashes) orelse return error.RecordRejected;
+    defer loaded.deinit(a);
+
+    try testing.expectEqual(@as(u32, 3), loaded.count());
+    try testing.expect(loaded.hasPiece(0));
+    try testing.expect(!loaded.hasPiece(1));
+    try testing.expect(loaded.hasPiece(2));
+    try testing.expect(loaded.hasPiece(3));
+}
+
+test "resume: a file whose size changed is rejected" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    bf.setPiece(0);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+
+    // Someone truncated (or grew) the payload behind our back.
+    try store.handles[0].setEndPos(test_total - 1);
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+}
+
+test "resume: a file touched after the save is rejected" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    bf.setPiece(1);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+    var fresh = r.load(a, &store, testKey(1), &fx.hashes) orelse return error.RecordRejected;
+    fresh.deinit(a);
+
+    // Same bytes, same size — only the mtime moves. That alone must sink the
+    // record: we can't tell a harmless rewrite from a hostile one.
+    const before = try store.statFile(0);
+    try store.handles[0].updateTimes(before.mtime_ns + std.time.ns_per_s, before.mtime_ns + std.time.ns_per_s);
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+}
+
+test "resume: different geometry or info hash is rejected" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    bf.setPiece(0);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+
+    // Same file, but the caller now believes in a different piece length,
+    // piece count, total length, or file count: every bit would mean something
+    // else, so none of them may be used.
+    var k = testKey(1);
+    k.piece_length = test_piece_len * 2;
+    try testing.expect(r.load(a, &store, k, &fx.hashes) == null);
+
+    k = testKey(1);
+    k.num_pieces = test_pieces - 1;
+    try testing.expect(r.load(a, &store, k, &fx.hashes) == null);
+
+    k = testKey(1);
+    k.total_length = test_total - 1;
+    try testing.expect(r.load(a, &store, k, &fx.hashes) == null);
+
+    k = testKey(2);
+    try testing.expect(r.load(a, &store, k, &fx.hashes) == null);
+
+    // And a record for a different torrent that happens to sit in the same
+    // directory is not ours to read (it isn't even at our path, but the key
+    // check is the belt to that suspenders).
+    k = testKey(1);
+    k.info_hash = .{0xCD} ** 20;
+    try testing.expect(r.load(a, &store, k, &fx.hashes) == null);
+}
+
+test "resume: truncated or corrupt records are rejected" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    bf.setPiece(0);
+    bf.setPiece(1);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+
+    var pb: [path_max]u8 = undefined;
+    const rec_path = recordPath(&pb, test_info_hash, false);
+    const good = try store.dir.readFileAlloc(a, rec_path, max_record_bytes);
+    defer a.free(good);
+
+    // Truncated (a crash mid-write, a full disk).
+    try store.dir.writeFile(.{ .sub_path = rec_path, .data = good[0 .. good.len - 3] });
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+
+    // Trailing junk.
+    const longer = try a.alloc(u8, good.len + 4);
+    defer a.free(longer);
+    @memcpy(longer[0..good.len], good);
+    @memset(longer[good.len..], 0);
+    try store.dir.writeFile(.{ .sub_path = rec_path, .data = longer });
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+
+    // A single flipped bit anywhere (bit rot, a partial overwrite).
+    const flipped = try a.dupe(u8, good);
+    defer a.free(flipped);
+    flipped[header_len + 2] ^= 0x40;
+    try store.dir.writeFile(.{ .sub_path = rec_path, .data = flipped });
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+
+    // A record from another format version.
+    const aliened = try a.dupe(u8, good);
+    defer a.free(aliened);
+    aliened[7] = format_version + 1;
+    try store.dir.writeFile(.{ .sub_path = rec_path, .data = aliened });
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+
+    // The untouched original still loads, so the rejections above are about
+    // the damage and not about the fixture.
+    try store.dir.writeFile(.{ .sub_path = rec_path, .data = good });
+    var ok = r.load(a, &store, testKey(1), &fx.hashes) orelse return error.RecordRejected;
+    ok.deinit(a);
+}
+
+test "resume: a missing record is simply absent" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+}
+
+test "resume: content that changed under an unchanged stamp fails the spot check" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    var p: u32 = 0;
+    while (p < test_pieces) : (p += 1) bf.setPiece(p);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+    const stamp = try store.statFile(0);
+
+    // The adversarial case size+mtime cannot catch on its own: the payload is
+    // rewritten in place at the same length and the timestamp is put back
+    // (a restore from backup, a coarse-granularity filesystem, a same-second
+    // overwrite). The spot check is the only thing standing between this and
+    // serving garbage to peers.
+    const junk = [_]u8{0x00} ** test_piece_len;
+    try store.writePiece(0, &junk);
+    try store.writePiece(test_pieces - 1, &junk);
+    try store.handles[0].updateTimes(stamp.mtime_ns, stamp.mtime_ns);
+    try testing.expectEqual(stamp.mtime_ns, (try store.statFile(0)).mtime_ns);
+
+    try testing.expect(r.load(a, &store, testKey(1), &fx.hashes) == null);
+}
+
+test "resume: a cleared piece is not resurrected by the next load" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &single_file);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    var p: u32 = 0;
+    while (p < test_pieces) : (p += 1) bf.setPiece(p);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(1), bf);
+
+    // A piece that later failed verification (unreadable on disk, bad hash)
+    // is dropped and the record rewritten; the old bit must not come back.
+    bf.clearPiece(2);
+    r.markDirty();
+    r.save(a, &store, testKey(1), bf);
+
+    var loaded = r.load(a, &store, testKey(1), &fx.hashes) orelse return error.RecordRejected;
+    defer loaded.deinit(a);
+    try testing.expect(!loaded.hasPiece(2));
+    try testing.expectEqual(@as(u32, test_pieces - 1), loaded.count());
+}
+
+test "resume: multi-file torrents stamp every file" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    // Two files, split mid-piece, so a change in either one invalidates
+    // pieces that straddle the boundary.
+    const files = [_]metainfo.FileInfo{
+        .{ .length = test_piece_len + 100, .path = &.{"a.bin"} },
+        .{ .length = test_total - test_piece_len - 100, .path = &.{ "sub", "b.bin" } },
+    };
+
+    const fx = Fixture.make();
+    var store = try openStore(a, &fx, path, &files);
+    defer store.deinit();
+
+    var bf = try piece_mod.Bitfield.init(a, test_pieces);
+    defer bf.deinit(a);
+    var p: u32 = 0;
+    while (p < test_pieces) : (p += 1) bf.setPiece(p);
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    r.save(a, &store, testKey(2), bf);
+
+    var loaded = r.load(a, &store, testKey(2), &fx.hashes) orelse return error.RecordRejected;
+    loaded.deinit(a);
+
+    // Touching the SECOND file must invalidate the record too — a per-torrent
+    // stamp of only the first file would miss most of the payload.
+    const st = try store.statFile(1);
+    try store.handles[1].updateTimes(st.mtime_ns + std.time.ns_per_s, st.mtime_ns + std.time.ns_per_s);
+    try testing.expect(r.load(a, &store, testKey(2), &fx.hashes) == null);
+}
+
+test "resume: junk in the bits past the last piece is rejected" {
+    const a = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = tmp.dir.realpathAlloc(a, ".") catch return;
+    defer a.free(path);
+
+    // 3 pieces means 5 spare bits in the single bitfield byte.
+    const three = 3;
+    const files = [_]metainfo.FileInfo{
+        .{ .length = test_piece_len * three, .path = &.{"payload.bin"} },
+    };
+    const fx = Fixture.make();
+    var store = try storage_mod.Storage.init(a, fx.meta(&files), path, true);
+    defer store.deinit();
+    var p: u32 = 0;
+    while (p < three) : (p += 1) {
+        try store.writePiece(p, fx.data[p * test_piece_len ..][0..test_piece_len]);
+    }
+
+    const key: Key = .{
+        .info_hash = test_info_hash,
+        .piece_length = test_piece_len,
+        .total_length = test_piece_len * three,
+        .num_pieces = three,
+        .num_files = 1,
+    };
+
+    const stamps = [_]FileStamp{try store.statFile(0)};
+    const bits = [_]u8{0b1110_0001}; // pieces 0-2 set, plus a bit that can't exist
+    const blob = try encode(a, key, &stamps, std.time.timestamp(), &bits);
+    defer a.free(blob);
+    try store.dir.makePath(dir_name);
+    var pb: [path_max]u8 = undefined;
+    try store.dir.writeFile(.{ .sub_path = recordPath(&pb, test_info_hash, false), .data = blob });
+
+    var r: Resume = .{ .info_hash = test_info_hash };
+    try testing.expect(r.load(a, &store, key, &fx.hashes) == null);
+}
+
+test "resume: encode/decode round-trip preserves every field" {
+    const a = testing.allocator;
+    const key = testKey(2);
+    const stamps = [_]FileStamp{
+        .{ .size = 1234, .mtime_ns = -42 }, // pre-epoch mtimes exist; keep the sign
+        .{ .size = std.math.maxInt(u64), .mtime_ns = std.math.maxInt(i64) },
+    };
+    const bits = [_]u8{0b1010_0000};
+    const blob = try encode(a, key, &stamps, 1_700_000_000, &bits);
+    defer a.free(blob);
+
+    const rec = try decode(blob);
+    try testing.expect(rec.key.eql(key));
+    try testing.expectEqual(@as(i64, 1_700_000_000), rec.saved_at);
+    try testing.expectEqual(stamps[0].size, rec.stamp(0).size);
+    try testing.expectEqual(stamps[0].mtime_ns, rec.stamp(0).mtime_ns);
+    try testing.expectEqual(stamps[1].size, rec.stamp(1).size);
+    try testing.expectEqual(stamps[1].mtime_ns, rec.stamp(1).mtime_ns);
+    try testing.expectEqualSlices(u8, &bits, rec.bits());
+}
+
+test "decode: a wildly wrong file count can't wrap the length check" {
+    const a = testing.allocator;
+    const stamps = [_]FileStamp{.{ .size = 1, .mtime_ns = 1 }};
+    const bits = [_]u8{0};
+    const blob = try encode(a, testKey(1), &stamps, 0, &bits);
+    defer a.free(blob);
+
+    // num_files = 2^32-1: the implied size is far past the buffer, and the
+    // arithmetic must notice rather than overflow into a plausible number.
+    std.mem.writeInt(u32, blob[48..52], std.math.maxInt(u32), .little);
+    std.mem.writeInt(u32, blob[blob.len - 4 ..][0..4], std.hash.Crc32.hash(blob[0 .. blob.len - 4]), .little);
+    try testing.expectError(error.BadLength, decode(blob));
+}
+
+test "nthSetPiece and spareBitsClear" {
+    const a = testing.allocator;
+    var bf = try piece_mod.Bitfield.init(a, 20);
+    defer bf.deinit(a);
+    bf.setPiece(3);
+    bf.setPiece(11);
+    bf.setPiece(19);
+    try testing.expectEqual(@as(?u32, 3), nthSetPiece(bf, 0));
+    try testing.expectEqual(@as(?u32, 11), nthSetPiece(bf, 1));
+    try testing.expectEqual(@as(?u32, 19), nthSetPiece(bf, 2));
+    try testing.expectEqual(@as(?u32, null), nthSetPiece(bf, 3));
+
+    try testing.expect(spareBitsClear(&[_]u8{ 0xFF, 0xFF }, 16)); // no spare bits
+    try testing.expect(spareBitsClear(&[_]u8{ 0xFF, 0b1110_0000 }, 11));
+    try testing.expect(!spareBitsClear(&[_]u8{ 0xFF, 0b1110_0001 }, 11));
+}

--- a/src/seeding.zig
+++ b/src/seeding.zig
@@ -67,11 +67,25 @@ pub fn publish(
     const relay_urls = try nostr_config.readRelays(allocator);
     defer nostr_config.freeRelays(allocator, relay_urls);
 
+    // Publishing is one-shot and there is no retry behind it: the event is
+    // either accepted now or lost. So honor the shared per-relay backoff only
+    // while it still leaves someone to publish to — if every relay happens to
+    // be backing off, dial them all anyway rather than silently no-op. (One
+    // extra round of dials per publish, versus a seed nobody can discover.)
+    const gate = relay.oneShotGate(relay_urls);
+    if (gate == .force) log.info("nostr publish: every relay is backing off, publishing anyway", .{});
+
     var torrent_acks: usize = 0;
     var announce_acks: usize = 0;
     for (relay_urls) |url| {
-        var r = relay.Relay.connect(allocator, url, proxy) catch |err| {
-            log.warn("nostr publish: {s}: {}", .{ url, err });
+        var r = relay.dial(allocator, url, proxy, gate) catch |err| {
+            // A skip is expected bookkeeping, not a problem worth a warning;
+            // a real dial failure still is.
+            if (err == error.Skipped) {
+                log.debug("nostr publish: {s}: backing off, skipped", .{url});
+            } else {
+                log.warn("nostr publish: {s}: {}", .{ url, err });
+            }
             continue;
         };
         defer r.deinit();

--- a/src/session.zig
+++ b/src/session.zig
@@ -19,7 +19,42 @@ const i2p_sam = @import("i2p_sam.zig");
 
 const log = std.log.scoped(.session);
 
-const max_peers: usize = 50;
+/// Hard ceiling on simultaneous peer connections, and the size of the
+/// `[max_peers + 1]pollfd` / `[max_peers]*PeerConnection` stack arrays that
+/// walk the peer set (~1 KiB each — fine on any thread stack). Raised from 50
+/// once dialing became asynchronous: with blocking dials a bigger number was
+/// unreachable anyway, since filling the set would have frozen the loop for
+/// minutes. libtorrent's `connections_limit` defaults to 200; 100 keeps us well
+/// inside a conservative 256 open-file limit (peers + payload files + DHT).
+const max_peers: usize = 100;
+/// Peer ceiling for anonymized routes (proxy/Tor/I2P), where each dial still
+/// costs a blocking SOCKS/SAM handshake and every connection is a circuit.
+const max_peers_anonymized: usize = 50;
+/// New outbound dials started per `pumpConnects` (which runs at 1 Hz), i.e. a
+/// connection RATE, not a half-open limit — libtorrent's `connection_speed`
+/// default, 30 connections per second. Capping concurrent dials instead would
+/// mean a batch of unreachable peers blocked every other candidate for a full
+/// `connect_timeout_secs`; the total is already bounded by `max_peers`, which
+/// counts peers still in `.connecting`.
+const max_dials_per_pump: usize = 30;
+/// Proxied dials are still blocking, so only one may start per pump — ten
+/// seconds of Tor circuit setup is ten seconds the event loop is not serving
+/// peers. (The old code ran ten of them back to back per announce.)
+const max_dials_per_pump_proxied: usize = 1;
+/// Cap on the retained candidate-peer pool. libtorrent's `max_peerlist_size`
+/// is 3000; a few hundred is plenty to keep `max_peers` topped up between
+/// tracker announces (which are 15-30 minutes apart).
+const max_peer_pool: usize = 500;
+/// Minimum seconds between two dials of the same address, so a peer that
+/// refuses (or drops) us is not hammered every second.
+const min_reconnect_secs: i64 = 60;
+/// Consecutive failed dials after which a candidate address is dropped from
+/// the pool entirely.
+const max_dial_fails: u32 = 3;
+/// How often the dial telemetry line is emitted (debug level), when anything
+/// has been dialed since the last one.
+const dial_log_interval_secs: i64 = 30;
+
 const unchoke_slots: usize = 4;
 const unchoke_interval_secs: i64 = 10;
 const optimistic_interval_secs: i64 = 30;
@@ -319,6 +354,27 @@ const WebSeedWorker = struct {
     }
 };
 
+/// A discovered peer address we may dial, retained across announces.
+///
+/// The announce response used to be freed the moment its peers had been dialed
+/// once, so there was no candidate pool at all: between two tracker announces
+/// (15-30 minutes) the peer count could only go down, and a swarm that decayed
+/// to zero had to wait for the next announce to recover. Keeping the addresses
+/// lets `maintenance` top the set back up every second.
+const PoolEntry = struct {
+    addr: std.net.Address,
+    /// Earliest wall-clock second this address may be dialed again.
+    next_try: i64 = 0,
+    /// Consecutive failed dials; dropped from the pool past `max_dial_fails`.
+    fails: u32 = 0,
+};
+
+/// Byte-compare two addresses. Matches the comparison the peer set already
+/// used for de-duplication (sockaddr storage, so family + ip + port).
+fn addrEql(a: std.net.Address, b: std.net.Address) bool {
+    return std.mem.eql(u8, &std.mem.toBytes(a), &std.mem.toBytes(b));
+}
+
 pub const Session = struct {
     allocator: Allocator,
     meta: metainfo.Metainfo,
@@ -329,6 +385,24 @@ pub const Session = struct {
 
     peers: std.ArrayList(*peer_mod.PeerConnection),
     active_pieces: std.AutoHashMap(u32, *piece_mod.PieceProgress),
+
+    // --- Candidate peer pool (all defaulted; `init`'s literal need not set them) ---
+
+    /// Addresses learned from trackers / DHT / nostr that we are not currently
+    /// connected to. Deduplicated, capped at `max_peer_pool`, drained by
+    /// `pumpConnects`.
+    peer_pool: std.ArrayList(PoolEntry) = .empty,
+    /// Round-robin scan position into `peer_pool`, so a run of dead addresses
+    /// at the front cannot shadow the rest.
+    pool_cursor: usize = 0,
+    /// Second at which `pumpConnects` last ran; gates it to 1 Hz.
+    last_connect_pump_s: i64 = 0,
+    /// Dial telemetry since the last `dial_log_interval_secs` report. Without
+    /// these, 50 dials and 5 dials produced identical (empty) logs.
+    dial_attempts: u64 = 0,
+    dial_ok: u64 = 0,
+    dial_failed: u64 = 0,
+    last_dial_log_s: i64 = 0,
 
     // Piece availability counts (how many peers have each piece)
     piece_availability: []u32,
@@ -648,6 +722,7 @@ pub const Session = struct {
             self.allocator.destroy(p);
         }
         self.peers.deinit(self.allocator);
+        self.peer_pool.deinit(self.allocator);
 
         if (self.dht_instance) |*d| d.deinit();
         if (self.metadata_download) |*md| md.deinit();
@@ -909,8 +984,13 @@ pub const Session = struct {
             if (p.state == .disconnected or p.stream == null) continue;
             if (n >= fds.len) break;
 
-            var events: i16 = std.posix.POLL.IN;
-            if (p.wantsSend()) events |= std.posix.POLL.OUT;
+            // A `.connecting` socket only cares about writability: POLLOUT (or
+            // an error) is how the kernel reports the finished TCP handshake.
+            var events: i16 = if (p.state == .connecting)
+                std.posix.POLL.OUT
+            else
+                std.posix.POLL.IN;
+            if (p.state != .connecting and p.wantsSend()) events |= std.posix.POLL.OUT;
 
             fds[n] = .{ .fd = p.fd(), .events = events, .revents = 0 };
             n += 1;
@@ -934,6 +1014,14 @@ pub const Session = struct {
             if (fd_idx >= fds.len) break;
 
             const revents = fds[fd_idx].revents;
+
+            // Outbound dial in progress: any readiness at all (writable, or
+            // HUP/ERR for a refused connection) means the kernel is done.
+            if (p.state == .connecting) {
+                if (revents != 0) self.onConnectReady(p);
+                fd_idx += 1;
+                continue;
+            }
 
             if (revents & (std.posix.POLL.HUP | std.posix.POLL.ERR) != 0) {
                 p.disconnect();
@@ -1003,6 +1091,33 @@ pub const Session = struct {
 
             fd_idx += 1;
         }
+    }
+
+    /// Poll says a `.connecting` socket is ready: collect the connect result and,
+    /// on success, put the BitTorrent handshake ON THE WIRE immediately.
+    ///
+    /// Queueing the 68-byte handshake and leaving it for the next POLLOUT was
+    /// the second half of the dial bug: the remote saw an established TCP
+    /// connection carrying zero bytes and dropped us at its handshake timeout
+    /// (10 s in libtorrent). Writing it here makes "connected" and "greeted"
+    /// the same event.
+    fn onConnectReady(self: *Session, p: *peer_mod.PeerConnection) void {
+        p.completeConnect() catch {
+            self.dial_failed += 1;
+            self.notePoolDial(p.address, false);
+            p.disconnect();
+            return;
+        };
+        self.dial_ok += 1;
+        self.notePoolDial(p.address, true);
+
+        p.sendHandshake(self.info_hash, self.peer_id) catch {
+            p.disconnect();
+            return;
+        };
+        _ = p.flushSend() catch {
+            p.disconnect();
+        };
     }
 
     fn handleMessage(self: *Session, p: *peer_mod.PeerConnection, msg: wire.Message) !void {
@@ -1875,6 +1990,8 @@ pub const Session = struct {
             self.allocator.destroy(p);
             return;
         };
+        // Answer the incoming handshake immediately; see `onConnectReady`.
+        _ = p.flushSend() catch {};
 
         self.peers.append(self.allocator, p) catch {
             p.deinit();
@@ -1888,11 +2005,16 @@ pub const Session = struct {
         // Resample the live transfer rate (≤ once a second; `now` is seconds).
         self.sampleRate(now);
 
-        // Publish the live peer count for the daemon's cross-thread snapshot.
-        // Refreshed each tick here (and just below after pruning) so the daemon
-        // never reads `self.peers` directly. One tick of staleness is invisible
-        // to the 1 Hz snapshot.
-        self.peer_count.store(self.peers.items.len, .monotonic);
+        // Enforce the connect deadline here instead of blocking inside
+        // connect(): a peer that never completes its TCP handshake is dropped
+        // after `connect_timeout_secs` without the loop ever waiting on it.
+        for (self.peers.items) |p| {
+            if (p.connectTimedOut(now)) {
+                self.dial_failed += 1;
+                self.notePoolDial(p.address, false);
+                p.disconnect();
+            }
+        }
 
         // Remove disconnected peers and update availability
         var i: usize = 0;
@@ -1907,14 +2029,53 @@ pub const Session = struct {
                 self.allocator.destroy(p);
                 _ = self.peers.orderedRemove(i);
             } else {
-                if (now - p.last_send_time > 60) {
-                    p.enqueueMessage(.keep_alive) catch {};
-                }
-                if (now - p.last_recv_time > 120) {
-                    p.disconnect();
+                if (p.state != .connecting) {
+                    if (now - p.last_send_time > 60) {
+                        p.enqueueMessage(.keep_alive) catch {};
+                    }
+                    if (now - p.last_recv_time > 120) {
+                        p.disconnect();
+                    }
                 }
                 i += 1;
             }
+        }
+
+        // Publish the live peer count for the daemon's cross-thread snapshot.
+        // In-flight dials are excluded: they are not peers yet, and a whole
+        // pump's worth of them would inflate the displayed count. The daemon
+        // never reads `self.peers` directly.
+        {
+            var established: usize = 0;
+            for (self.peers.items) |p| {
+                if (p.state != .connecting) established += 1;
+            }
+            self.peer_count.store(established, .monotonic);
+        }
+
+        // Top the swarm up from the candidate pool, once a second. This used to
+        // happen only at the tracker interval (15-30 min) or when the peer count
+        // hit exactly zero, so between announces the count could only shrink.
+        if (now - self.last_connect_pump_s >= 1 and self.peers.items.len < self.peerLimit()) {
+            self.pumpConnects(now);
+        }
+
+        // Dial telemetry: without it a session that dialed 50 peers and one that
+        // dialed 5 produced identical (silent) logs.
+        if (self.last_dial_log_s == 0) self.last_dial_log_s = now; // start the clock
+        if (self.dial_attempts > 0 and now - self.last_dial_log_s >= dial_log_interval_secs) {
+            self.last_dial_log_s = now;
+            log.debug("dials: {d} attempted, {d} connected, {d} failed; peers {d} (+{d} connecting), pool {d}", .{
+                self.dial_attempts,
+                self.dial_ok,
+                self.dial_failed,
+                self.peers.items.len,
+                self.countConnecting(),
+                self.peer_pool.items.len,
+            });
+            self.dial_attempts = 0;
+            self.dial_ok = 0;
+            self.dial_failed = 0;
         }
 
         // Once a second: resize each peer's request pipeline from its
@@ -2140,83 +2301,183 @@ pub const Session = struct {
         return remaining;
     }
 
+    /// Absorb a discovery result (tracker, DHT, or nostr) into the candidate
+    /// pool and immediately start dialing, up to this pump's connection budget.
+    /// The addresses are RETAINED — the response they came from is freed by the
+    /// caller, but the pool keeps feeding `maintenance` until the next announce.
     fn connectToPeers(self: *Session, peer_list: []const tracker_mod.Peer) !void {
-        // Each proxied connection attempt takes ~10s through Tor (SOCKS
-        // handshake + circuit). Trying all 50 peers serially would block
-        // the session thread for minutes. Cap attempts per call; the
-        // tracker re-announce cycle gradually fills the peer pool.
-        const max_attempts: usize = if (self.proxy != null) 10 else 50;
-        var attempts: usize = 0;
-
-        // Rotate start offset so repeated announces don't always retry
-        // the same failing peers at the front of the list.
-        const offset = if (peer_list.len > 0)
-            std.crypto.random.intRangeAtMost(usize, 0, peer_list.len - 1)
-        else
-            0;
-
-        for (0..peer_list.len) |i| {
-            const tracker_peer = peer_list[(i + offset) % peer_list.len];
-            if (self.peers.items.len >= max_peers) break;
-            if (attempts >= max_attempts) break;
-
+        var added: usize = 0;
+        for (peer_list) |tracker_peer| {
             const addr = std.net.Address.initIp4(tracker_peer.ip, tracker_peer.port);
-            var already = false;
-            for (self.peers.items) |existing| {
-                if (std.mem.eql(u8, &std.mem.toBytes(existing.address), &std.mem.toBytes(addr))) {
-                    already = true;
-                    break;
-                }
-            }
-            if (already) continue;
+            if (self.addCandidate(addr)) added += 1;
+        }
+        log.debug("discovery: {d} peers offered, {d} new candidates, pool now {d}", .{
+            peer_list.len,
+            added,
+            self.peer_pool.items.len,
+        });
+        // Randomize where this announce's dialing starts, so a tracker that
+        // consistently lists dead peers first can't spend the whole per-pump
+        // budget on them. (The cursor still advances round-robin between pumps.)
+        if (self.peer_pool.items.len > 0) {
+            self.pool_cursor = std.crypto.random.uintLessThan(usize, self.peer_pool.items.len);
+        }
+        self.pumpConnects(std.time.timestamp());
+    }
 
-            attempts += 1;
+    /// Add an address to the candidate pool. Returns true if it was actually
+    /// added — an address already pooled, already connected, or currently being
+    /// dialed is dropped, as is anything past `max_peer_pool`.
+    fn addCandidate(self: *Session, addr: std.net.Address) bool {
+        if (self.peer_pool.items.len >= max_peer_pool) return false;
+        for (self.peer_pool.items) |e| {
+            if (addrEql(e.addr, addr)) return false;
+        }
+        if (self.isPeerLive(addr)) return false;
+        self.peer_pool.append(self.allocator, .{ .addr = addr }) catch return false;
+        return true;
+    }
 
-            const p = self.allocator.create(peer_mod.PeerConnection) catch continue;
-            p.* = peer_mod.PeerConnection.init(self.allocator, addr);
-            p.proxy = self.proxy;
+    /// Whether we already hold a connection (established or in flight) to this
+    /// address.
+    fn isPeerLive(self: *Session, addr: std.net.Address) bool {
+        for (self.peers.items) |p| {
+            if (p.state == .disconnected) continue;
+            if (addrEql(p.address, addr)) return true;
+        }
+        return false;
+    }
 
-            p.connect() catch {
-                p.deinit();
-                self.allocator.destroy(p);
-                continue;
-            };
-
-            p.sendHandshake(self.info_hash, self.peer_id) catch {
-                p.deinit();
-                self.allocator.destroy(p);
-                continue;
-            };
-
-            self.peers.append(self.allocator, p) catch {
-                p.deinit();
-                self.allocator.destroy(p);
-                continue;
-            };
+    /// Record a dial outcome against the pool entry for `addr`: success clears
+    /// the failure streak, failure counts toward `max_dial_fails` (after which
+    /// `pumpConnects` prunes the entry).
+    fn notePoolDial(self: *Session, addr: std.net.Address, ok: bool) void {
+        for (self.peer_pool.items) |*e| {
+            if (!addrEql(e.addr, addr)) continue;
+            if (ok) e.fails = 0 else e.fails +|= 1;
+            return;
         }
     }
 
+    fn countConnecting(self: *Session) usize {
+        var n: usize = 0;
+        for (self.peers.items) |p| {
+            if (p.state == .connecting) n += 1;
+        }
+        return n;
+    }
+
+    /// Peer ceiling for the active route. Anonymized routes still pay a
+    /// blocking handshake per dial, so they keep the old, smaller limit.
+    fn peerLimit(self: *const Session) usize {
+        return if (self.anonymized()) max_peers_anonymized else max_peers;
+    }
+
+    /// Start outbound dials from the candidate pool, up to `max_dials_per_pump`,
+    /// and prune addresses that have failed too often. Cheap enough to call
+    /// every event-loop iteration but gated to 1 Hz by `maintenance`; the
+    /// direct-route dials it starts never block.
+    fn pumpConnects(self: *Session, now: i64) void {
+        self.last_connect_pump_s = now;
+
+        // Drop candidates that keep refusing us, so the round-robin scan does
+        // not spend its budget re-dialing corpses.
+        var i: usize = 0;
+        while (i < self.peer_pool.items.len) {
+            if (self.peer_pool.items[i].fails > max_dial_fails) {
+                _ = self.peer_pool.swapRemove(i);
+            } else i += 1;
+        }
+        if (self.peer_pool.items.len == 0) return;
+
+        const budget = if (self.proxy != null) max_dials_per_pump_proxied else max_dials_per_pump;
+        var started: usize = 0;
+        var scanned: usize = 0;
+        while (scanned < self.peer_pool.items.len) : (scanned += 1) {
+            // `peers` includes peers still connecting, so this is what bounds
+            // the number of sockets (and file descriptors) in flight.
+            if (self.peers.items.len >= self.peerLimit()) break;
+            if (started >= budget) break;
+
+            const idx = self.pool_cursor % self.peer_pool.items.len;
+            self.pool_cursor = idx + 1;
+
+            const entry = &self.peer_pool.items[idx];
+            if (now < entry.next_try) continue;
+            const addr = entry.addr;
+            if (self.isPeerLive(addr)) continue;
+            // Stamp the cool-down before dialing, so a failure (async or
+            // immediate) cannot be retried until `min_reconnect_secs` has
+            // passed no matter which path reports it.
+            entry.next_try = now + min_reconnect_secs;
+
+            self.dial_attempts += 1;
+            started += 1;
+            if (!self.startDial(addr)) {
+                self.dial_failed += 1;
+                // `startDial` did not touch the pool; the entry index is still
+                // valid (nothing was added or removed above).
+                self.peer_pool.items[idx].fails +|= 1;
+            }
+        }
+    }
+
+    /// Create a peer for `addr` and begin connecting. Returns false if the dial
+    /// could not even be started (the peer is freed in that case; on success
+    /// ownership is in `self.peers`).
+    ///
+    /// The direct route returns with the peer in `.connecting` and the poll loop
+    /// owning the rest. Proxy dials still block here: SOCKS/CONNECT is a
+    /// request/response handshake of its own, and making it async would mean
+    /// reimplementing `proxy.zig` as a state machine for a route where each
+    /// connection costs ~10 s of circuit setup anyway. `max_inflight_connects_proxied`
+    /// keeps that to one blocking dial per pump.
+    fn startDial(self: *Session, addr: std.net.Address) bool {
+        const p = self.allocator.create(peer_mod.PeerConnection) catch return false;
+        p.* = peer_mod.PeerConnection.init(self.allocator, addr);
+        p.proxy = self.proxy;
+
+        var ok = false;
+        defer if (!ok) {
+            p.deinit();
+            self.allocator.destroy(p);
+        };
+
+        if (self.proxy != null) {
+            p.connect() catch return false;
+            p.sendHandshake(self.info_hash, self.peer_id) catch return false;
+            _ = p.flushSend() catch return false;
+            self.dial_ok += 1;
+            self.notePoolDial(addr, true);
+        } else {
+            // Handshake is sent by `onConnectReady` the moment the socket
+            // completes, not here — there is no connection to write to yet.
+            p.startConnect() catch return false;
+        }
+
+        self.peers.append(self.allocator, p) catch return false;
+        ok = true;
+        return true;
+    }
+
     /// Connect directly to a peer address, bypassing the tracker.
-    /// Useful for testing and for manual peer addition.
+    /// Useful for testing and for manual peer addition (nostr peer-announces).
     pub fn connectDirectPeer(self: *Session, addr: std.net.Address) !void {
-        if (self.peers.items.len >= max_peers) return;
+        if (self.peers.items.len >= self.peerLimit()) return;
         // On the I2P transport there is no clearnet route (and no proxy to tunnel
         // through), so a clearnet IPv4 peer is unreachable and dialing it would
         // leak the real IP — skip it. I2P peers arrive via connectI2pPeer.
         if (self.i2p != null) return;
 
-        const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
-        errdefer self.allocator.destroy(p);
-        p.* = peer_mod.PeerConnection.init(self.allocator, addr);
-        errdefer p.deinit();
-        p.proxy = self.proxy;
-
-        try self.finishPeerConnect(p);
+        // Route it through the pool so the address survives a failed or dropped
+        // connection and is retried on the normal cool-down.
+        _ = self.addCandidate(addr);
+        self.pumpConnects(std.time.timestamp());
     }
 
     /// Connect to a Tor hidden service (or other hostname) via the session proxy.
     pub fn connectOnionPeer(self: *Session, host: []const u8, port: u16) !void {
-        if (self.peers.items.len >= max_peers) return;
+        if (self.peers.items.len >= self.peerLimit()) return;
         const px = self.proxy orelse return error.ConnectionFailed;
 
         const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
@@ -2241,7 +2502,7 @@ pub const Session = struct {
     /// to SAM as `TO_PORT`; 0 = default). Requires the `i2p` route (a live SAM
     /// session).
     pub fn connectI2pPeer(self: *Session, dest: []const u8, port: u16) !void {
-        if (self.peers.items.len >= max_peers) return;
+        if (self.peers.items.len >= self.peerLimit()) return;
         const sam = self.i2p orelse return error.ConnectionFailed;
 
         const p = self.allocator.create(peer_mod.PeerConnection) catch return error.OutOfMemory;
@@ -2260,6 +2521,10 @@ pub const Session = struct {
     fn finishPeerConnect(self: *Session, p: *peer_mod.PeerConnection) !void {
         p.connect() catch return error.ConnectionFailed;
         p.sendHandshake(self.info_hash, self.peer_id) catch return error.OutOfMemory;
+        // Put the handshake on the wire now rather than waiting for the loop's
+        // next POLLOUT: remote clients drop a silent connection at their
+        // handshake timeout (10 s in libtorrent).
+        _ = p.flushSend() catch return error.ConnectionFailed;
         try self.peers.append(self.allocator, p);
     }
 
@@ -2681,6 +2946,85 @@ test "WebSeedWorker stopAndJoin frees an uncollected result" {
 
     w.stopAndJoin();
     try std.testing.expect(w.res_data == null);
+}
+
+test "candidate pool: dedupes, skips live peers, and honours the cap" {
+    const a = std.testing.allocator;
+
+    // Only the fields `addCandidate` touches, like the sampleRate test below.
+    var s: Session = undefined;
+    s.allocator = a;
+    s.peers = .empty;
+    s.peer_pool = .empty;
+    s.pool_cursor = 0;
+    defer s.peer_pool.deinit(a);
+
+    const addr = std.net.Address.initIp4(.{ 10, 0, 0, 1 }, 6881);
+    try std.testing.expect(s.addCandidate(addr));
+    // Same address again: the pool must not grow.
+    try std.testing.expect(!s.addCandidate(addr));
+    // Same IP, different port is a different peer.
+    try std.testing.expect(s.addCandidate(std.net.Address.initIp4(.{ 10, 0, 0, 1 }, 6882)));
+    try std.testing.expectEqual(@as(usize, 2), s.peer_pool.items.len);
+
+    // An address we already hold a connection to (including an in-flight dial)
+    // is not a candidate.
+    var live = peer_mod.PeerConnection.init(a, std.net.Address.initIp4(.{ 10, 0, 0, 9 }, 6881));
+    defer live.deinit();
+    live.state = .connecting;
+    try s.peers.append(a, &live);
+    defer s.peers.deinit(a);
+    try std.testing.expect(!s.addCandidate(live.address));
+
+    // Cap: the pool never grows past `max_peer_pool`.
+    var port: u16 = 7000;
+    while (s.peer_pool.items.len < max_peer_pool) : (port += 1) {
+        _ = s.addCandidate(std.net.Address.initIp4(.{ 10, 0, 1, 1 }, port));
+    }
+    try std.testing.expectEqual(max_peer_pool, s.peer_pool.items.len);
+    try std.testing.expect(!s.addCandidate(std.net.Address.initIp4(.{ 10, 0, 2, 2 }, 6881)));
+}
+
+test "pumpConnects respects the reconnect cool-down and prunes dead candidates" {
+    const a = std.testing.allocator;
+
+    var s: Session = undefined;
+    s.allocator = a;
+    s.peers = .empty;
+    s.peer_pool = .empty;
+    s.pool_cursor = 0;
+    s.proxy = null;
+    s.i2p = null;
+    s.dial_attempts = 0;
+    s.dial_ok = 0;
+    s.dial_failed = 0;
+    s.info_hash = [_]u8{0} ** 20;
+    s.peer_id = [_]u8{0} ** 20;
+    defer s.peer_pool.deinit(a);
+    defer {
+        for (s.peers.items) |p| {
+            p.deinit();
+            a.destroy(p);
+        }
+        s.peers.deinit(a);
+    }
+
+    // One candidate that must not be dialed yet, and one that has failed too
+    // often and must be dropped.
+    try s.peer_pool.append(a, .{
+        .addr = std.net.Address.initIp4(.{ 10, 0, 0, 1 }, 6881),
+        .next_try = 5_000,
+    });
+    try s.peer_pool.append(a, .{
+        .addr = std.net.Address.initIp4(.{ 10, 0, 0, 2 }, 6881),
+        .fails = max_dial_fails + 1,
+    });
+
+    s.pumpConnects(1_000);
+
+    try std.testing.expectEqual(@as(usize, 1), s.peer_pool.items.len);
+    try std.testing.expectEqual(@as(u64, 0), s.dial_attempts);
+    try std.testing.expectEqual(@as(usize, 0), s.peers.items.len);
 }
 
 test "sampleRate counts block bytes as progress before a piece verifies" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -93,6 +93,232 @@ pub const Mode = enum { download, seed };
 
 pub const ListenBind = enum { any, loopback };
 
+/// Seconds to park the web seed after `fail_streak` consecutive failed piece
+/// fetches: 5s doubling per failure, capped at 120s. A mirror that 404s (or a
+/// url-list entry that never pointed at the payload) would otherwise claim a
+/// piece, fail, and re-claim it on the very next loop iteration forever —
+/// burning a worker wake-up and a TCP handshake every tick for nothing.
+fn webSeedBackoffSecs(fail_streak: u32) i64 {
+    if (fail_streak == 0) return 0;
+    const shift: u6 = @intCast(@min(fail_streak - 1, 5));
+    return @min(web_seed_backoff_base_secs << shift, web_seed_backoff_cap_secs);
+}
+
+const web_seed_backoff_base_secs: i64 = 5;
+const web_seed_backoff_cap_secs: i64 = 120;
+
+/// Pick the next piece the web seed should fetch: scan forward from `cursor`,
+/// wrapping exactly once, and return the first index `ctx` still wants.
+///
+/// The old code restarted the scan at piece 0 on every loop iteration, so on a
+/// 3000-piece torrent it re-walked the whole low end of the file every tick and
+/// always handed the web seed the same early piece the peers were already
+/// working on. A rotating cursor keeps the common-case scan to a single step
+/// and spreads the web seed across the file instead of fighting the peers for
+/// the front of it.
+///
+/// `ctx` must expose `fn wants(ctx, idx: u32) bool` — true for a piece we still
+/// need and that nothing else has claimed.
+fn nextWebSeedPiece(num_pieces: u32, cursor: u32, ctx: anytype) ?u32 {
+    if (num_pieces == 0) return null;
+    const n: u64 = num_pieces;
+    const start: u64 = @as(u64, cursor) % n;
+    var i: u64 = 0;
+    while (i < n) : (i += 1) {
+        const idx: u32 = @intCast((start + i) % n);
+        if (ctx.wants(idx)) return idx;
+    }
+    return null;
+}
+
+/// BEP 19 web-seed fetcher: one worker thread that performs the ranged HTTP
+/// GETs so the session's poll loop never blocks on them.
+///
+/// This used to run inline on the event loop, with a brand-new
+/// `std.http.Client` per 256 KiB piece — a full TCP+TLS handshake per piece,
+/// and hundreds of milliseconds during which no peer socket was read. Real
+/// peers (qBittorrent/libtorrent) time out and drop that connection, so a
+/// swarm of 50 tracker peers decayed to one or two live sockets. Both halves
+/// of the fix live here: the client is kept alive across fetches (std's
+/// connection pool then reuses the socket per host) and the fetch happens on
+/// another thread.
+///
+/// Threading contract: the ONLY shared state is this struct, guarded by
+/// `mutex`. The worker never touches session state (bitfield, storage,
+/// `active_pieces`, peers) — it returns bytes and the session thread runs them
+/// through the same verify/write/broadcast path a peer-delivered piece takes.
+const WebSeedWorker = struct {
+    /// idle -> requested (session) -> fetching (worker) -> done (worker)
+    /// -> idle (session, once it has taken the result). Exactly one fetch is
+    /// in flight at a time; that is already enough to keep a mirror saturated
+    /// while leaving the event loop free.
+    const State = enum { idle, requested, fetching, done };
+
+    /// What the worker needs to perform one fetch. Deliberately self-contained
+    /// (no pointer back into the Session) so nothing the session thread mutates
+    /// can be read from the worker.
+    const Job = struct {
+        piece: u32,
+        /// Fully-built absolute URL. Session-allocated; borrowed for the fetch
+        /// and freed by the session when it collects the result.
+        url: []const u8,
+        start: u64,
+        len: u64,
+    };
+
+    const Result = struct {
+        piece: u32,
+        /// Piece bytes on success, null on any failure. Session owns and frees.
+        data: ?[]u8,
+        /// The job's URL, handed back so the session frees it exactly once.
+        url: []const u8,
+    };
+
+    allocator: Allocator,
+    mutex: std.Thread.Mutex = .{},
+    cond: std.Thread.Condition = .{},
+    thread: ?std.Thread = null,
+    state: State = .idle,
+    stop: bool = false,
+
+    job: Job = .{ .piece = 0, .url = &.{}, .start = 0, .len = 0 },
+    res_data: ?[]u8 = null,
+
+    fn start(w: *WebSeedWorker) !void {
+        if (w.thread != null) return;
+        w.thread = try std.Thread.spawn(.{}, threadMain, .{w});
+    }
+
+    /// Session side, non-blocking: hand a job to the worker. Returns false when
+    /// a fetch is already in flight or a result is still uncollected, in which
+    /// case the caller keeps ownership of `url`.
+    fn submit(w: *WebSeedWorker, job: Job) bool {
+        w.mutex.lock();
+        defer w.mutex.unlock();
+        if (w.state != .idle or w.stop) return false;
+        w.job = job;
+        w.state = .requested;
+        w.cond.signal();
+        return true;
+    }
+
+    /// Worker side: block until a job is queued. Returns null when the worker
+    /// has been asked to stop, which is the thread's exit signal.
+    fn awaitJob(w: *WebSeedWorker) ?Job {
+        w.mutex.lock();
+        defer w.mutex.unlock();
+        while (!w.stop and w.state != .requested) w.cond.wait(&w.mutex);
+        if (w.stop) return null;
+        w.state = .fetching;
+        return w.job;
+    }
+
+    /// Worker side: publish the outcome. `data` (or null on failure) transfers
+    /// to the session, which frees it.
+    fn publish(w: *WebSeedWorker, data: ?[]u8) void {
+        w.mutex.lock();
+        defer w.mutex.unlock();
+        w.res_data = data;
+        w.state = .done;
+    }
+
+    /// Session side, non-blocking: take a finished fetch, or null if none is
+    /// ready. The caller owns both `data` and `url` afterwards.
+    fn takeResult(w: *WebSeedWorker) ?Result {
+        w.mutex.lock();
+        defer w.mutex.unlock();
+        if (w.state != .done) return null;
+        const r: Result = .{ .piece = w.job.piece, .data = w.res_data, .url = w.job.url };
+        w.res_data = null;
+        w.job = .{ .piece = 0, .url = &.{}, .start = 0, .len = 0 };
+        w.state = .idle;
+        return r;
+    }
+
+    /// Ask the thread to exit and join it. A fetch already in flight runs to
+    /// completion first (std's HTTP client has no cancellation hook), so this
+    /// can block for as long as one 256 KiB ranged GET takes.
+    fn stopAndJoin(w: *WebSeedWorker) void {
+        w.mutex.lock();
+        w.stop = true;
+        w.cond.signal();
+        w.mutex.unlock();
+
+        if (w.thread) |t| t.join();
+        w.thread = null;
+
+        // Whatever the last cycle left behind is ours to free: a published
+        // result the session never collected, and the URL of the job it came
+        // from (or of a job that was queued but never picked up).
+        if (w.res_data) |d| w.allocator.free(d);
+        w.res_data = null;
+        if (w.job.url.len > 0) w.allocator.free(w.job.url);
+        w.job = .{ .piece = 0, .url = &.{}, .start = 0, .len = 0 };
+    }
+
+    fn threadMain(w: *WebSeedWorker) void {
+        // One client for the whole worker lifetime: std's connection pool is
+        // keyed by host, so consecutive ranged GETs against the same mirror
+        // reuse the socket (and the TLS session) instead of re-handshaking.
+        // Created lazily so a session that never uses a web seed pays nothing.
+        var client: ?std.http.Client = null;
+        defer if (client) |*c| c.deinit();
+
+        while (w.awaitJob()) |job| {
+            if (client == null) client = .{ .allocator = w.allocator };
+
+            const data: ?[]u8 = fetchRange(&client.?, w.allocator, job) catch |err| blk: {
+                // A failed request can leave a pooled connection unusable — and
+                // often the failure IS the pool (a mirror that quietly closed a
+                // kept-alive socket). Drop the client so the next attempt starts
+                // from a clean handshake rather than retrying through a
+                // poisoned pool.
+                if (client) |*c| c.deinit();
+                client = null;
+                log.debug("web seed: piece {d} fetch failed: {t}", .{ job.piece, err });
+                break :blk null;
+            };
+
+            w.publish(data);
+        }
+    }
+
+    /// Perform one ranged GET into a freshly allocated, exactly `job.len`-sized
+    /// buffer. Runs on the worker thread only. Caller owns the result.
+    fn fetchRange(client: *std.http.Client, a: Allocator, job: Job) ![]u8 {
+        var range_buf: [64]u8 = undefined;
+        const range_str = try std.fmt.bufPrint(&range_buf, "bytes={d}-{d}", .{
+            job.start,
+            job.start + job.len - 1,
+        });
+
+        const buf = try a.alloc(u8, @intCast(job.len));
+        errdefer a.free(buf);
+
+        // A fixed writer is both the destination and the length check: a mirror
+        // that ignores Range and streams the whole file overruns it and fails
+        // the fetch instead of quietly allocating gigabytes.
+        var body_writer = std.Io.Writer.fixed(buf);
+
+        const extra_headers = [_]std.http.Header{
+            .{ .name = "Range", .value = range_str },
+        };
+
+        const result = try client.fetch(.{
+            .location = .{ .url = job.url },
+            .response_writer = &body_writer,
+            .extra_headers = &extra_headers,
+        });
+
+        // 206 Partial Content, or 200 OK for a server that ignored the Range
+        // header but happened to hand us exactly the bytes we asked for.
+        if (result.status != .partial_content and result.status != .ok) return error.WebSeedHttpStatus;
+        if (body_writer.end != job.len) return error.WebSeedShortBody;
+
+        return buf;
+    }
+};
+
 pub const Session = struct {
     allocator: Allocator,
     meta: metainfo.Metainfo,
@@ -250,6 +476,32 @@ pub const Session = struct {
     /// the torrent on Nostr (NIP-35) if not already present on relays.
     on_complete: ?OnComplete = null,
 
+    // --- BEP 19 web seed (all defaulted; `init`'s struct literal need not set them) ---
+
+    /// The fetch thread, created on the first usable web-seed tick and joined in
+    /// `deinit`. Heap-allocated because the worker thread holds a pointer to it
+    /// and `Session` is returned by value from `init` (its own address is not
+    /// stable until the caller has parked it).
+    web_seed: ?*WebSeedWorker = null,
+    /// Rotating scan cursor for `nextWebSeedPiece`, advanced past every piece
+    /// the web seed claims.
+    web_seed_cursor: u32 = 0,
+    /// The piece currently handed to the worker. Kept as its own field rather
+    /// than a placeholder entry in `active_pieces` because a placeholder would
+    /// mean allocating a full piece-sized `PieceProgress` buffer we never write
+    /// a block into; the peer picker skips this index explicitly instead. Always
+    /// cleared when the result comes back, so a failing mirror can never
+    /// permanently sideline a piece.
+    web_seed_piece: ?u32 = null,
+    /// Round-robin position in `meta.url_list`, advanced per attempt so one dead
+    /// entry in a multi-mirror list doesn't shadow the working ones.
+    web_seed_url_idx: usize = 0,
+    /// Consecutive failed web-seed fetches; drives `webSeedBackoffSecs`. Reset
+    /// by any verified piece.
+    web_seed_fail_streak: u32 = 0,
+    /// Wall-clock second before which no new web-seed fetch is dispatched.
+    web_seed_retry_at: i64 = 0,
+
     // Progress tracking
     start_time: i64,
     last_progress_time: i64,
@@ -378,6 +630,11 @@ pub const Session = struct {
     }
 
     pub fn deinit(self: *Session) void {
+        // Join the web-seed thread before anything it could be racing goes
+        // away. It only ever touches its own handoff struct, but it borrows
+        // `allocator`, so it must be gone before the caller tears that down.
+        self.stopWebSeed();
+
         var it = self.active_pieces.iterator();
         while (it.next()) |entry| {
             entry.value_ptr.*.deinit(self.allocator);
@@ -615,9 +872,11 @@ pub const Session = struct {
 
             self.processPollResults(fds[0..nfds]) catch {};
 
-            // Try web seed downloads if available
+            // Collect any finished web-seed fetch and dispatch the next one.
+            // Both halves are non-blocking: the actual HTTP transfer happens on
+            // the worker thread, so the loop keeps servicing peer sockets.
             if (self.mode == .download and !self.metadata_only) {
-                self.tryWebSeedDownload() catch {};
+                self.pumpWebSeed();
             }
 
             // Check endgame activation
@@ -757,6 +1016,7 @@ pub const Session = struct {
             },
             .interested => {
                 p.peer_interested = true;
+                self.unchokeIfSlotFree(p);
             },
             .not_interested => {
                 p.peer_interested = false;
@@ -1408,6 +1668,14 @@ pub const Session = struct {
                 if (pp.nextUnrequestedBlock() == null) continue;
             }
 
+            // The web seed has one piece in flight at a time and holds it
+            // outside `active_pieces`; don't have peers duplicate that fetch.
+            // The claim is always released when the fetch resolves, so this can
+            // never strand a piece.
+            if (self.web_seed_piece) |claimed| {
+                if (claimed == idx) continue;
+            }
+
             const avail = if (idx < self.piece_availability.len) self.piece_availability[idx] else 0;
             if (avail < best_avail) {
                 best_avail = avail;
@@ -1428,7 +1696,10 @@ pub const Session = struct {
             const idx: u32 = @intCast(i);
             if (!self.our_bitfield.hasPiece(idx)) {
                 missing += 1;
-                if (self.active_pieces.contains(idx)) active += 1;
+                // A web-seed-claimed piece is "being fetched" just like an
+                // active one; counting it keeps the endgame trigger honest.
+                const claimed = if (self.web_seed_piece) |c| c == idx else false;
+                if (claimed or self.active_pieces.contains(idx)) active += 1;
             }
         }
         if (missing > 0 and missing == active and missing <= 5) {
@@ -1454,6 +1725,33 @@ pub const Session = struct {
             self.last_optimistic_time = now;
             self.optimisticUnchoke();
         }
+    }
+
+    /// Unchoke a newly-interested peer right away when a reciprocation slot is
+    /// still free, instead of making it wait for the next `regularUnchoke`.
+    ///
+    /// The periodic choker runs every `unchoke_interval_secs`, so a peer that
+    /// declared interest just after a tick sat choked for up to 10s. On a
+    /// loopback transfer that showed up as 8.0s of dead air between the
+    /// handshake and the first block — paid once per transfer we start, and
+    /// inflicted on every leecher we serve while seeding. libtorrent (our
+    /// reference implementation) likewise triggers its choker on the interested
+    /// message rather than waiting for the timer.
+    ///
+    /// Fairness is unaffected: this only fills a slot nobody holds, and the
+    /// next periodic run still re-ranks everyone by rate.
+    fn unchokeIfSlotFree(self: *Session, p: *peer_mod.PeerConnection) void {
+        if (!p.am_choking) return;
+
+        var unchoked: usize = 0;
+        for (self.peers.items) |q| {
+            if (q.state != .active) continue;
+            if (!q.am_choking) unchoked += 1;
+        }
+        if (unchoked >= unchoke_slots) return;
+
+        p.am_choking = false;
+        p.enqueueMessage(.unchoke) catch {};
     }
 
     fn regularUnchoke(self: *Session) void {
@@ -2028,7 +2326,31 @@ pub const Session = struct {
 
     // --- BEP 19: Web seed downloads ---
 
-    fn tryWebSeedDownload(self: *Session) !void {
+    /// One non-blocking web-seed tick: collect a finished fetch, then dispatch
+    /// the next one. Called once per event-loop iteration.
+    fn pumpWebSeed(self: *Session) void {
+        self.collectWebSeedResult();
+        self.dispatchWebSeedFetch();
+    }
+
+    /// Predicate context for `nextWebSeedPiece`: a piece is wanted when we don't
+    /// have it, no peer is assembling it, and the web seed hasn't claimed it.
+    const WebSeedWant = struct {
+        s: *Session,
+        fn wants(ctx: WebSeedWant, idx: u32) bool {
+            if (ctx.s.our_bitfield.hasPiece(idx)) return false;
+            if (ctx.s.active_pieces.contains(idx)) return false;
+            if (ctx.s.web_seed_piece) |claimed| {
+                if (claimed == idx) return false;
+            }
+            return true;
+        }
+    };
+
+    /// Hand one piece to the fetch thread, if the web seed is usable and idle.
+    /// Everything here is O(1) plus the (cursor-bounded) piece scan; the HTTP
+    /// work happens on the worker.
+    fn dispatchWebSeedFetch(self: *Session) void {
         // Web seeds use std.http.Client directly (clearnet); disable on any
         // anonymized transport (a tunneled, Range-aware path is a follow-up).
         if (self.anonymized()) return;
@@ -2036,108 +2358,138 @@ pub const Session = struct {
         const urls = self.meta.url_list orelse return;
         if (urls.len == 0) return;
         if (self.num_pieces == 0) return;
+        // A fetch is already in flight, or its result hasn't been collected yet.
+        if (self.web_seed_piece != null) return;
 
-        // Find a piece we need
-        for (0..self.num_pieces) |i| {
-            const idx: u32 = @intCast(i);
-            if (self.our_bitfield.hasPiece(idx)) continue;
-            if (self.active_pieces.contains(idx)) continue;
+        const now = std.time.timestamp();
+        if (now < self.web_seed_retry_at) return;
 
-            // Try each web seed URL
-            for (urls) |base_url| {
-                if (self.downloadWebSeedPiece(base_url, idx) catch false) {
-                    return;
-                } else {
-                    continue; // Try next URL
-                }
-            }
-            return; // Don't try more pieces if all URLs failed
-        }
-    }
+        const idx = nextWebSeedPiece(self.num_pieces, self.web_seed_cursor, WebSeedWant{ .s = self }) orelse return;
+        const plen = piece_mod.pieceLength(idx, self.piece_len, self.total_length);
+        if (plen == 0) return;
 
-    fn downloadWebSeedPiece(self: *Session, base_url: []const u8, piece_idx: u32) !bool {
-        const plen = piece_mod.pieceLength(piece_idx, self.piece_len, self.total_length);
-        if (plen == 0) return false;
+        // Rotate mirrors per attempt: with one fetch in flight we can't race the
+        // URLs against each other like the old inline loop did, so instead each
+        // attempt uses the next entry. A dead mirror then costs one piece
+        // attempt, not the whole web seed.
+        const base_url = urls[self.web_seed_url_idx % urls.len];
+        self.web_seed_url_idx +%= 1;
 
-        const start = @as(u64, piece_idx) * self.piece_len;
-        const end = start + plen - 1;
+        const url = self.buildWebSeedUrl(base_url) catch return;
 
-        // Build URL -- for single-file torrents, url-list points directly to the file
-        // Append the filename if the URL ends with /
-        var url_buf: [4096]u8 = undefined;
-        var url_len: usize = 0;
-        if (base_url.len > url_buf.len) return false;
-        @memcpy(url_buf[0..base_url.len], base_url);
-        url_len = base_url.len;
-
-        if (base_url.len > 0 and base_url[base_url.len - 1] == '/') {
-            // Append filename
-            if (url_len + self.meta.name.len > url_buf.len) return false;
-            @memcpy(url_buf[url_len .. url_len + self.meta.name.len], self.meta.name);
-            url_len += self.meta.name.len;
-        }
-
-        const url = url_buf[0..url_len];
-
-        // Build Range header value
-        var range_buf: [64]u8 = undefined;
-        const range_str = std.fmt.bufPrint(&range_buf, "bytes={d}-{d}", .{ start, end }) catch return false;
-
-        // HTTP request with Range header
-        var client: std.http.Client = .{ .allocator = self.allocator };
-        defer client.deinit();
-
-        var response_body: std.ArrayList(u8) = .empty;
-        defer response_body.deinit(self.allocator);
-
-        var adapt_buf: [4096]u8 = undefined;
-        const deprecated_writer = response_body.writer(self.allocator);
-        var adapter = deprecated_writer.adaptToNewApi(&adapt_buf);
-
-        const extra_headers = [_]std.http.Header{
-            .{ .name = "Range", .value = range_str },
+        const w = self.webSeedWorker() orelse {
+            self.allocator.free(url);
+            return;
         };
 
-        const result = client.fetch(.{
-            .location = .{ .url = url },
-            .response_writer = &adapter.new_interface,
-            .extra_headers = &extra_headers,
-        }) catch return false;
-
-        // 206 Partial Content or 200 OK
-        if (result.status != .partial_content and result.status != .ok) return false;
-
-        // Flush remaining buffered data from the adapter
-        const buffered = adapter.new_interface.buffered();
-        if (buffered.len > 0) {
-            response_body.appendSlice(self.allocator, buffered) catch return false;
+        const submitted = w.submit(.{
+            .piece = idx,
+            .url = url,
+            .start = @as(u64, idx) * self.piece_len,
+            .len = plen,
+        });
+        if (!submitted) {
+            // Worker busy after all (only reachable if `web_seed_piece` and the
+            // worker state ever disagree); drop the URL rather than leak it.
+            self.allocator.free(url);
+            return;
         }
 
-        const data = response_body.items;
-        if (data.len != plen) return false;
+        self.web_seed_piece = idx;
+        // Start the next scan after this piece so the web seed walks the file
+        // instead of re-picking around the same neighbourhood.
+        self.web_seed_cursor = (idx +% 1) % self.num_pieces;
+    }
 
-        // Verify SHA-1
-        const hash = piece_mod.pieceHash(self.meta.pieces, piece_idx) orelse return false;
-        if (!piece_mod.verifyPiece(data, hash)) return false;
+    /// Build the absolute URL for a web-seed request. BEP 19: a url-list entry
+    /// ending in `/` is a directory the torrent name hangs off; anything else
+    /// points straight at the payload. Caller owns the result.
+    fn buildWebSeedUrl(self: *Session, base_url: []const u8) ![]u8 {
+        if (base_url.len == 0) return error.EmptyWebSeedUrl;
+        if (base_url[base_url.len - 1] != '/') return self.allocator.dupe(u8, base_url);
+        return std.fmt.allocPrint(self.allocator, "{s}{s}", .{ base_url, self.meta.name });
+    }
 
-        // Write to disk
-        self.store.writePiece(piece_idx, data) catch return false;
-        self.our_bitfield.setPiece(piece_idx);
-        self.downloaded += plen;
-        self.block_bytes_in += plen;
+    /// Lazily create and start the fetch thread. Returns null if the thread
+    /// can't be spawned, in which case the web seed simply stays unused (peers
+    /// still carry the download).
+    fn webSeedWorker(self: *Session) ?*WebSeedWorker {
+        if (self.web_seed) |w| return w;
+
+        const w = self.allocator.create(WebSeedWorker) catch return null;
+        w.* = .{ .allocator = self.allocator };
+        w.start() catch {
+            self.allocator.destroy(w);
+            log.warn("web seed: could not spawn fetch thread; web seeds disabled", .{});
+            // Park it for a while instead of retrying the spawn every tick.
+            self.web_seed_retry_at = std.time.timestamp() + web_seed_backoff_cap_secs;
+            return null;
+        };
+        self.web_seed = w;
+        return w;
+    }
+
+    /// Non-blocking. If the worker published a piece, run it through the same
+    /// verify -> write -> bitfield -> `have` broadcast path a peer-delivered
+    /// piece takes. All session state is mutated here, on the session thread.
+    fn collectWebSeedResult(self: *Session) void {
+        const w = self.web_seed orelse return;
+        const r = w.takeResult() orelse return;
+        defer self.allocator.free(r.url);
+
+        // The claim is released no matter the outcome, so a failing mirror can
+        // never keep a piece out of the peer picker.
+        self.web_seed_piece = null;
+
+        const data = r.data orelse return self.onWebSeedFailure(r.piece);
+        defer self.allocator.free(data);
+
+        // A peer may well have finished this piece while the fetch was in
+        // flight — the bytes are then redundant, not wrong.
+        if (self.our_bitfield.hasPiece(r.piece)) return;
+
+        const hash = piece_mod.pieceHash(self.meta.pieces, r.piece) orelse return self.onWebSeedFailure(r.piece);
+        if (!piece_mod.verifyPiece(data, hash)) {
+            log.warn("web seed: piece {d} failed hash check", .{r.piece});
+            return self.onWebSeedFailure(r.piece);
+        }
+
+        self.store.writePiece(r.piece, data) catch return self.onWebSeedFailure(r.piece);
+        self.our_bitfield.setPiece(r.piece);
+        self.downloaded += data.len;
+        self.block_bytes_in += data.len;
         self.have_pieces.store(self.our_bitfield.count(), .monotonic);
+        self.web_seed_fail_streak = 0;
+        self.web_seed_retry_at = 0;
 
         self.printProgress() catch {};
 
-        // Broadcast have to all peers
         for (self.peers.items) |p| {
             if (p.state == .active) {
-                p.enqueueMessage(.{ .have = piece_idx }) catch {};
+                p.enqueueMessage(.{ .have = r.piece }) catch {};
+                cancelPieceRequests(p, r.piece);
             }
         }
 
-        log.info("web seed: piece {d}/{d} from {s}", .{ piece_idx + 1, self.num_pieces, url });
-        return true;
+        log.info("web seed: piece {d}/{d}", .{ r.piece + 1, self.num_pieces });
+    }
+
+    fn onWebSeedFailure(self: *Session, piece_idx: u32) void {
+        self.web_seed_fail_streak +|= 1;
+        self.web_seed_retry_at = std.time.timestamp() + webSeedBackoffSecs(self.web_seed_fail_streak);
+        // Re-pick this piece first once the backoff expires: the failure may
+        // have been the mirror, not the range.
+        self.web_seed_cursor = piece_idx;
+    }
+
+    /// Stop and join the fetch thread. Idempotent, and safe to call on a session
+    /// that never used a web seed.
+    fn stopWebSeed(self: *Session) void {
+        const w = self.web_seed orelse return;
+        w.stopAndJoin();
+        self.allocator.destroy(w);
+        self.web_seed = null;
+        self.web_seed_piece = null;
     }
 
     fn printProgress(self: *Session) !void {
@@ -2211,6 +2563,124 @@ test "rediscoveryBackoffSecs: 45s doubling, capped at 600s" {
     try std.testing.expectEqual(@as(i64, 360), rediscoveryBackoffSecs(3));
     try std.testing.expectEqual(@as(i64, 600), rediscoveryBackoffSecs(4));
     try std.testing.expectEqual(@as(i64, 600), rediscoveryBackoffSecs(1000));
+}
+
+test "webSeedBackoffSecs: 5s doubling, capped at 120s" {
+    try std.testing.expectEqual(@as(i64, 0), webSeedBackoffSecs(0));
+    try std.testing.expectEqual(@as(i64, 5), webSeedBackoffSecs(1));
+    try std.testing.expectEqual(@as(i64, 10), webSeedBackoffSecs(2));
+    try std.testing.expectEqual(@as(i64, 40), webSeedBackoffSecs(4));
+    try std.testing.expectEqual(@as(i64, 120), webSeedBackoffSecs(6));
+    try std.testing.expectEqual(@as(i64, 120), webSeedBackoffSecs(1000));
+}
+
+test "nextWebSeedPiece: scans forward from the cursor and wraps once" {
+    const Want = struct {
+        needed: []const u32,
+        fn wants(ctx: @This(), idx: u32) bool {
+            for (ctx.needed) |n| {
+                if (n == idx) return true;
+            }
+            return false;
+        }
+    };
+
+    // The whole point of the cursor: don't hand back piece 0 every tick.
+    const all = [_]u32{ 0, 1, 2, 3, 4, 5, 6, 7 };
+    try std.testing.expectEqual(@as(?u32, 0), nextWebSeedPiece(8, 0, Want{ .needed = &all }));
+    try std.testing.expectEqual(@as(?u32, 5), nextWebSeedPiece(8, 5, Want{ .needed = &all }));
+
+    // Wraps past the end exactly once to find a piece behind the cursor.
+    const only_low = [_]u32{ 1, 2 };
+    try std.testing.expectEqual(@as(?u32, 1), nextWebSeedPiece(8, 6, Want{ .needed = &only_low }));
+
+    // A cursor past the end is normalized, not an out-of-bounds scan.
+    try std.testing.expectEqual(@as(?u32, 1), nextWebSeedPiece(8, 99, Want{ .needed = &only_low }));
+
+    // Nothing wanted, and the degenerate zero-piece case.
+    const none = [_]u32{};
+    try std.testing.expectEqual(@as(?u32, null), nextWebSeedPiece(8, 3, Want{ .needed = &none }));
+    try std.testing.expectEqual(@as(?u32, null), nextWebSeedPiece(0, 0, Want{ .needed = &all }));
+}
+
+test "WebSeedWorker handoff: idle -> requested -> fetching -> done -> idle" {
+    const a = std.testing.allocator;
+    // No thread started: the test drives both sides of the handoff itself, so
+    // the transitions are checked without depending on scheduling.
+    var w: WebSeedWorker = .{ .allocator = a };
+
+    // Nothing to collect while idle.
+    try std.testing.expect(w.takeResult() == null);
+
+    const url = try a.dupe(u8, "http://example.invalid/f.bin");
+    try std.testing.expect(w.submit(.{ .piece = 7, .url = url, .start = 0, .len = 4 }));
+
+    // A second submit must be refused while a fetch is outstanding — that's
+    // what keeps exactly one fetch in flight and the URL ownership unambiguous.
+    const url2 = try a.dupe(u8, "http://example.invalid/other.bin");
+    defer a.free(url2);
+    try std.testing.expect(!w.submit(.{ .piece = 8, .url = url2, .start = 0, .len = 4 }));
+
+    const job = w.awaitJob().?;
+    try std.testing.expectEqual(@as(u32, 7), job.piece);
+    try std.testing.expectEqual(@as(u64, 4), job.len);
+
+    // Still nothing to collect mid-fetch.
+    try std.testing.expect(w.takeResult() == null);
+
+    const data = try a.dupe(u8, "abcd");
+    w.publish(data);
+
+    const r = w.takeResult().?;
+    try std.testing.expectEqual(@as(u32, 7), r.piece);
+    try std.testing.expectEqualStrings("abcd", r.data.?);
+    a.free(r.data.?);
+    a.free(r.url);
+
+    // Back to idle: the next piece can be dispatched, and the collected result
+    // is gone (a second take must not hand out the same buffer twice).
+    try std.testing.expect(w.takeResult() == null);
+    try std.testing.expectEqual(WebSeedWorker.State.idle, w.state);
+}
+
+test "WebSeedWorker failure publishes null and stays collectable" {
+    const a = std.testing.allocator;
+    var w: WebSeedWorker = .{ .allocator = a };
+
+    const url = try a.dupe(u8, "http://example.invalid/f.bin");
+    try std.testing.expect(w.submit(.{ .piece = 3, .url = url, .start = 0, .len = 16 }));
+    _ = w.awaitJob().?;
+    w.publish(null);
+
+    const r = w.takeResult().?;
+    try std.testing.expectEqual(@as(u32, 3), r.piece);
+    try std.testing.expect(r.data == null);
+    a.free(r.url);
+}
+
+test "WebSeedWorker stops and joins its thread without hanging" {
+    const a = std.testing.allocator;
+    var w: WebSeedWorker = .{ .allocator = a };
+    try w.start();
+    // Never submits a job: the thread must be parked on the condvar and exit on
+    // the stop signal alone.
+    w.stopAndJoin();
+    try std.testing.expect(w.thread == null);
+}
+
+test "WebSeedWorker stopAndJoin frees an uncollected result" {
+    // Shutdown can land between the worker publishing and the session
+    // collecting; the leftover buffer (and the job URL) must not leak.
+    const a = std.testing.allocator;
+    var w: WebSeedWorker = .{ .allocator = a };
+
+    const url = try a.dupe(u8, "http://example.invalid/f.bin");
+    try std.testing.expect(w.submit(.{ .piece = 1, .url = url, .start = 0, .len = 2 }));
+    _ = w.awaitJob().?;
+    w.publish(try a.dupe(u8, "hi"));
+
+    w.stopAndJoin();
+    try std.testing.expect(w.res_data == null);
 }
 
 test "sampleRate counts block bytes as progress before a piece verifies" {

--- a/src/session.zig
+++ b/src/session.zig
@@ -29,12 +29,40 @@ const optimistic_interval_secs: i64 = 30;
 /// no_peers forever. Re-querying relays is slow (~seconds per relay), so only
 /// retry when stuck at zero peers and not more often than this.
 const peer_rediscovery_interval_secs: i64 = 45;
+/// Cap for the zero-peer Nostr re-discovery backoff (base is
+/// `peer_rediscovery_interval_secs`, doubling per consecutive empty query).
+/// Without it a seedless torrent re-queried the relays every 45s forever and
+/// got the client rate-limited (relay.damus.io). Any found peer resets it.
+const peer_rediscovery_backoff_cap_secs: i64 = 600;
+/// Backoff for failed tracker/DHT announce attempts: base doubling per
+/// consecutive fully-failed announce, capped. A total failure never stamps
+/// `last_announce_time`, so without an attempt-stamped backoff the maintenance
+/// gate re-ran the whole blocking multi-tracker announce every tick.
+const announce_backoff_base_secs: i64 = 15;
+const announce_backoff_cap_secs: i64 = 300;
 /// How long an outstanding block request may go unanswered before it is
 /// cancelled and released back to the scheduler. Long enough that a slow
 /// anonymized route (I2P round trips run seconds) is never penalized; short
 /// enough that one silent peer can't hold blocks hostage while others could
 /// fetch them.
 const request_timeout_secs: i64 = 60;
+
+/// Seconds to wait before retrying tracker/DHT discovery after `fail_streak`
+/// consecutive fully-failed announces: 15s doubling per failure, capped at
+/// 300s. Returns 0 while nothing has failed (the regular tracker-provided
+/// interval applies then).
+fn announceBackoffSecs(fail_streak: u32) i64 {
+    if (fail_streak == 0) return 0;
+    const shift: u6 = @intCast(@min(fail_streak - 1, 5));
+    return @min(announce_backoff_base_secs << shift, announce_backoff_cap_secs);
+}
+
+/// Seconds to wait before the next zero-peer Nostr re-discovery: the base
+/// 45s interval doubling per consecutive empty query, capped at 600s.
+fn rediscoveryBackoffSecs(fail_streak: u32) i64 {
+    const shift: u6 = @intCast(@min(fail_streak, 4));
+    return @min(peer_rediscovery_interval_secs << shift, peer_rediscovery_backoff_cap_secs);
+}
 
 /// Periodic peer re-discovery hook. The session run loop calls `run(ctx)` on
 /// its own thread when the transfer has zero peers, so the callback can safely
@@ -87,6 +115,14 @@ pub const Session = struct {
     // Tracker state
     tracker_interval: u64,
     last_announce_time: i64,
+    /// Stamped at the START of every tracker/DHT discovery attempt, regardless
+    /// of outcome — unlike `last_announce_time`, which only a successful
+    /// announce stamps. Gates retries so a failing announce backs off instead
+    /// of re-running every maintenance tick. Defaulted so init need not set it.
+    last_announce_attempt: i64 = 0,
+    /// Consecutive fully-failed announces; drives `announceBackoffSecs`.
+    /// Reset by any successful tracker response. Defaulted like the above.
+    announce_fail_streak: u32 = 0,
     uploaded: u64,
     downloaded: u64,
 
@@ -207,6 +243,9 @@ pub const Session = struct {
     peer_discovery: ?PeerDiscovery = null,
     /// Timestamp of the last peer re-discovery, to rate-limit retries.
     last_peer_discovery_s: i64 = 0,
+    /// Consecutive zero-peer Nostr re-discovery attempts; drives
+    /// `rediscoveryBackoffSecs`. Reset once any peer shows up.
+    rediscovery_fail_streak: u32 = 0,
     /// Fired once when a download completes. The manager uses this to broadcast
     /// the torrent on Nostr (NIP-35) if not already present on relays.
     on_complete: ?OnComplete = null,
@@ -498,6 +537,17 @@ pub const Session = struct {
                     .{},
                 );
             }
+        }
+
+        // Native I2P (no proxy): `tryAnnounceUrl` skips every clearnet tracker
+        // and DHT is off (`anonymized`), so Nostr `.b32.i2p` peer-announces are
+        // the only discovery source. Say so once, or an eternal "no peers" has
+        // no explanation.
+        if (self.i2p != null and self.proxy == null) {
+            log.warn(
+                "i2p route: peer discovery is nostr-only (clearnet trackers and DHT are disabled); torrents without i2p seeders will not find peers",
+                .{},
+            );
         }
 
         // Multi-tracker announce (BEP 12) / DHT peer discovery
@@ -1421,10 +1471,13 @@ pub const Session = struct {
             }
         }
 
-        // Sort by bytes_downloaded descending (they upload to us the most)
+        // Sort by current download rate descending (who uploads to us fastest
+        // NOW — the per-peer EWMA, not lifetime bytes, which favored old peers
+        // that have gone quiet). Tie-break by lifetime bytes_downloaded.
         const slice = interested_peers[0..count];
         std.mem.sort(*peer_mod.PeerConnection, slice, {}, struct {
             fn cmp(_: void, a: *peer_mod.PeerConnection, b: *peer_mod.PeerConnection) bool {
+                if (a.down_rate != b.down_rate) return a.down_rate > b.down_rate;
                 return a.bytes_downloaded > b.bytes_downloaded;
             }
         }.cmp);
@@ -1582,14 +1635,24 @@ pub const Session = struct {
         self.runChokingAlgorithm();
 
         if (!self.tor_hidden) {
-            // Re-announce to trackers at the tracker-provided interval
+            // Re-announce to trackers at the tracker-provided interval. After
+            // a fully-failed announce (which never stamps `last_announce_time`)
+            // retry on the exponential backoff clock instead — gating on the
+            // success stamp alone re-ran the whole blocking announce every tick.
+            // The attempt clock only applies while failing: the zero-peer DHT
+            // retry below stamps `last_announce_attempt` every ~30s, which
+            // would otherwise starve the regular interval re-announce.
             const interval_secs = std.math.cast(i64, self.tracker_interval) orelse 1800;
-            if (now - self.last_announce_time > interval_secs) {
+            const retry_ok = self.announce_fail_streak == 0 or
+                now - self.last_announce_attempt > announceBackoffSecs(self.announce_fail_streak);
+            if (now - self.last_announce_time > interval_secs and retry_ok) {
                 self.doMultiTrackerAnnounce(.none) catch {};
             }
 
-            // DHT: retry more aggressively when we have zero peers
-            if (self.peers.items.len == 0 and now - self.last_announce_time > 30) {
+            // DHT: retry more aggressively when we have zero peers — but on
+            // the same attempt-stamped backoff, never every tick.
+            if (self.peers.items.len == 0 and now - self.last_announce_attempt > @max(30, announceBackoffSecs(self.announce_fail_streak))) {
+                self.last_announce_attempt = now;
                 self.tryDhtPeerDiscovery() catch {};
             }
         }
@@ -1600,11 +1663,26 @@ pub const Session = struct {
         // safely. Gated on download mode + zero peers so it never duplicates a
         // live connection, competes with an active download, or fires once the
         // transfer has completed and is only seeding (dialing out is pointless
-        // then); rate-limited because relay queries are slow.
+        // then); rate-limited because relay queries are slow, and backed off
+        // exponentially while queries keep coming back empty so a seedless
+        // torrent can't hammer (and get rate-limited by) the relays forever.
         if (self.peer_discovery) |pd| {
-            if (self.mode == .download and self.peers.items.len == 0 and now - self.last_peer_discovery_s > peer_rediscovery_interval_secs) {
-                self.last_peer_discovery_s = now;
-                pd.run(pd.ctx);
+            if (self.mode == .download and self.peers.items.len == 0) {
+                if (now - self.last_peer_discovery_s > rediscoveryBackoffSecs(self.rediscovery_fail_streak)) {
+                    self.last_peer_discovery_s = now;
+                    pd.run(pd.ctx);
+                    // The callback adds peers synchronously (same thread): an
+                    // empty result grows the backoff, any peer resets it.
+                    if (self.peers.items.len == 0) {
+                        self.rediscovery_fail_streak +|= 1;
+                    } else {
+                        self.rediscovery_fail_streak = 0;
+                    }
+                }
+            } else if (self.rediscovery_fail_streak != 0) {
+                // Peers connected (or we're seeding): the next dry spell
+                // starts from the base interval again.
+                self.rediscovery_fail_streak = 0;
             }
         }
     }
@@ -1612,6 +1690,12 @@ pub const Session = struct {
     // --- Multi-tracker announce (BEP 12 + BEP 15) ---
 
     fn doMultiTrackerAnnounce(self: *Session, event: tracker_mod.Event) !void {
+        // Stamp the attempt up front, whatever the outcome: a total failure
+        // never reaches `handleAnnounceResponse` (which stamps
+        // `last_announce_time`), and the maintenance gates key their backoff
+        // off this stamp.
+        self.last_announce_attempt = std.time.timestamp();
+
         const req = tracker_mod.AnnounceRequest{
             .info_hash = self.info_hash,
             .peer_id = self.peer_id,
@@ -1657,6 +1741,7 @@ pub const Session = struct {
             if (self.peers.items.len > 0) return;
         }
 
+        self.announce_fail_streak +|= 1;
         return error.TrackerFailed;
     }
 
@@ -1733,6 +1818,7 @@ pub const Session = struct {
 
         self.tracker_interval = resp.interval;
         self.last_announce_time = std.time.timestamp();
+        self.announce_fail_streak = 0;
 
         const stderr = std.fs.File.stderr().deprecatedWriter();
         stderr.print("tracker: {d} peers", .{resp.peers.len}) catch {};
@@ -2105,6 +2191,27 @@ pub const Session = struct {
         }
     }
 };
+
+test "announceBackoffSecs: exponential from 15s, capped at 300s" {
+    try std.testing.expectEqual(@as(i64, 0), announceBackoffSecs(0));
+    try std.testing.expectEqual(@as(i64, 15), announceBackoffSecs(1));
+    try std.testing.expectEqual(@as(i64, 30), announceBackoffSecs(2));
+    try std.testing.expectEqual(@as(i64, 60), announceBackoffSecs(3));
+    try std.testing.expectEqual(@as(i64, 120), announceBackoffSecs(4));
+    try std.testing.expectEqual(@as(i64, 240), announceBackoffSecs(5));
+    try std.testing.expectEqual(@as(i64, 300), announceBackoffSecs(6));
+    // Huge streaks must not overflow the shift, just stay at the cap.
+    try std.testing.expectEqual(@as(i64, 300), announceBackoffSecs(1000));
+}
+
+test "rediscoveryBackoffSecs: 45s doubling, capped at 600s" {
+    try std.testing.expectEqual(@as(i64, 45), rediscoveryBackoffSecs(0));
+    try std.testing.expectEqual(@as(i64, 90), rediscoveryBackoffSecs(1));
+    try std.testing.expectEqual(@as(i64, 180), rediscoveryBackoffSecs(2));
+    try std.testing.expectEqual(@as(i64, 360), rediscoveryBackoffSecs(3));
+    try std.testing.expectEqual(@as(i64, 600), rediscoveryBackoffSecs(4));
+    try std.testing.expectEqual(@as(i64, 600), rediscoveryBackoffSecs(1000));
+}
 
 test "sampleRate counts block bytes as progress before a piece verifies" {
     // Regression: on a slow link (single I2P peer) a piece can take far longer

--- a/src/session.zig
+++ b/src/session.zig
@@ -10,6 +10,7 @@ const udp_tracker = @import("udp_tracker.zig");
 const wire = @import("wire.zig");
 const piece_mod = @import("piece.zig");
 const storage_mod = @import("storage.zig");
+const resume_mod = @import("resume_data.zig");
 const peer_mod = @import("peer.zig");
 const extension = @import("extension.zig");
 const bencode = @import("bencode.zig");
@@ -119,6 +120,22 @@ pub const OnComplete = struct {
 /// Global flag for graceful shutdown on SIGINT. Atomic because it's
 /// written from a signal handler and read from event loop / test threads.
 pub var shutdown_requested = std.atomic.Value(bool).init(false);
+
+/// Ignore any persisted resume record and re-hash every piece from disk
+/// (`--verify`).
+///
+/// The resume record is a cache of a hash check keyed on each file's size and
+/// mtime. That is what libtorrent does too, and it is sound for the ordinary
+/// case, but nothing keyed on metadata can see a same-size in-place change that
+/// leaves mtime alone — silent disk corruption being the realistic one, since
+/// bad sectors do not touch mtime. The record's spot check re-hashes a handful
+/// of pieces, which narrows that window without closing it.
+///
+/// So every torrent client ships a "force recheck", and this is ours: the way
+/// out when a file is suspect. Global rather than a parameter because every
+/// frontend (CLI, daemon, manager, follow) builds sessions through different
+/// paths and this is a process-wide, run-once user intent.
+pub var force_verify: bool = false;
 
 fn sigintHandler(_: i32) callconv(.c) void {
     shutdown_requested.store(true, .release);
@@ -382,6 +399,10 @@ pub const Session = struct {
     peer_id: [20]u8,
     our_bitfield: piece_mod.Bitfield,
     store: storage_mod.Storage,
+    /// Persisted verified-piece bitfield, so a restart doesn't re-hash the
+    /// whole payload. Never trusted blindly — see resume_data.zig for the
+    /// staleness rules that decide between "load" and "verify everything".
+    resume_data: resume_mod.Resume,
 
     peers: std.ArrayList(*peer_mod.PeerConnection),
     active_pieces: std.AutoHashMap(u32, *piece_mod.PieceProgress),
@@ -620,23 +641,52 @@ pub const Session = struct {
             return error.StorageInitFailed;
         errdefer store.deinit();
 
-        // Verify existing pieces (resume + seed)
+        // Resume + seed: establish which pieces we already have.
+        //
+        // Hashing every existing piece is O(bytes on disk) — seconds for a
+        // 755 MB torrent, minutes for a multi-GB one, on whichever thread added
+        // the transfer. So prefer the bitfield the last run persisted, and only
+        // fall back to the full scan when that record can't be trusted (see
+        // resume_data.zig). The scan's result is saved on the way out, which is
+        // what makes the NEXT start O(1).
+        var resume_state: resume_mod.Resume = .{ .info_hash = info_hash };
+        const resume_key: resume_mod.Key = .{
+            .info_hash = info_hash,
+            .piece_length = meta.piece_length,
+            .total_length = total_length,
+            .num_pieces = num_pieces,
+            .num_files = std.math.cast(u32, meta.files.len) orelse 0,
+        };
         {
             const stderr = std.fs.File.stderr().deprecatedWriter();
-            stderr.print("verifying existing pieces...\n", .{}) catch {};
-            for (0..num_pieces) |i| {
-                const idx: u32 = @intCast(i);
-                const plen = piece_mod.pieceLength(idx, meta.piece_length, total_length);
-                const data = store.readPiece(allocator, idx, plen) catch continue;
-                defer allocator.free(data);
-                const hash = piece_mod.pieceHash(meta.pieces, idx) orelse continue;
-                if (piece_mod.verifyPiece(data, hash)) {
-                    our_bitfield.setPiece(idx);
+            const saved_state = if (force_verify)
+                null
+            else
+                resume_state.load(allocator, &store, resume_key, meta.pieces);
+            if (saved_state) |saved| {
+                our_bitfield.deinit(allocator);
+                our_bitfield = saved;
+                stderr.print("resume: {d}/{d} pieces from saved state\n", .{
+                    our_bitfield.count(),
+                    num_pieces,
+                }) catch {};
+            } else {
+                stderr.print("verifying existing pieces...\n", .{}) catch {};
+                for (0..num_pieces) |i| {
+                    const idx: u32 = @intCast(i);
+                    const plen = piece_mod.pieceLength(idx, meta.piece_length, total_length);
+                    const data = store.readPiece(allocator, idx, plen) catch continue;
+                    defer allocator.free(data);
+                    const hash = piece_mod.pieceHash(meta.pieces, idx) orelse continue;
+                    if (piece_mod.verifyPiece(data, hash)) {
+                        our_bitfield.setPiece(idx);
+                    }
                 }
-            }
-            const verified = our_bitfield.count();
-            if (verified > 0) {
-                stderr.print("resume: {d}/{d} pieces already verified\n", .{ verified, num_pieces }) catch {};
+                const verified = our_bitfield.count();
+                if (verified > 0) {
+                    stderr.print("resume: {d}/{d} pieces already verified\n", .{ verified, num_pieces }) catch {};
+                }
+                resume_state.save(allocator, &store, resume_key, our_bitfield);
             }
         }
 
@@ -664,6 +714,7 @@ pub const Session = struct {
             .peer_id = peer_id,
             .our_bitfield = our_bitfield,
             .store = store,
+            .resume_data = resume_state,
             .peers = .empty,
             .active_pieces = std.AutoHashMap(u32, *piece_mod.PieceProgress).init(allocator),
             .piece_availability = piece_availability,
@@ -709,6 +760,11 @@ pub const Session = struct {
         // `allocator`, so it must be gone before the caller tears that down.
         self.stopWebSeed();
 
+        // Clean shutdown: persist whatever this run verified, while the files
+        // are still open (the record stamps them). A crash skips this and
+        // costs a re-verify — never a wrong bitfield.
+        self.saveResume();
+
         var it = self.active_pieces.iterator();
         while (it.next()) |entry| {
             entry.value_ptr.*.deinit(self.allocator);
@@ -734,6 +790,41 @@ pub const Session = struct {
         // The magnet path replaces `meta` with a session-owned copy; free it.
         // The original caller-owned `meta` is freed by the caller.
         if (self.meta_owned) self.meta.deinit(self.allocator);
+    }
+
+    /// The geometry a resume record must match to be usable for this transfer.
+    /// Recomputed on demand rather than stored, because a magnet's geometry
+    /// only settles when its metadata lands (`onMetadataComplete` replaces the
+    /// piece length, piece count, and file list wholesale).
+    fn resumeKey(self: *const Session) resume_mod.Key {
+        return .{
+            .info_hash = self.info_hash,
+            .piece_length = self.piece_len,
+            .total_length = self.total_length,
+            .num_pieces = self.num_pieces,
+            .num_files = std.math.cast(u32, self.meta.files.len) orelse 0,
+        };
+    }
+
+    /// Persist the verified bitfield now (completion, clean shutdown). A no-op
+    /// unless a piece moved since the last save: the record on disk already
+    /// describes the payload exactly, and rewriting it would only cost an
+    /// fsync.
+    fn saveResume(self: *Session) void {
+        if (self.metadata_only) return;
+        if (!self.resume_data.dirty) return;
+        self.resume_data.save(self.allocator, &self.store, self.resumeKey(), self.our_bitfield);
+    }
+
+    /// Forget a piece we previously verified: drop the bit, restate the
+    /// cross-thread count, and mark the record for rewrite so the piece is not
+    /// resurrected from a stale save on the next start.
+    fn dropVerifiedPiece(self: *Session, index: u32) void {
+        if (!self.our_bitfield.hasPiece(index)) return;
+        self.our_bitfield.clearPiece(index);
+        self.have_pieces.store(self.our_bitfield.count(), .monotonic);
+        self.resume_data.markDirty();
+        log.warn("piece {d} unreadable on disk; dropped from the verified set", .{index});
     }
 
     /// A consistent, race-safe view of the session's live progress, for other
@@ -902,6 +993,10 @@ pub const Session = struct {
         while (self.running and !shutdown_requested.load(.acquire)) {
             if (self.mode == .download and !self.metadata_only and self.num_pieces > 0 and self.our_bitfield.isComplete()) {
                 stdout.print("\ndownload complete!\n", .{}) catch {};
+                // Record the finished set before anything closes or reopens the
+                // files: a completed torrent is exactly the case that must never
+                // re-hash gigabytes on the next start.
+                self.saveResume();
                 self.doMultiTrackerAnnounce(.completed) catch {};
                 if (self.on_complete) |cb| cb.run(cb.ctx);
 
@@ -1218,6 +1313,7 @@ pub const Session = struct {
                 self.our_bitfield.setPiece(pd.index);
                 self.downloaded += pp_ptr.piece_len;
                 self.have_pieces.store(self.our_bitfield.count(), .monotonic);
+                self.resume_data.markDirty();
 
                 self.printProgress() catch {};
 
@@ -1250,7 +1346,14 @@ pub const Session = struct {
         if (req.length == 0) return;
         if (req.begin >= plen or req.length > plen - req.begin) return;
 
-        const block = self.store.readRange(self.allocator, req.index, req.begin, req.length) catch return;
+        const block = self.store.readRange(self.allocator, req.index, req.begin, req.length) catch {
+            // We advertised this piece but can't read it back: the bytes are
+            // gone or the disk is failing. Stop claiming it (and stop
+            // persisting the claim) instead of silently failing every request
+            // for it forever.
+            if (!self.store.files_closed) self.dropVerifiedPiece(req.index);
+            return;
+        };
         defer self.allocator.free(block);
 
         p.enqueueMessage(.{ .piece = .{
@@ -1584,6 +1687,22 @@ pub const Session = struct {
         self.store.deinit();
         self.store = storage_mod.Storage.init(self.allocator, self.meta, self.output_dir, true) catch
             return error.StorageInitFailed;
+
+        // An earlier run of this same magnet may have left a resume record: the
+        // info hash was known from the start, so the record was always
+        // addressable — only now is there a geometry to match it against. It is
+        // checked exactly as strictly as at startup (same sizes, same mtimes,
+        // same spot check), so a re-added magnet resumes instead of
+        // re-downloading, and anything doubtful just leaves the fresh bitfield
+        // alone.
+        if (self.resume_data.load(self.allocator, &self.store, self.resumeKey(), self.meta.pieces)) |saved| {
+            self.snapshot_mutex.lock();
+            self.our_bitfield.deinit(self.allocator);
+            self.our_bitfield = saved;
+            self.have_pieces.store(self.our_bitfield.count(), .monotonic);
+            self.snapshot_mutex.unlock();
+            log.info("resume: {d}/{d} pieces from saved state", .{ self.our_bitfield.count(), self.num_pieces });
+        }
 
         // Metadata is in; clear the fetch-progress atomics BEFORE flipping to
         // download mode, so a snapshot that observes `metadata_only == false`
@@ -2092,6 +2211,19 @@ pub const Session = struct {
 
         // Run choking algorithm
         self.runChokingAlgorithm();
+
+        // Checkpoint the verified bitfield while pieces are arriving, so a
+        // crash costs at most `save_interval_secs` of re-hashing instead of the
+        // whole payload. No-op unless something moved since the last save.
+        if (!self.metadata_only) {
+            self.resume_data.maybeSave(
+                self.allocator,
+                &self.store,
+                self.resumeKey(),
+                self.our_bitfield,
+                now,
+            );
+        }
 
         if (!self.tor_hidden) {
             // Re-announce to trackers at the tracker-provided interval. After
@@ -2724,6 +2856,7 @@ pub const Session = struct {
         self.downloaded += data.len;
         self.block_bytes_in += data.len;
         self.have_pieces.store(self.our_bitfield.count(), .monotonic);
+        self.resume_data.markDirty();
         self.web_seed_fail_streak = 0;
         self.web_seed_retry_at = 0;
 

--- a/src/storage.zig
+++ b/src/storage.zig
@@ -82,6 +82,14 @@ pub const FileMap = struct {
     }
 };
 
+/// Size and last-modification time of one payload file. The resume record
+/// stamps every file with this and refuses to be believed unless both still
+/// match, so it lives here — next to the handles it is taken from.
+pub const FileStat = struct {
+    size: u64,
+    mtime_ns: i128,
+};
+
 /// Manages open file handles and performs positioned reads/writes.
 pub const Storage = struct {
     allocator: Allocator,
@@ -178,7 +186,16 @@ pub const Storage = struct {
                 // on the error path — Session.init failures don't kill the
                 // daemon, so leaked fds would accumulate.
                 opened += 1;
-                handles[i].setEndPos(file_info.length) catch return error.WriteFailed;
+                // Only resize when the file isn't already the right length.
+                // Truncating a file to the size it already has is a no-op that
+                // still bumps its mtime on some filesystems, and the resume
+                // record keys on mtime — a pointless ftruncate here would
+                // invalidate every saved bitfield and force a full re-hash on
+                // every single start.
+                const cur_len = handles[i].getEndPos() catch 0;
+                if (cur_len != file_info.length) {
+                    handles[i].setEndPos(file_info.length) catch return error.WriteFailed;
+                }
             } else {
                 // Seeding only reads: a read-only handle leaves the file free
                 // for other programs (no write lock on data we never modify).
@@ -231,6 +248,26 @@ pub const Storage = struct {
             h.* = ro;
         }
         self.read_only = true;
+    }
+
+    /// Size + mtime of payload file `index`, via `fstat` on the handle pieces
+    /// are actually read through. Deliberately not a path lookup: the resume
+    /// record's whole job is to prove the bytes we will read are the bytes we
+    /// hashed, and a path stat could describe a different file than the open
+    /// descriptor does.
+    pub fn statFile(self: *Storage, index: u32) IoError!FileStat {
+        if (self.files_closed or index >= self.handles.len) return error.ReadFailed;
+        const st = self.handles[index].stat() catch return error.ReadFailed;
+        return .{ .size = st.size, .mtime_ns = st.mtime };
+    }
+
+    /// Flush every payload file to stable storage, best-effort. Called before
+    /// the resume record is written so a power cut can never leave a record
+    /// vouching for pieces whose bytes were still only in the page cache.
+    /// A read-only store never wrote anything, so there is nothing to flush.
+    pub fn syncAll(self: *Storage) void {
+        if (self.files_closed or self.read_only) return;
+        for (self.handles) |h| h.sync() catch {};
     }
 
     /// Write a verified piece to disk.

--- a/src/tracker.zig
+++ b/src/tracker.zig
@@ -202,33 +202,28 @@ pub fn announce(
     defer allocator.free(url);
 
     if (proxy) |px| return announceThroughProxy(allocator, px, url);
+    return announceDirect(allocator, url);
+}
 
-    var client: std.http.Client = .{ .allocator = allocator };
-    defer client.deinit();
-
-    var response_body: std.ArrayList(u8) = .empty;
-    defer response_body.deinit(allocator);
-
-    var adapt_buf: [4096]u8 = undefined;
-    const deprecated_writer = response_body.writer(allocator);
-    var adapter = deprecated_writer.adaptToNewApi(&adapt_buf);
-
-    const result = client.fetch(.{
-        .location = .{ .url = url },
-        .response_writer = &adapter.new_interface,
-    }) catch return error.HttpError;
-
-    if (result.status != .ok) return error.HttpError;
-
-    // Flush the adapter's buffered tail: a response smaller than the adapter
-    // buffer (announce responses almost always are) would otherwise never
-    // reach `response_body` and parse as empty.
-    const buffered = adapter.new_interface.buffered();
-    if (buffered.len > 0) {
-        response_body.appendSlice(allocator, buffered) catch return error.OutOfMemory;
-    }
-
-    return parseAnnounceResponse(allocator, response_body.items);
+/// Announce straight to the tracker (no proxy), via `proxy.httpGetDirect`.
+///
+/// We deliberately do not use `std.http.Client` here: it has no timeout knobs
+/// (0.15), so a black-holed or very slow tracker blocked this call -- which runs
+/// on the session's event-loop thread -- for the OS TCP default, stalling every
+/// peer connection with it. `httpGetDirect` bounds the connect and the socket
+/// I/O by the same `http_get_timeout_secs` the proxied path already used, and a
+/// timeout surfaces as a plain `HttpError` so the announce backoff handles it.
+/// `https://` is not downgraded: it runs TLS with certificate verification over
+/// the same bounded stream. Like the proxied path, a 3xx is a failure rather
+/// than a followed redirect -- announce endpoints are expected to answer
+/// directly, and BEP 12 already gives us other tiers to fall back on.
+fn announceDirect(allocator: Allocator, url: []const u8) TrackerError!AnnounceResponse {
+    const body = proxy_mod.httpGetDirect(allocator, url, null) catch |err| {
+        log.debug("tracker announce failed: {}", .{err});
+        return error.HttpError;
+    };
+    defer allocator.free(body);
+    return parseAnnounceResponse(allocator, body);
 }
 
 /// Announce by tunneling the GET through the proxy. `http://` goes in plaintext,
@@ -477,6 +472,110 @@ test "percent encode" {
     // Binary data gets encoded
     try percentEncode(allocator, &buf, &[_]u8{ 0x00, 0xFF, 0x20 });
     try std.testing.expectEqualStrings("%00%FF%20", buf.items);
+}
+
+// --- Direct (unproxied) announce against a mock tracker ---
+
+const MockTracker = struct {
+    server: *std.net.Server,
+    stop: std.atomic.Value(bool),
+    body: []const u8,
+};
+
+fn mockTrackerRun(ctx: *MockTracker) void {
+    // Poll-with-timeout accept so the thread can observe `stop` and exit.
+    var pfd = [_]std.posix.pollfd{.{ .fd = ctx.server.stream.handle, .events = std.posix.POLL.IN, .revents = 0 }};
+    while (!ctx.stop.load(.acquire)) {
+        const ready = std.posix.poll(&pfd, 200) catch 0;
+        if (ready == 0) continue;
+        const conn = ctx.server.accept() catch continue;
+        defer conn.stream.close();
+        var buf: [4096]u8 = undefined;
+        var len: usize = 0;
+        while (len < buf.len) {
+            const n = conn.stream.read(buf[len..]) catch break;
+            if (n == 0) break;
+            len += n;
+            if (std.mem.indexOf(u8, buf[0..len], "\r\n\r\n") != null) break;
+        }
+        var head_buf: [64]u8 = undefined;
+        const head = std.fmt.bufPrint(
+            &head_buf,
+            "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\n\r\n",
+            .{ctx.body.len},
+        ) catch return;
+        _ = conn.stream.write(head) catch return;
+        var sent: usize = 0;
+        while (sent < ctx.body.len) {
+            const n = conn.stream.write(ctx.body[sent..]) catch break;
+            if (n == 0) break;
+            sent += n;
+        }
+    }
+}
+
+test "direct announce parses a live response" {
+    const allocator = std.testing.allocator;
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+
+    const ctx = try allocator.create(MockTracker);
+    ctx.* = .{
+        .server = &server,
+        .stop = std.atomic.Value(bool).init(false),
+        // interval 900, one compact peer 10.0.0.1:80
+        .body = "d8:intervali900e5:peers6:\n\x00\x00\x01\x00P" ++ "e",
+    };
+    const thread = try std.Thread.spawn(.{}, mockTrackerRun, .{ctx});
+    defer {
+        server.deinit();
+        allocator.destroy(ctx);
+    }
+
+    var url_buf: [64]u8 = undefined;
+    const announce_url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/announce", .{port});
+    const resp = announce(allocator, announce_url, .{
+        .info_hash = [_]u8{0x12} ** 20,
+        .peer_id = [_]u8{0xAB} ** 20,
+        .port = 6881,
+        .uploaded = 0,
+        .downloaded = 0,
+        .left = 1024,
+        .compact = true,
+        .event = .started,
+    }, null);
+
+    ctx.stop.store(true, .release);
+    thread.join();
+
+    const r = try resp;
+    defer r.deinit(allocator);
+    try std.testing.expectEqual(@as(u64, 900), r.interval);
+    try std.testing.expectEqual(@as(usize, 1), r.peers.len);
+    try std.testing.expectEqual([4]u8{ 10, 0, 0, 1 }, r.peers[0].ip);
+    try std.testing.expectEqual(@as(u16, 80), r.peers[0].port);
+}
+
+test "direct announce on a dead tracker fails fast with HttpError" {
+    const allocator = std.testing.allocator;
+    // Bind to grab a free port, then close it so the connect is refused --
+    // a tracker failure must surface as an error, never a hang.
+    var server = try std.net.Address.initIp4(.{ 127, 0, 0, 1 }, 0).listen(.{ .reuse_address = true });
+    const port = server.listen_address.getPort();
+    server.deinit();
+
+    var url_buf: [64]u8 = undefined;
+    const announce_url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/announce", .{port});
+    try std.testing.expectError(error.HttpError, announce(allocator, announce_url, .{
+        .info_hash = [_]u8{0} ** 20,
+        .peer_id = [_]u8{0} ** 20,
+        .port = 6881,
+        .uploaded = 0,
+        .downloaded = 0,
+        .left = 0,
+        .compact = true,
+        .event = .none,
+    }, null));
 }
 
 test "parse IPv4" {

--- a/src/ws.zig
+++ b/src/ws.zig
@@ -101,34 +101,32 @@ pub fn parseUrl(input: []const u8) Error!Url {
     return .{ .secure = secure, .host = host, .port = port, .path = path };
 }
 
-/// A live WebSocket connection. `wss://` uses `std.http.Client` for TLS (same
-/// stack as our HTTPS tracker client). `ws://` uses a plain TCP socket.
+/// A live WebSocket connection. `wss://` runs `std.crypto.tls` on top of a
+/// stream we own (a direct socket, or a SOCKS tunnel when a proxy is set);
+/// `ws://` uses that stream raw.
 pub const Conn = struct {
     allocator: Allocator,
     /// Socket handle for `setsockopt` (recv timeout). Closed via `deinit`.
     stream: std.net.Stream,
     /// Non-null for `wss://`; owns the TLS session used for reads/writes.
-    http: ?HttpIo = null,
-    /// Non-null for `wss://` over a proxy tunnel (TLS on top of SOCKS).
-    tls_proxy: ?*TlsProxyIo = null,
+    tls_io: ?*TlsIo = null,
 
     /// Buffer used to accumulate the payload of an in-progress message when
     /// the relay fragments. Owned by the Conn.
     fragment_buf: std.ArrayList(u8),
     fragment_opcode: ?Opcode,
 
-    const HttpIo = struct {
-        client: *std.http.Client,
-        connection: *std.http.Client.Connection,
-    };
-
     const tls_io_buf_len = tls.max_ciphertext_record_len;
 
-    /// SO_RCVTIMEO (seconds) for the proxied-TLS path: bounds the handshake and
-    /// every read so an unresponsive relay fails instead of hanging.
-    const tls_proxy_handshake_secs: u32 = 20;
+    /// SO_RCVTIMEO (seconds) for the TLS path: bounds the handshake and every
+    /// read so an unresponsive relay fails instead of hanging.
+    const tls_handshake_secs: u32 = 20;
 
-    const TlsProxyIo = struct {
+    /// How many redirects the upgrade follows before giving up. Some relays
+    /// (and the CDNs in front of them) 301 the upgrade to a canonical path.
+    const max_redirects: u8 = 3;
+
+    const TlsIo = struct {
         stream: std.net.Stream,
         socket_reader: std.net.Stream.Reader,
         socket_writer: std.net.Stream.Writer,
@@ -139,131 +137,104 @@ pub const Conn = struct {
         tls_read_buf: [tls_io_buf_len]u8,
         tls_write_buf: [tls_io_buf_len]u8,
 
-        fn deinit(self: *TlsProxyIo, allocator: Allocator) void {
+        fn deinit(self: *TlsIo, allocator: Allocator) void {
             self.ca_bundle.deinit(allocator);
             self.stream.close();
             allocator.destroy(self);
         }
     };
 
+    /// Open a WebSocket to `url_input`, following up to `max_redirects` hops.
+    ///
+    /// One dial per hop: the connect is bounded by `connect_timeout_ms` on the
+    /// socket we then keep, instead of the old probe-then-reconnect pair (a
+    /// bounded TCP connect that was immediately closed, followed by the real
+    /// connect). That double-dial showed a CDN edge a connect-abort right
+    /// before every TLS handshake — exactly the shape edge rate-limiting
+    /// punishes — and cost two dials per attempt for nothing.
     pub fn connect(allocator: Allocator, url_input: []const u8, options: ConnectOptions) Error!Conn {
+        // Ping-pong buffers: the hop we are dialing may alias one of them, so
+        // the next location is always written into the other.
+        var bufs: [2][512]u8 = undefined;
+        var target: []const u8 = url_input;
+        var hops: u8 = 0;
+        while (true) {
+            var redirect: RedirectOut = .{ .buf = &bufs[hops % 2] };
+            if (try connectOnce(allocator, target, options, &redirect)) |conn| return conn;
+            hops += 1;
+            if (hops > max_redirects) {
+                log.warn("ws handshake to {s}: too many redirects", .{url_input});
+                return error.HandshakeFailed;
+            }
+            target = redirect.value();
+        }
+    }
+
+    /// One dial + upgrade attempt. Returns null when the relay redirected us
+    /// (the resolved target is written to `redirect`) — the caller re-dials.
+    fn connectOnce(
+        allocator: Allocator,
+        url_input: []const u8,
+        options: ConnectOptions,
+        redirect: *RedirectOut,
+    ) Error!?Conn {
         const url = try parseUrl(url_input);
 
-        // For direct connections, probe reachability with a bounded timeout
-        // first so a relay with a hanging TCP connect can't stall us for the
-        // OS default (~75 s) inside std's timeout-free connect. Proxied
-        // connections dial the proxy, not the relay, so skip the probe there.
-        if (options.proxy == null and
-            !preflightReachable(allocator, url.host, url.port, preflight_connect_ms))
-        {
-            log.warn("relay {s}:{d} unreachable within {d}ms, skipping", .{ url.host, url.port, preflight_connect_ms });
-            return error.ConnectFailed;
-        }
-
-        if (url.secure) {
-            // wss:// through the proxy: tunnel TCP via SOCKS, then run TLS on top
-            // of the proxied stream so the proxy only sees ciphertext. The relay
-            // never learns our IP -- the whole connection rides the proxy/Tor.
-            if (options.proxy) |px| {
-                const stream = proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
-                    log.debug("wss proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
-                    return error.ConnectFailed;
-                };
-                var conn = Conn{
-                    .allocator = allocator,
-                    .stream = stream,
-                    .fragment_buf = .empty,
-                    .fragment_opcode = null,
-                };
-                conn.tls_proxy = connectTlsOverProxy(allocator, stream, url.host) catch |err| {
-                    // connectTlsOverProxy already closed `stream` on failure.
-                    conn.fragment_buf.deinit(allocator);
-                    log.warn("tls over proxy to {s}:{d} failed: {}", .{ url.host, url.port, err });
-                    return err;
-                };
-                conn.stream = conn.tls_proxy.?.stream;
-                errdefer conn.deinit();
-                try conn.performHandshake(url);
-                return conn;
-            }
-            const client = try allocator.create(std.http.Client);
-            client.* = .{ .allocator = allocator };
-
-            {
-                client.ca_bundle_mutex.lock();
-                defer client.ca_bundle_mutex.unlock();
-                client.ca_bundle.rescan(allocator) catch {
-                    client.deinit();
-                    allocator.destroy(client);
-                    return error.TlsInitFailed;
-                };
-            }
-
-            const connection = client.connectTcp(url.host, url.port, .tls) catch |err| {
-                log.warn("tls connect to {s}:{d} failed: {}", .{ url.host, url.port, err });
-                client.deinit();
-                allocator.destroy(client);
-                return httpConnectError(err);
-            };
-
-            var conn = Conn{
-                .allocator = allocator,
-                .stream = connection.stream_reader.getStream(),
-                .http = .{
-                    .client = client,
-                    .connection = connection,
-                },
-                .fragment_buf = .empty,
-                .fragment_opcode = null,
-            };
-            errdefer conn.deinit();
-
-            try conn.performHandshake(url);
-            setRecvTimeout(conn.stream, 30);
-            return conn;
-        }
-
-        // `ws://` (no TLS). Through a proxy this is how we reach a relay's
-        // `.onion` address: the SOCKS tunnel (Tor) provides the encryption and
-        // authenticates the address, so the plaintext WebSocket rides safely on
-        // top -- no redundant TLS layer needed.
+        // Through a proxy we dial the proxy, not the relay: the SOCKS tunnel
+        // carries the connection so the relay never learns our IP. `ws://`
+        // rides the tunnel raw (an onion relay: Tor already encrypts and
+        // authenticates it); `wss://` runs TLS on top, so the proxy only ever
+        // sees ciphertext.
         const stream = if (options.proxy) |px|
             proxy_mod.connectThroughProxyHost(allocator, px, url.host, url.port) catch |err| {
-                log.debug("ws proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
+                log.debug("proxy tunnel to {s}:{d} failed: {}", .{ url.host, url.port, err });
                 return error.ConnectFailed;
             }
         else
             tcpConnect(allocator, url.host, url.port) catch |err| {
                 log.warn("tcp connect to {s}:{d} failed: {}", .{ url.host, url.port, err });
-                return error.ConnectFailed;
+                return err;
             };
 
         var conn = Conn{
             .allocator = allocator,
             .stream = stream,
-            .http = null,
             .fragment_buf = .empty,
             .fragment_opcode = null,
         };
+
+        if (url.secure) {
+            conn.tls_io = connectTls(allocator, stream, url.host) catch |err| {
+                // connectTls already closed `stream` on failure.
+                conn.fragment_buf.deinit(allocator);
+                log.warn("tls handshake with {s}:{d} failed: {}", .{ url.host, url.port, err });
+                return err;
+            };
+            conn.stream = conn.tls_io.?.stream;
+        } else {
+            // Set the recv timeout before the handshake so a silent relay
+            // can't hang us (the TLS path sets its own inside connectTls).
+            setRecvTimeout(conn.stream, 30);
+        }
         errdefer conn.deinit();
 
-        // Set the recv timeout before the handshake so a silent onion relay
-        // can't hang us (the proxy dial leaves its own timeout, but be explicit).
-        setRecvTimeout(conn.stream, 30);
-        try conn.performHandshake(url);
-        return conn;
+        if (try conn.performHandshake(url, redirect)) return conn;
+        // Redirected: this connection is done with. (Not an error path, so the
+        // errdefer above doesn't fire — close it here.)
+        conn.deinit();
+        return null;
     }
 
-    /// Run a TLS client handshake over an already-proxied `stream` and return a
-    /// heap-allocated `TlsProxyIo` that owns it (same TLS-over-a-raw-stream
-    /// mechanism as proxy.httpsExchange; the buffers + reader/writer live inside
-    /// the returned struct, which is heap-stable so TLS's pointers stay valid).
+    /// Run a TLS client handshake over `stream` and return a heap-allocated
+    /// `TlsIo` that owns it (same TLS-over-a-raw-stream mechanism as
+    /// proxy.httpsExchange; the buffers + reader/writer live inside the
+    /// returned struct, which is heap-stable so TLS's pointers stay valid).
     /// On any error the stream is closed and nothing leaks.
-    fn connectTlsOverProxy(allocator: Allocator, stream: std.net.Stream, host: []const u8) Error!*TlsProxyIo {
+    fn connectTls(allocator: Allocator, stream: std.net.Stream, host: []const u8) Error!*TlsIo {
         var owned = false;
         defer if (!owned) stream.close();
 
-        const tp = allocator.create(TlsProxyIo) catch return error.OutOfMemory;
+        const tp = allocator.create(TlsIo) catch return error.OutOfMemory;
         errdefer allocator.destroy(tp);
 
         tp.stream = stream;
@@ -286,7 +257,7 @@ pub const Conn = struct {
         // unresponsive relay fails instead of hanging. std's File.Reader turns a
         // read timeout into an error, which for our request/response +
         // subscribe-until-timeout relay usage simply ends the op -- the intent.
-        setRecvTimeout(stream, tls_proxy_handshake_secs);
+        setRecvTimeout(stream, tls_handshake_secs);
         tp.tls = tls.Client.init(tp.socket_reader.interface(), &tp.socket_writer.interface, .{
             .host = if (onion) .no_verification else .{ .explicit = host },
             .ca = if (onion) .no_verification else .{ .bundle = tp.ca_bundle },
@@ -294,19 +265,12 @@ pub const Conn = struct {
             .read_buffer = &tp.tls_read_buf,
         }) catch return error.TlsInitFailed;
 
-        owned = true; // tp now owns `stream`; TlsProxyIo.deinit closes it
+        owned = true; // tp now owns `stream`; TlsIo.deinit closes it
         return tp;
     }
 
     pub fn deinit(self: *Conn) void {
-        if (self.http) |h| {
-            // `connectTcp` registers the connection in the client's pool.
-            // Mark closing and release so `client.deinit()` does not panic.
-            h.connection.closing = true;
-            h.client.connection_pool.release(h.connection);
-            h.client.deinit();
-            self.allocator.destroy(h.client);
-        } else if (self.tls_proxy) |t| {
+        if (self.tls_io) |t| {
             t.deinit(self.allocator);
         } else {
             self.stream.close();
@@ -415,126 +379,18 @@ pub const Conn = struct {
     // Internal
     // -------------------------------------------------------------------
 
-    fn performHandshake(self: *Conn, url: Url) Error!void {
-        if (self.http) |h| return performHandshakeHttps(self, url, h);
-        return performHandshakePlain(self, url);
-    }
-
-    /// `wss://` upgrade via `std.http.Client` — the same stack as HTTPS
-    /// trackers. Hand-writing TLS application data and reading it back with
-    /// `tls.Client.reader` deadlocks on Zig 0.15 for Nostr relays.
-    fn performHandshakeHttps(self: *Conn, url: Url, h: HttpIo) Error!void {
-        var key_raw: [16]u8 = undefined;
-        std.crypto.random.bytes(&key_raw);
-        var key_b64: [24]u8 = undefined;
-        _ = std.base64.standard.Encoder.encode(&key_b64, &key_raw);
-
-        const uri_str = std.fmt.allocPrint(self.allocator, "https://{s}{s}", .{ url.host, url.path }) catch return error.OutOfMemory;
-        defer self.allocator.free(uri_str);
-        const uri = std.Uri.parse(uri_str) catch return error.HandshakeFailed;
-
-        const extra = [_]std.http.Header{
-            .{ .name = "Upgrade", .value = "websocket" },
-            .{ .name = "Sec-WebSocket-Key", .value = &key_b64 },
-            .{ .name = "Sec-WebSocket-Version", .value = "13" },
-        };
-
-        var req = h.client.request(.GET, uri, .{
-            .connection = h.connection,
-            .keep_alive = true,
-            .extra_headers = &extra,
-            .headers = .{
-                .host = .{ .override = url.host },
-                .connection = .{ .override = "Upgrade" },
-                .user_agent = .{ .override = "carl/0.1" },
-            },
-        }) catch return error.HandshakeFailed;
-
-        req.sendBodiless() catch return error.HandshakeFailed;
-
-        // Read + parse the response head ourselves instead of req.receiveHead():
-        // std's Response.Head.parse does @enumFromInt into the *exhaustive*
-        // std.http.Status enum, so a relay (or the CDN in front of it)
-        // answering with a non-standard code (Cloudflare's 52x/530, etc.)
-        // panics the whole daemon with "invalid enum value" — and the desktop
-        // app sits "offline" on its dead sidecar. Here any non-101 is a
-        // handshake failure, not a crash. (Observed in the field: a relay
-        // behind Cloudflare aborted the daemon exactly this way.)
-        //
-        // Redirects are still followed (std's default redirect_behavior allows
-        // 3): some relays/CDNs 301 the upgrade to a canonical path. Location
-        // is parsed from the raw head so the status never becomes a
-        // std.http.Status.
-        var redirects_left: u8 = 3;
-        var head: []const u8 = undefined;
-        var st: HeadStatus = undefined;
-        while (true) {
-            head = req.reader.receiveHead() catch return error.HandshakeFailed;
-            st = parseHeadStatus(head) orelse {
-                log.warn("ws handshake malformed status line", .{});
-                return error.HandshakeFailed;
-            };
-            switch (st.code) {
-                301, 302, 303, 307, 308 => {
-                    if (redirects_left == 0) {
-                        log.warn("ws handshake too many redirects", .{});
-                        return error.HandshakeFailed;
-                    }
-                    redirects_left -= 1;
-                    const location = findHeadHeader(head, "location") orelse {
-                        log.warn("ws handshake {d} without Location header", .{st.code});
-                        return error.HandshakeFailed;
-                    };
-                    // Drain the redirect body so the stream stays in sync for
-                    // the follow-up request (as std's Request.redirect does).
-                    const te: std.http.TransferEncoding = if (findHeadHeader(head, "transfer-encoding") != null) .chunked else .none;
-                    const cl: ?u64 = if (findHeadHeader(head, "content-length")) |v| std.fmt.parseInt(u64, v, 10) catch null else null;
-                    _ = req.reader.bodyReader(&.{}, te, cl).discardRemaining() catch return error.HandshakeFailed;
-                    // Resolve Location the two ways relays actually use it:
-                    // an absolute https:// URI, or an absolute path on the
-                    // same host.
-                    var new_uri_str: []u8 = undefined;
-                    if (std.mem.startsWith(u8, location, "https://")) {
-                        new_uri_str = self.allocator.dupe(u8, location) catch return error.OutOfMemory;
-                    } else if (location.len > 0 and location[0] == '/') {
-                        new_uri_str = std.fmt.allocPrint(self.allocator, "https://{s}{s}", .{ url.host, location }) catch return error.OutOfMemory;
-                    } else {
-                        log.warn("ws handshake unsupported redirect target: {s}", .{location});
-                        return error.HandshakeFailed;
-                    }
-                    defer self.allocator.free(new_uri_str);
-                    req.uri = std.Uri.parse(new_uri_str) catch return error.HandshakeFailed;
-                    req.sendBodiless() catch return error.HandshakeFailed;
-                    continue;
-                },
-                else => break,
-            }
-        }
-        if (st.code != 101) {
-            log.warn("ws handshake status {d} {s}", .{ st.code, st.reason });
-            return error.HandshakeFailed;
-        }
-
-        const expected = expectedAccept(&key_b64);
-        const accept = findHeadHeader(head, "Sec-WebSocket-Accept") orelse {
-            log.warn("ws handshake missing Sec-WebSocket-Accept header", .{});
-            return error.HandshakeFailed;
-        };
-        if (!std.mem.eql(u8, accept, &expected)) {
-            log.warn("ws handshake bad Sec-WebSocket-Accept", .{});
-            return error.HandshakeFailed;
-        }
-
-        // Detach the connection so `req.deinit` does not return it to the pool
-        // or drain bytes that belong to the first WebSocket frame.
-        h.connection.closing = false;
-        req.reader.state = .ready;
-        req.connection = null;
-        req.deinit();
-    }
-
-    /// `ws://` upgrade over a plain TCP socket.
-    fn performHandshakePlain(self: *Conn, url: Url) Error!void {
+    /// Send the upgrade request and read the response. Returns true when the
+    /// relay switched protocols; false when it redirected us, in which case
+    /// `redirect` holds the resolved target and the caller re-dials.
+    ///
+    /// The response head is parsed by hand rather than with std.http: std's
+    /// Response.Head.parse does @enumFromInt into the *exhaustive*
+    /// std.http.Status enum, so a relay (or the CDN in front of it) answering
+    /// with a non-standard code (Cloudflare's 52x/530, etc.) panics the whole
+    /// daemon with "invalid enum value" -- and the desktop app sits "offline"
+    /// on its dead sidecar. Here any non-101 is a handshake failure, not a
+    /// crash. (Observed in the field.)
+    fn performHandshake(self: *Conn, url: Url, redirect: *RedirectOut) Error!bool {
         var key_raw: [16]u8 = undefined;
         std.crypto.random.bytes(&key_raw);
         var key_b64: [24]u8 = undefined;
@@ -556,25 +412,51 @@ pub const Conn = struct {
 
         try self.writeAll(req);
 
+        // Read until the head is complete. A 101 carries no body, so anything
+        // past the blank line would be WebSocket frames -- but a redirect may
+        // carry one, hence indexOf rather than "the read ended on \r\n\r\n"
+        // (we drop the connection on a redirect, so a partly-read body is
+        // harmless).
         var hdr_buf: [4096]u8 = undefined;
         var hdr_len: usize = 0;
-        while (hdr_len < hdr_buf.len) {
-            const space = hdr_buf.len - hdr_len;
-            const want = @min(space, 512);
+        while (std.mem.indexOf(u8, hdr_buf[0..hdr_len], "\r\n\r\n") == null) {
+            if (hdr_len == hdr_buf.len) {
+                log.warn("ws handshake response head too large", .{});
+                return error.HandshakeFailed;
+            }
+            const want = @min(hdr_buf.len - hdr_len, 512);
             const n = try self.readSome(hdr_buf[hdr_len..][0..want]);
             if (n == 0) return error.HandshakeFailed;
             hdr_len += n;
-            if (hdr_len >= 4 and std.mem.eql(u8, hdr_buf[hdr_len - 4 .. hdr_len], "\r\n\r\n")) break;
         }
         const headers = hdr_buf[0..hdr_len];
 
-        if (!std.mem.startsWith(u8, headers, "HTTP/1.1 101")) {
-            log.warn("ws handshake non-101 response: {s}", .{headers[0..@min(80, headers.len)]});
+        const st = parseHeadStatus(headers) orelse {
+            log.warn("ws handshake malformed status line", .{});
             return error.HandshakeFailed;
+        };
+        switch (st.code) {
+            101 => {},
+            301, 302, 303, 307, 308 => {
+                const location = findHeadHeader(headers, "location") orelse {
+                    log.warn("ws handshake {d} without Location header", .{st.code});
+                    return error.HandshakeFailed;
+                };
+                if (!resolveRedirect(url, location, redirect)) {
+                    log.warn("ws handshake unsupported redirect target: {s}", .{location});
+                    return error.HandshakeFailed;
+                }
+                log.info("ws {s}: relay redirected the upgrade to {s}", .{ url.host, redirect.value() });
+                return false;
+            },
+            else => {
+                log.warn("ws handshake status {d} {s}", .{ st.code, st.reason });
+                return error.HandshakeFailed;
+            },
         }
 
         const expected = expectedAccept(&key_b64);
-        const accept_value = findHeader(headers, "Sec-WebSocket-Accept") orelse {
+        const accept_value = findHeadHeader(headers, "Sec-WebSocket-Accept") orelse {
             log.warn("ws handshake missing Sec-WebSocket-Accept header", .{});
             return error.HandshakeFailed;
         };
@@ -582,25 +464,7 @@ pub const Conn = struct {
             log.warn("ws handshake bad Sec-WebSocket-Accept", .{});
             return error.HandshakeFailed;
         }
-    }
-
-    /// Find the value of a case-insensitive header name in an HTTP/1.1 header
-    /// block. Returns null if the header is absent.
-    fn findHeader(headers: []const u8, name: []const u8) ?[]const u8 {
-        var line_start: usize = 0;
-        while (line_start < headers.len) {
-            const line_end = std.mem.indexOfScalarPos(u8, headers, line_start, '\n') orelse return null;
-            const line = headers[line_start..line_end];
-            const trimmed = std.mem.trimRight(u8, line, "\r");
-            if (std.mem.indexOfScalar(u8, trimmed, ':')) |colon| {
-                const hdr_name = trimmed[0..colon];
-                if (hdr_name.len == name.len and std.ascii.eqlIgnoreCase(hdr_name, name)) {
-                    return std.mem.trim(u8, trimmed[colon + 1 ..], " \t");
-                }
-            }
-            line_start = line_end + 1;
-        }
-        return null;
+        return true;
     }
 
     const FrameMeta = struct {
@@ -679,11 +543,7 @@ pub const Conn = struct {
     }
 
     fn writeAll(self: *Conn, buf: []const u8) Error!void {
-        if (self.http) |h| {
-            const w = h.connection.writer();
-            w.writeAll(buf) catch return error.SendFailed;
-            h.connection.flush() catch return error.SendFailed;
-        } else if (self.tls_proxy) |t| {
+        if (self.tls_io) |t| {
             t.tls.writer.writeAll(buf) catch return error.SendFailed;
             t.tls.writer.flush() catch return error.SendFailed;
             t.socket_writer.interface.flush() catch return error.SendFailed;
@@ -698,11 +558,7 @@ pub const Conn = struct {
     }
 
     fn readSome(self: *Conn, buf: []u8) Error!usize {
-        if (self.http) |h| {
-            const r = h.connection.reader();
-            return r.readSliceShort(buf) catch return error.RecvFailed;
-        }
-        if (self.tls_proxy) |t| {
+        if (self.tls_io) |t| {
             // readSliceShort() fills the whole buffer -- it loops until `buf` is
             // full or EOF -- so it deadlocks reading a kept-alive HTTP/WS
             // response that never reaches EOF (e.g. the 101 upgrade headers).
@@ -746,66 +602,11 @@ fn setRecvTimeout(stream: std.net.Stream, sec: u32) void {
     posix.setsockopt(stream.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, std.mem.asBytes(&tv)) catch {};
 }
 
-fn httpConnectError(err: std.http.Client.ConnectTcpError) Error {
-    return switch (err) {
-        error.TlsInitializationFailed => error.TlsInitFailed,
-        error.UnknownHostName, error.HostLacksNetworkAddresses => error.DnsResolveFailed,
-        else => error.ConnectFailed,
-    };
-}
-
-/// Connect-probe budget (ms) for the preflight reachability check. The blocking
-/// connect inside `std.http.Client` (used for the `wss://` TLS path) has no
-/// timeout, so a relay whose TCP connect hangs -- e.g. an unroutable address or
-/// a silently-dropped SYN, as public relays like relay.nostr.band sometimes do
-/// -- would otherwise stall the caller for the OS default (~75 s). We probe
-/// first with a bounded non-blocking connect and skip the relay fast on failure.
-const preflight_connect_ms: i32 = 4000;
-
-/// Best-effort fast reachability probe: resolve `host` and try a non-blocking
-/// TCP connect (IPv4 first) bounded by `timeout_ms`. Returns true as soon as any
-/// address accepts. A false return lets the caller skip a dead/slow relay
-/// quickly instead of blocking in std's timeout-free connect.
-fn preflightReachable(allocator: Allocator, host: []const u8, port: u16, timeout_ms: i32) bool {
-    const list = std.net.getAddressList(allocator, host, port) catch return false;
-    defer list.deinit();
-
-    inline for (.{ posix.AF.INET, posix.AF.INET6 }) |family| {
-        for (list.addrs) |addr| {
-            if (addr.any.family != family) continue;
-            if (probeConnect(addr, timeout_ms)) return true;
-        }
-    }
-    return false;
-}
-
-/// Non-blocking connect to a single address, bounded by `timeout_ms`. The probe
-/// socket is always closed; we only care whether the connect would succeed.
-fn probeConnect(addr: std.net.Address, timeout_ms: i32) bool {
-    const sock = posix.socket(
-        addr.any.family,
-        posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
-        posix.IPPROTO.TCP,
-    ) catch return false;
-    defer posix.close(sock);
-
-    const flags = posix.fcntl(sock, posix.F.GETFL, 0) catch return false;
-    var o: posix.O = @bitCast(@as(u32, @truncate(flags)));
-    o.NONBLOCK = true;
-    _ = posix.fcntl(sock, posix.F.SETFL, @as(u32, @bitCast(o))) catch {};
-
-    posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
-        error.WouldBlock => {
-            var pfd = [_]posix.pollfd{.{ .fd = sock, .events = posix.POLL.OUT, .revents = 0 }};
-            const ready = posix.poll(&pfd, timeout_ms) catch return false;
-            if (ready == 0) return false;
-            posix.getsockoptError(sock) catch return false;
-            return true;
-        },
-        else => return false,
-    };
-    return true; // connected synchronously
-}
+/// Connect-timeout budget (ms) for the TCP dial. std's `connect` has no
+/// timeout at all, so a relay whose TCP connect hangs -- an unroutable address
+/// or a silently-dropped SYN, as public relays like relay.nostr.band sometimes
+/// do -- would otherwise stall the caller for the OS default (~75 s).
+const connect_timeout_ms: i32 = 4000;
 
 /// Open TCP to `host`:`port`, preferring IPv4 and trying every resolved address
 /// before giving up. `std.net.tcpConnectToHost` stops on the first non-refused
@@ -815,21 +616,101 @@ fn tcpConnect(allocator: Allocator, host: []const u8, port: u16) Error!std.net.S
     defer list.deinit();
     if (list.addrs.len == 0) return error.DnsResolveFailed;
 
-    var last_err: ?std.net.TcpConnectToAddressError = null;
-
     inline for (.{ posix.AF.INET, posix.AF.INET6 }) |family| {
         for (list.addrs) |addr| {
             if (addr.any.family != family) continue;
-            const stream = std.net.tcpConnectToAddress(addr) catch |err| {
-                last_err = err;
-                continue;
-            };
-            return stream;
+            if (connectTimed(addr, connect_timeout_ms)) |stream| return stream;
         }
     }
-
-    if (last_err) |_| return error.ConnectFailed;
     return error.ConnectFailed;
+}
+
+/// TCP connect to a single address bounded by `timeout_ms`, handing back the
+/// *connected* socket: dial non-blocking, wait with poll(), then restore
+/// blocking mode. The socket that proves the relay reachable is the one we
+/// keep -- no probe-and-throw-away, so a relay sees exactly one connect per
+/// attempt.
+fn connectTimed(addr: std.net.Address, timeout_ms: i32) ?std.net.Stream {
+    const sock = posix.socket(
+        addr.any.family,
+        posix.SOCK.STREAM | posix.SOCK.CLOEXEC,
+        posix.IPPROTO.TCP,
+    ) catch return null;
+    var keep = false;
+    defer if (!keep) posix.close(sock);
+
+    if (!setNonBlocking(sock, true)) return null;
+    posix.connect(sock, &addr.any, addr.getOsSockLen()) catch |err| switch (err) {
+        error.WouldBlock => {
+            var pfd = [_]posix.pollfd{.{ .fd = sock, .events = posix.POLL.OUT, .revents = 0 }};
+            const ready = posix.poll(&pfd, timeout_ms) catch return null;
+            if (ready == 0) return null; // timed out
+            // poll() only says "the connect finished" -- SO_ERROR says how.
+            posix.getsockoptError(sock) catch return null;
+        },
+        else => return null,
+    };
+    // Everything downstream (our recv loop, std's TLS client) assumes a
+    // blocking socket with SO_RCVTIMEO.
+    if (!setNonBlocking(sock, false)) return null;
+
+    keep = true;
+    return .{ .handle = sock };
+}
+
+fn setNonBlocking(sock: posix.socket_t, on: bool) bool {
+    const flags = posix.fcntl(sock, posix.F.GETFL, 0) catch return false;
+    var o: posix.O = @bitCast(@as(u32, @truncate(flags)));
+    o.NONBLOCK = on;
+    _ = posix.fcntl(sock, posix.F.SETFL, @as(u32, @bitCast(o))) catch return false;
+    return true;
+}
+
+/// Where a relay's redirect points, resolved into an absolute ws/wss URL. The
+/// caller owns the backing buffer (see `Conn.connect`).
+const RedirectOut = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn value(self: RedirectOut) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    fn set(self: *RedirectOut, parts: []const []const u8) bool {
+        var n: usize = 0;
+        for (parts) |p| {
+            if (n + p.len > self.buf.len) return false;
+            @memcpy(self.buf[n..][0..p.len], p);
+            n += p.len;
+        }
+        self.len = n;
+        return true;
+    }
+};
+
+/// Resolve a `Location` value against the URL we just requested. Handles the
+/// two forms relays actually send: an absolute URL (https/wss and their
+/// insecure twins) and an absolute path on the same host. Anything else --
+/// including a relative path -- is rejected rather than guessed at. Returns
+/// false when the target doesn't fit the caller's buffer either.
+fn resolveRedirect(url: Url, location: []const u8, out: *RedirectOut) bool {
+    if (location.len == 0) return false;
+    if (std.mem.startsWith(u8, location, "wss://") or std.mem.startsWith(u8, location, "ws://"))
+        return out.set(&.{location});
+    // A wss endpoint IS an https endpoint pre-upgrade; relays name it either way.
+    if (std.mem.startsWith(u8, location, "https://"))
+        return out.set(&.{ "wss://", location["https://".len..] });
+    if (std.mem.startsWith(u8, location, "http://"))
+        return out.set(&.{ "ws://", location["http://".len..] });
+    if (location[0] != '/') return false;
+
+    const scheme: []const u8 = if (url.secure) "wss://" else "ws://";
+    var port_buf: [8]u8 = undefined;
+    const port: []const u8 = if (url.port == (if (url.secure) @as(u16, 443) else 80))
+        ""
+    else
+        std.fmt.bufPrint(&port_buf, ":{d}", .{url.port}) catch return false;
+    return out.set(&.{ scheme, url.host, port, location });
 }
 
 /// Compute the expected Sec-WebSocket-Accept header value for a given
@@ -937,6 +818,46 @@ test "findHeadHeader: lookup is case-insensitive and trims the value" {
     try std.testing.expectEqualStrings("wss://relay.example.com/nostr", findHeadHeader(head, "location").?);
     try std.testing.expectEqualStrings("0", findHeadHeader(head, "Content-Length").?);
     try std.testing.expect(findHeadHeader(head, "sec-websocket-accept") == null);
+}
+
+fn expectRedirect(expected: []const u8, from: []const u8, location: []const u8) !void {
+    var buf: [256]u8 = undefined;
+    var out: RedirectOut = .{ .buf = &buf };
+    try std.testing.expect(resolveRedirect(try parseUrl(from), location, &out));
+    try std.testing.expectEqualStrings(expected, out.value());
+}
+
+test "resolveRedirect: absolute targets keep (or gain) a websocket scheme" {
+    try expectRedirect("wss://b.example/nostr", "wss://a.example", "wss://b.example/nostr");
+    try expectRedirect("ws://b.example/", "wss://a.example", "ws://b.example/");
+    // A wss endpoint is an https endpoint pre-upgrade; relays name it both ways.
+    try expectRedirect("wss://b.example/nostr", "wss://a.example", "https://b.example/nostr");
+    try expectRedirect("ws://b.example:8080/", "wss://a.example", "http://b.example:8080/");
+}
+
+test "resolveRedirect: absolute paths resolve against the current host" {
+    try expectRedirect("wss://a.example/nostr", "wss://a.example", "/nostr");
+    try expectRedirect("wss://a.example/canonical", "wss://a.example/", "/canonical");
+    // A non-default port has to survive the rewrite, or we'd re-dial 443.
+    try expectRedirect("wss://a.example:7777/nostr", "wss://a.example:7777/x", "/nostr");
+    try expectRedirect("ws://a.example/nostr", "ws://a.example", "/nostr");
+    try expectRedirect("ws://a.example:81/nostr", "ws://a.example:81", "/nostr");
+}
+
+test "resolveRedirect: rejects what we can't resolve safely" {
+    var buf: [256]u8 = undefined;
+    var out: RedirectOut = .{ .buf = &buf };
+    const url = try parseUrl("wss://a.example");
+    try std.testing.expect(!resolveRedirect(url, "", &out));
+    try std.testing.expect(!resolveRedirect(url, "nostr", &out)); // relative
+    try std.testing.expect(!resolveRedirect(url, "ftp://b.example", &out));
+
+    // A target longer than the caller's buffer is refused, never truncated
+    // (a truncated URL would dial the wrong host).
+    var tiny: [8]u8 = undefined;
+    var small: RedirectOut = .{ .buf = &tiny };
+    try std.testing.expect(!resolveRedirect(url, "wss://much.longer.example/nostr", &small));
+    try std.testing.expectEqual(@as(usize, 0), small.len);
 }
 
 // Frame-level tests use a fixed-buffer "byte stream" instead of real sockets,


### PR DESCRIPTION
Debugging a live stalled daemon turned into a full performance pass. Every number below is A/B measured against the pre-change binary on an idle machine, using hash-verified benchmark harnesses added in this PR.

| benchmark | before | after | gain |
|---|---|---|---|
| **tracker returns 40 dead peers + 1 seeder, 64 MiB** | **did not finish in 400s** | **0.3–2.1s** | **transfer was impossible, now works** |
| 1 GiB loopback download | 15.2s (67.4 MiB/s) | 4.1s (251.4 MiB/s) | 3.7x |
| upload fan-out, 4 leechers x 512 MiB | 163.5 MiB/s | 649.9 MiB/s | 4.0x |
| 1 MiB transfer (fixed startup cost) | 8.1s | 1.0s | 8x |

End-to-end correctness: Debian 13.6 netinst (755 MB) pulled from the real swarm hashes to Debian's published SHA256 exactly.

## The two findings that mattered most

**A tracker full of dead peers made downloads impossible, not just slow.** All dials ran serially and blocking *before* the event loop started, each bounded only by the 5s connect timeout. Worse, `sendHandshake` merely *queued* its 68 bytes — nothing was written until the loop began — so early-dialed peers sat with an open socket and total silence until remote clients dropped them at their own 10s handshake timeout. That is why a 50-peer announce on the live Debian swarm produced exactly 3 completed handshakes. Peers are now dialed non-blocking and completed through the poll set, writing the handshake in the same event as the connect.

**8 seconds of every transfer was spent waiting to be unchoked.** A peer that declared interest just after a choker tick waited out the full `unchoke_interval_secs`. A timestamped run showed the handshake completing, then 8.003s of dead air, then the entire transfer finishing in 5 ms. We paid it on every download and inflicted it on every leecher we served, so it hurt upload as much as download.

## Throughput

- **Peer sockets stay non-blocking after connect.** They were switched back to blocking, capping each peer at one 64 KiB buffer per poll wake — peer throughput was literally `peers x 64 KiB x loop_rate`, measured on the live swarm as 3 x 64 KiB x 2 Hz = 384 KB/s. Reads drain to EAGAIN; writes loop until the kernel pushes back, so one slow leecher can no longer stall the session mid piece-send.
- **Web seed off the event loop.** It built a fresh `std.http.Client` per 256 KiB piece — new TCP connection and TLS handshake each time — and blocked the loop for the whole fetch, throttling it to ~2 Hz. Now a worker thread with one reused client (verified by observing a single client source port across consecutive ranged GETs), a handoff state machine, per-mirror backoff, and a rotating piece cursor.
- **Candidate peer pool.** Announce/DHT/nostr addresses are retained (500 entries, 60s per-address reconnect spacing, failure pruning) instead of freed after one dial pass, and `maintenance` tops the peer set up at 1 Hz. Previously top-up fired only at *exactly zero* peers, so the count could only decay between 15-30 minute announces. `max_peers` 50 -> 100 (anonymized routes stay at 50).
- **O(1) bitfield accounting** — `count()`/`isComplete()` were per-bit loops running every poll wake; now cached counters plus word-level `@popCount`/`@clz`. 3020 pieces: 269 ns -> ~0 ns.

## Robustness

- **Direct HTTP tracker announces are bounded.** They used `std.http.Client` with no timeout at all, so a black-holed tracker hung the session thread for the OS TCP default. Direct and proxied paths now share one implementation; this also bounds the proxy dial's `connect()`, itself previously unbounded.
- **Relay URL normalization** — a user-entered `https://` relay failed `error.InvalidUrl` every cycle forever (1200+ retries in the live log) though the relay answered a valid websocket upgrade.
- **Exponential backoff** on failed announces, DHT, and nostr re-queries. `last_announce_time` was stamped only on success, so after total failure the maintenance gate re-ran the full blocking announce every ~1s tick; the nostr re-query had gotten us rate-limited by relay.damus.io.
- **Default tracker tier** for tracker-less magnets on non-i2p routes; DHT was previously the sole source on `direct` and there was none at all on `tor`.
- **i2p dead-end warning**, **truthful route banner**, and **rate-based unchoke** (reciprocation by EWMA rather than lifetime bytes, which favored long-dead peers).

## Benchmarks added

`scripts/bench_loopback.sh` (single stream; `DEAD_PEERS=N` reproduces the swarm case above) and `scripts/bench_upload.sh` (seeder fan-out to N leechers). Both verify every downloader's SHA-256 against the seeder rather than trusting carl's own "complete" message.

`zig build test` green (299 tests), ReleaseSafe clean, `zig fmt` clean.

## Known follow-ups

Proxy/SOCKS and I2P/SAM dials remain blocking (multi-step handshakes needing their own state machines) but are now one per pump instead of ten back-to-back, cutting worst-case loop freeze from ~100s to ~10s. `peer_count` now excludes in-flight dials, so the UI can briefly show 0 peers while dialing — honest, but a visible change. Still open: per-relay health skip-list, DHT off-thread with a persisted routing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)