### PR TITLE
fix(tracker): dispatch udp:// announces so `carl announce` works with UDP trackers

### DIFF
--- a/src/session.zig
+++ b/src/session.zig
@@ -6,7 +6,6 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const metainfo = @import("metainfo.zig");
 const tracker_mod = @import("tracker.zig");
-const udp_tracker = @import("udp_tracker.zig");
 const wire = @import("wire.zig");
 const piece_mod = @import("piece.zig");
 const storage_mod = @import("storage.zig");
@@ -2079,48 +2078,15 @@ pub const Session = struct {
         // trackers, and announcing over them directly would leak the real IP.
         // (I2P-native trackers are a follow-up.) Skip all clearnet trackers.
         if (self.anonymized() and self.proxy == null) return null;
-        if (std.mem.startsWith(u8, url, "udp://")) {
-            if (self.proxy != null) {
-                // UDP can't be tunneled through SOCKS/Tor.  Most public
-                // trackers serve both UDP and HTTP on the same host, so
-                // rewrite udp://host:port → http://host:port/announce and
-                // try through the proxy.
-                return self.tryUdpAsHttp(url, req);
-            }
-            return udp_tracker.announce(self.allocator, url, req) catch |err| {
-                log.warn("UDP tracker {s} failed: {}", .{ url, err });
-                return null;
-            };
-        } else if (url.len > 0) {
-            return tracker_mod.announce(self.allocator, url, req, self.proxy) catch |err| {
-                log.warn("HTTP tracker {s} failed: {}", .{ url, err });
-                return null;
-            };
-        } else {
-            return null;
-        }
-    }
+        if (url.len == 0) return null;
 
-    /// Rewrite a udp:// tracker URL to http:// and try an HTTP announce
-    /// through the proxy.  Many public trackers (opentrackr, openbittorrent,
-    /// torrent.eu.org, …) serve both protocols on the same host:port.
-    fn tryUdpAsHttp(self: *Session, udp_url: []const u8, req: tracker_mod.AnnounceRequest) ?tracker_mod.AnnounceResponse {
-        // udp://host:port[/anything] → http://host:port/announce
-        const host_start = "udp://".len;
-        const rest = udp_url[host_start..];
-        // Find end of host:port (first '/' or end of string)
-        const slash_pos = std.mem.indexOfScalar(u8, rest, '/');
-        const host_port = rest[0..(slash_pos orelse rest.len)];
-
-        var buf: [256]u8 = undefined;
-        const http_url = std.fmt.bufPrint(&buf, "http://{s}/announce", .{host_port}) catch return null;
-
-        const resp = tracker_mod.announce(self.allocator, http_url, req, self.proxy) catch |err| {
-            log.debug("HTTP rewrite of UDP tracker {s} failed: {}", .{ udp_url, err });
+        // tracker_mod.announce owns the transport choice (udp:// vs http://)
+        // and the fail-closed proxy rewrite, so the session and `carl announce`
+        // cannot drift apart on which trackers are safe to dial.
+        return tracker_mod.announce(self.allocator, url, req, self.proxy) catch |err| {
+            log.warn("tracker {s} failed: {t}", .{ url, err });
             return null;
         };
-        log.info("proxied: rewriting {s} → {s}", .{ udp_url, http_url });
-        return resp;
     }
 
     fn handleAnnounceResponse(self: *Session, resp: tracker_mod.AnnounceResponse) void {

--- a/src/tracker.zig
+++ b/src/tracker.zig
@@ -191,33 +191,44 @@ pub fn parseAnnounceResponse(
     };
 }
 
-/// Perform an HTTP tracker announce. Returns the parsed response. When `proxy`
-/// is set, the announce is tunneled through it (fail-closed: no direct request).
+/// Perform a tracker announce over whichever transport `announce_url` names.
+/// Returns the parsed response. When `proxy` is set, the announce is tunneled
+/// through it (fail-closed: no direct request).
+///
+/// This is the single dispatch point for every announce in carl — the session
+/// loop, `carl announce`, and the seeding paths all come through here, so the
+/// udp:// and proxy rules below cannot drift between callers.
 pub fn announce(
     allocator: Allocator,
     announce_url: []const u8,
     req: AnnounceRequest,
     proxy: ?proxy_mod.Proxy,
 ) TrackerError!AnnounceResponse {
-    // BEP 15: udp:// announce URLs go to the UDP tracker client. UDP cannot be
-    // tunneled through SOCKS/HTTP proxies, so with a proxy set we rewrite
-    // udp://host:port → http://host:port/announce (most public trackers serve
-    // both protocols on the same port) and tunnel that — the same fail-closed
-    // strategy Session.tryAnnounceUrl applies to session announces. This used
-    // to be session-only: `carl announce` (CLI) sent udp:// URLs down the HTTP
-    // path and failed with error.HttpError.
-    if (std.mem.startsWith(u8, announce_url, "udp://")) {
-        if (proxy != null) {
-            var buf: [512]u8 = undefined;
-            const http_url = udpAsHttpUrl(&buf, announce_url) orelse return error.HttpError;
-            return announceHttp(allocator, http_url, req, proxy);
-        }
-        return udp_tracker.announce(allocator, announce_url, req) catch |err| switch (err) {
-            error.OutOfMemory => error.OutOfMemory,
-            else => error.HttpError,
-        };
+    if (!std.mem.startsWith(u8, announce_url, "udp://")) {
+        return announceHttp(allocator, announce_url, req, proxy);
     }
-    return announceHttp(allocator, announce_url, req, proxy);
+
+    // BEP 15: udp:// goes to the UDP tracker client. UDP cannot be tunneled
+    // through SOCKS/HTTP proxies, so with a proxy set we must not dial it
+    // directly — that would leak the real IP. Rewrite
+    // udp://host:port → http://host:port/announce (most public trackers serve
+    // both protocols on the same port) and tunnel that instead.
+    if (proxy != null) {
+        var buf: [512]u8 = undefined;
+        const http_url = udpAsHttpUrl(&buf, announce_url) orelse return error.HttpError;
+        log.info("proxied: rewriting {s} -> {s}", .{ announce_url, http_url });
+        return announceHttp(allocator, http_url, req, proxy);
+    }
+
+    return udp_tracker.announce(allocator, announce_url, req) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        // TrackerError has no UDP-specific variant; log the real cause so a
+        // bare "HttpError" on a udp:// URL is still diagnosable.
+        else => {
+            log.warn("UDP tracker {s} failed: {t}", .{ announce_url, err });
+            return error.HttpError;
+        },
+    };
 }
 
 /// udp://host:port[/anything] → http://host:port/announce

--- a/src/tracker.zig
+++ b/src/tracker.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const bencode = @import("bencode.zig");
 const proxy_mod = @import("proxy.zig");
+const udp_tracker = @import("udp_tracker.zig");
 
 const log = std.log.scoped(.tracker);
 
@@ -193,6 +194,42 @@ pub fn parseAnnounceResponse(
 /// Perform an HTTP tracker announce. Returns the parsed response. When `proxy`
 /// is set, the announce is tunneled through it (fail-closed: no direct request).
 pub fn announce(
+    allocator: Allocator,
+    announce_url: []const u8,
+    req: AnnounceRequest,
+    proxy: ?proxy_mod.Proxy,
+) TrackerError!AnnounceResponse {
+    // BEP 15: udp:// announce URLs go to the UDP tracker client. UDP cannot be
+    // tunneled through SOCKS/HTTP proxies, so with a proxy set we rewrite
+    // udp://host:port → http://host:port/announce (most public trackers serve
+    // both protocols on the same port) and tunnel that — the same fail-closed
+    // strategy Session.tryAnnounceUrl applies to session announces. This used
+    // to be session-only: `carl announce` (CLI) sent udp:// URLs down the HTTP
+    // path and failed with error.HttpError.
+    if (std.mem.startsWith(u8, announce_url, "udp://")) {
+        if (proxy != null) {
+            var buf: [512]u8 = undefined;
+            const http_url = udpAsHttpUrl(&buf, announce_url) orelse return error.HttpError;
+            return announceHttp(allocator, http_url, req, proxy);
+        }
+        return udp_tracker.announce(allocator, announce_url, req) catch |err| switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => error.HttpError,
+        };
+    }
+    return announceHttp(allocator, announce_url, req, proxy);
+}
+
+/// udp://host:port[/anything] → http://host:port/announce
+fn udpAsHttpUrl(buf: []u8, udp_url: []const u8) ?[]const u8 {
+    const rest = udp_url["udp://".len..];
+    const slash_pos = std.mem.indexOfScalar(u8, rest, '/');
+    const host_port = rest[0 .. slash_pos orelse rest.len];
+    const url = std.fmt.bufPrint(buf, "http://{s}/announce", .{host_port}) catch return null;
+    return url;
+}
+
+fn announceHttp(
     allocator: Allocator,
     announce_url: []const u8,
     req: AnnounceRequest,
@@ -486,4 +523,16 @@ test "parse IPv4" {
     try std.testing.expect(parseIpv4("invalid") == null);
     try std.testing.expect(parseIpv4("1.2.3") == null);
     try std.testing.expect(parseIpv4("1.2.3.4.5") == null);
+}
+
+test "udp as http url rewrite" {
+    var buf: [512]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "http://tracker.example.com:1337/announce",
+        udpAsHttpUrl(&buf, "udp://tracker.example.com:1337/announce").?,
+    );
+    try std.testing.expectEqualStrings(
+        "http://tracker.example.com:1337/announce",
+        udpAsHttpUrl(&buf, "udp://tracker.example.com:1337").?,
+    );
 }


### PR DESCRIPTION
## Problem

`carl announce <file.torrent>` with a `udp://` tracker always failed with `error.HttpError` — no UDP packet was ever sent. The BEP 15 UDP client exists and is wired into `Session.tryAnnounceUrl`, but the shared `tracker.announce()` used by the CLI announce path only speaks HTTP.

Reproduced in the simulation harness (scenario `s03_udp_tracker`): `carl announce` against a stub BEP 15 tracker on loopback → `error(cli): tracker announce failed: error.HttpError`, while downloads through the same tracker worked (session path dispatches correctly).

## Fix

`tracker.announce()` now dispatches `udp://` URLs itself:

- **no proxy** → `udp_tracker.announce()` (BEP 15 connect + announce)
- **proxy set** → UDP can't be tunneled through SOCKS/HTTP: rewrite `udp://host:port` → `http://host:port/announce` and tunnel that through the proxy — identical fail-closed strategy to `Session.tryAnnounceUrl`, so behavior stays consistent between the CLI and session paths (which keeps its own dispatch).

Added a unit test for the `udpAsHttpUrl` rewrite (path suffix and bare host:port).

`zig build test` passes.