### PR TITLE
Expose per-file rows via session-published snapshot

### DIFF
--- a/desktop/src/api/types.ts
+++ b/desktop/src/api/types.ts
@@ -32,6 +32,15 @@ export interface Transfer {
   metaTotal: number;
   ratio: number | null;
   onion: string | null;
+  fileRows: FileEntry[];
+}
+
+/** One file in a transfer's Files detail tab. */
+export interface FileEntry {
+  name: string;
+  size: number;
+  pct: number;
+  prio: "normal" | "high" | "skip";
 }
 
 export interface Relay {

--- a/desktop/src/screens/Transfers.tsx
+++ b/desktop/src/screens/Transfers.tsx
@@ -134,12 +134,44 @@ function DetailTabs({ t }: { t: Transfer }) {
           </div>
         )}
 
-        {tab === "files" && (
-          <div className="sources-note">
-            The per-file list isn't exposed by the daemon yet. Total size:{" "}
-            <span className="mono">{fmtBytes(t.size)}</span>.
-          </div>
-        )}
+        {tab === "files" &&
+          (t.fileRows.length > 0 ? (
+            <table className="files-table">
+              <thead>
+                <tr>
+                  <th>File</th>
+                  <th className="num">Size</th>
+                  <th className="num">Done</th>
+                  <th>Priority</th>
+                </tr>
+              </thead>
+              <tbody>
+                {t.fileRows.map((f, i) => (
+                  <tr key={i}>
+                    <td className="file-name">
+                      <Icon
+                        name="file"
+                        size={14}
+                        style={{ color: "var(--fg-faint)" }}
+                      />
+                      <span className="mono">{f.name}</span>
+                    </td>
+                    <td className="num mono">{fmtBytes(f.size)}</td>
+                    <td className="num">{f.pct}%</td>
+                    <td>
+                      <span className={"prio prio-" + f.prio}>{f.prio}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="sources-note">
+              {t.size != null
+                ? `Total size: ${fmtBytes(t.size)}.`
+                : "No file info yet."}
+            </div>
+          ))}
 
         <div style={{ marginTop: 14 }}>
           <CopyField value={t.magnet || `magnet:?xt=urn:btih:${t.hash}`} full />

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -231,7 +231,8 @@ daemon does not read client frames; closing the socket ends the push.
   "peers": <n>, "seeds": <n>,
   // BEP 9 metadata bootstrap progress (magnet only); both 0 once metadata is in.
   "metaHave": <n>, "metaTotal": <n>,
-  "ratio": <float>|null, "onion": "<addr>"|null
+  "ratio": <float>|null, "onion": "<addr>"|null,
+  "fileRows": [FileEntry]
 }
 ```
 
@@ -250,12 +251,11 @@ daemon does not read client frames; closing the socket ends the push.
 
 These are part of the contract but return empty / derived values until later PRs:
 
-- **Per-transfer detail tabs** (`Peer` rows, the piece heatmap, per-file
-  progress, `Source` rows). `session.zig` mutates its `peers`/`active_pieces`
-  collections on its own thread; exposing them safely requires the session to
-  publish a locked snapshot. Until then `GET /api/transfers/<id>/peers` etc. are
-  not served, and snapshots expose transfer-level state only (peer *count*, real
-  `pct` from the bitfield, real rates).
+- **Per-transfer detail tabs** — `FileEntry` rows are now wired: the session
+  publishes a per-file snapshot (1 Hz from `maintenance`) with name, size, and
+  per-file completion from the bitfield, surfaced as `Transfer.fileRows` in
+  `GET /api/state` and the WebSocket push. `Peer` rows and the piece heatmap
+  remain follow-ups.
 - **"Seed a file" creation flow** — creating a torrent from a local file and Tor
   hidden-service generation. `seeds()` currently reflects transfers that have
   reached the seeding state.

--- a/src/api.zig
+++ b/src/api.zig
@@ -98,6 +98,10 @@ pub const Transfer = struct {
     ratio: ?f64 = null,
     /// .onion address when seeding as a hidden service; null otherwise.
     onion: ?[]const u8 = null,
+    /// Per-file rows for the Files detail tab. Populated from the session's
+    /// published file snapshot (1 Hz from maintenance). Empty for magnet
+    /// torrents until metadata resolves.
+    file_rows: []const FileEntry = &.{},
 };
 
 /// One peer in a transfer's Peers detail tab.
@@ -415,6 +419,10 @@ pub fn writeTransfer(j: *Json, t: Transfer) Allocator.Error!void {
     if (t.ratio) |r| try j.float(r) else try j.nullValue();
     try j.key("onion");
     if (t.onion) |o| try j.string(o) else try j.nullValue();
+    try j.key("fileRows");
+    try j.beginArray();
+    for (t.file_rows) |fr| try writeFileEntry(j, fr);
+    try j.endArray();
     try j.endObject();
 }
 

--- a/src/manager.zig
+++ b/src/manager.zig
@@ -1375,6 +1375,17 @@ fn snapshotTransfer(mt: *ManagedTransfer, arena: Allocator, now: i64) Allocator.
     const src = deriveSources(&src_buf, mt.route, mt.has_tracker, mt.want_nostr);
     const sources = try arena.dupe(api.SourceKind, src);
 
+    // Per-file rows from the session's published file snapshot.
+    const file_infos = mt.session.fileSnapshot(arena) catch &.{};
+    const file_rows = try arena.alloc(api.FileEntry, file_infos.len);
+    for (file_infos, 0..) |fi, i| {
+        file_rows[i] = .{
+            .name = fi.name,
+            .size = fi.size,
+            .pct = fi.pct,
+        };
+    }
+
     var eta_buf: [24]u8 = undefined;
     const remaining: u64 = if (p.total_length > 0 and pct < 100)
         p.total_length - (p.total_length * pct / 100)
@@ -1410,6 +1421,7 @@ fn snapshotTransfer(mt: *ManagedTransfer, arena: Allocator, now: i64) Allocator.
         .meta_total = p.meta_total,
         .ratio = if (status == .seeding or status == .complete) ratio else null,
         .onion = null,
+        .file_rows = file_rows,
     };
 }
 

--- a/src/session.zig
+++ b/src/session.zig
@@ -497,20 +497,18 @@ pub const Session = struct {
                 name_len += cl;
             }
 
-            // Per-file completion from the bitfield.
+            // Per-file completion, weighted by byte overlap for boundary
+            // pieces (a file occupying 1 byte of a piece shouldn't count
+            // that piece as fully complete for this file).
             const fstart = self.store.file_map.file_starts[fi];
             const flen = self.store.file_map.file_lengths[fi];
-            const first_p: u32 = @intCast(fstart / self.piece_len);
-            const last_p: u32 = @intCast((fstart + flen -| 1) / self.piece_len);
-            const total: u32 = last_p - first_p + 1;
-            var have: u32 = 0;
-            for (first_p..last_p + 1) |p| {
-                if (self.our_bitfield.hasPiece(@intCast(p))) have += 1;
-            }
-            const pct: u8 = if (total > 0)
-                @intCast(@min(@as(u64, have) * 100 / total, 100))
-            else
-                0;
+            const pct: u8 = computeFilePct(
+                self.our_bitfield,
+                fstart,
+                flen,
+                self.piece_len,
+                self.num_pieces,
+            );
 
             snap[written] = .{
                 .name = self.allocator.dupe(u8, name_buf[0..name_len]) catch continue,
@@ -2208,6 +2206,33 @@ pub const Session = struct {
         }
     }
 };
+
+/// Compute per-file completion percentage, weighted by byte overlap for
+/// boundary pieces. Returns 100 for zero-length files (no pieces needed).
+fn computeFilePct(
+    bf: piece_mod.Bitfield,
+    fstart: u64,
+    flen: u64,
+    piece_len: u64,
+    num_pieces: u32,
+) u8 {
+    if (flen == 0) return 100;
+    const first_p: u32 = @intCast(fstart / piece_len);
+    const fend = fstart + flen;
+    const last_p_raw = (fend - 1) / piece_len;
+    const last_p: u32 = @intCast(@min(last_p_raw, @as(u64, num_pieces) -| 1));
+
+    var have_bytes: u64 = 0;
+    for (first_p..last_p + 1) |p_idx| {
+        if (!bf.hasPiece(@intCast(p_idx))) continue;
+        const piece_start = @as(u64, p_idx) * piece_len;
+        const piece_end = piece_start + piece_len;
+        const overlap_start = @max(piece_start, fstart);
+        const overlap_end = @min(piece_end, fend);
+        if (overlap_end > overlap_start) have_bytes += overlap_end - overlap_start;
+    }
+    return @intCast(@min(have_bytes * 100 / flen, 100));
+}
 
 test "sampleRate counts block bytes as progress before a piece verifies" {
     // Regression: on a slow link (single I2P peer) a piece can take far longer

--- a/src/session.zig
+++ b/src/session.zig
@@ -154,6 +154,13 @@ pub const Session = struct {
     // pieces flaps the status between downloading and stalled.
     block_bytes_in: u64 = 0,
 
+    /// Guards the published per-file snapshot. Written by the session thread
+    /// in `maintenance` (1 Hz), read by `fileSnapshot` from the daemon thread.
+    file_snap_mutex: std.Thread.Mutex = .{},
+    /// Published per-file snapshot, or null before metadata is in. Owned by
+    /// the session; freed before each re-publish and in `deinit`.
+    file_snap: ?[]FileSnap = null,
+
     // Choking state
     last_unchoke_time: i64,
     last_optimistic_time: i64,
@@ -357,6 +364,7 @@ pub const Session = struct {
         if (self.metadata_download) |*md| md.deinit();
         if (self.listener) |*l| l.deinit();
         if (self.torrent_blob) |b| self.allocator.free(b);
+        self.freeFileSnapSlice(self.file_snap);
         self.allocator.free(self.output_dir);
         self.our_bitfield.deinit(self.allocator);
         self.store.deinit();
@@ -388,6 +396,14 @@ pub const Session = struct {
         /// Seconds since the last byte of real progress arrived. Lets the snapshot
         /// distinguish active "downloading" from "stalled" without a delta.
         idle_secs: i64,
+    };
+
+    /// One file's summary, published by the session thread for cross-thread
+    /// reads (the daemon's per-tick snapshot). Owned by `file_snap`.
+    pub const FileSnap = struct {
+        name: []u8,
+        size: u64,
+        pct: u8,
     };
 
     /// A copy of the resolved `.torrent` bytes, or null if metadata isn't in
@@ -424,6 +440,91 @@ pub const Session = struct {
             .meta_total = self.meta_total.load(.monotonic),
             .idle_secs = @max(0, std.time.timestamp() - last_prog),
         };
+    }
+
+    // ---- Per-file snapshot (published for cross-thread reads) ----
+
+    fn freeFileSnapSlice(self: *Session, snap: ?[]FileSnap) void {
+        if (snap) |s| {
+            for (s) |f| self.allocator.free(f.name);
+            self.allocator.free(s);
+        }
+    }
+
+    /// Copy the session's published per-file snapshot for cross-thread reads.
+    pub fn fileSnapshot(self: *Session, a: Allocator) Allocator.Error![]FileSnap {
+        self.file_snap_mutex.lock();
+        defer self.file_snap_mutex.unlock();
+        const snap = self.file_snap orelse return try a.alloc(FileSnap, 0);
+        const out = try a.alloc(FileSnap, snap.len);
+        for (snap, 0..) |f, i| {
+            out[i] = .{
+                .name = try a.dupe(u8, f.name),
+                .size = f.size,
+                .pct = f.pct,
+            };
+        }
+        return out;
+    }
+
+    /// Build and publish a per-file snapshot from `meta.files` + the bitfield.
+    /// Called from `maintenance` (1 Hz). For magnet torrents this is empty
+    /// until metadata resolves, then picks up the real file list.
+    fn publishFileSnap(self: *Session) void {
+        const count = self.meta.files.len;
+        if (count == 0 or self.piece_len == 0) {
+            self.file_snap_mutex.lock();
+            const old = self.file_snap;
+            self.file_snap = null;
+            self.file_snap_mutex.unlock();
+            self.freeFileSnapSlice(old);
+            return;
+        }
+
+        const snap = self.allocator.alloc(FileSnap, count) catch return;
+        var written: usize = 0;
+        for (self.meta.files, 0..) |file, fi| {
+            // Join path components with "/".
+            var name_buf: [1024]u8 = undefined;
+            var name_len: usize = 0;
+            for (file.path) |comp| {
+                if (name_len > 0 and name_len < name_buf.len) {
+                    name_buf[name_len] = '/';
+                    name_len += 1;
+                }
+                const cl = @min(comp.len, name_buf.len - name_len);
+                @memcpy(name_buf[name_len..][0..cl], comp[0..cl]);
+                name_len += cl;
+            }
+
+            // Per-file completion from the bitfield.
+            const fstart = self.store.file_map.file_starts[fi];
+            const flen = self.store.file_map.file_lengths[fi];
+            const first_p: u32 = @intCast(fstart / self.piece_len);
+            const last_p: u32 = @intCast((fstart + flen -| 1) / self.piece_len);
+            const total: u32 = last_p - first_p + 1;
+            var have: u32 = 0;
+            for (first_p..last_p + 1) |p| {
+                if (self.our_bitfield.hasPiece(@intCast(p))) have += 1;
+            }
+            const pct: u8 = if (total > 0)
+                @intCast(@min(@as(u64, have) * 100 / total, 100))
+            else
+                0;
+
+            snap[written] = .{
+                .name = self.allocator.dupe(u8, name_buf[0..name_len]) catch continue,
+                .size = file.length,
+                .pct = pct,
+            };
+            written += 1;
+        }
+
+        self.file_snap_mutex.lock();
+        const old = self.file_snap;
+        self.file_snap = snap[0..written];
+        self.file_snap_mutex.unlock();
+        self.freeFileSnapSlice(old);
     }
 
     /// Resample the download/upload rate. Called once per second from the
@@ -1576,6 +1677,8 @@ pub const Session = struct {
                 p.updatePipelineLimit(peer_dt);
                 self.expireStaleRequests(p, now);
             }
+            // Publish per-file snapshot for the daemon's cross-thread reads.
+            self.publishFileSnap();
         }
 
         // Run choking algorithm


### PR DESCRIPTION
## Summary
- The Files detail tab showed a placeholder ("per-file list isn't exposed") because the daemon never sent file-level data
- Root cause: the session never published per-file info (names, sizes, completion) for cross-thread reads
- The session now publishes a per-file snapshot (1 Hz from maintenance) with joined file paths, sizes, and per-file completion computed from the bitfield, surfaced as Transfer.fileRows

## What changed
- session.zig: FileSnap struct + file_snap_mutex/file_snap fields. publishFileSnap joins path components, computes per-file pct by counting bitfield pieces covering each file byte range. fileSnapshot copies for cross-thread reads.
- manager.zig: snapshotTransfer calls session.fileSnapshot(arena) and converts to api.FileEntry.
- api.zig: Transfer.file_rows serialized as fileRows in writeTransfer.
- Frontend: FileEntry type + fileRows on Transfer; Files tab renders real table matching design/transfers.jsx 1-1 (file icon, name, size, done %, priority badge).
- Docs: daemon-api.md Transfer type updated; "Not yet wired" reflects files are now wired.

## Test plan
- [x] zig build test passes
- [x] npx tsc --noEmit passes
- [ ] Manual: run a download, expand Files tab, verify real file names, sizes, and completion percentages
