### PR TITLE
perf(choking): unchoke immediately on interest when a slot is free (TTFB 17s → 0.1s)

### DIFF
--- a/src/session.zig
+++ b/src/session.zig
@@ -1047,6 +1047,23 @@ pub const Session = struct {
             },
             .interested => {
                 p.peer_interested = true;
+                // Opportunistic unchoke: if an upload slot is free, start
+                // uploading immediately instead of waiting up to
+                // unchoke_interval_secs (10s) for the next periodic
+                // recompute. Small swarms (a lone interested leecher) used to
+                // sit idle for as much as 10s before the first byte — the
+                // periodic tit-for-tat sort still re-evaluates every cycle
+                // and can choke this peer again if better peers appear.
+                if (p.am_choking and p.state == .active) {
+                    var unchoked: usize = 0;
+                    for (self.peers.items) |o| {
+                        if (o.state == .active and !o.am_choking) unchoked += 1;
+                    }
+                    if (unchoked < unchoke_slots) {
+                        p.am_choking = false;
+                        p.enqueueMessage(.unchoke) catch {};
+                    }
+                }
             },
             .not_interested => {
                 p.peer_interested = false;


### PR DESCRIPTION
## Problem

Upload slots were only recomputed by the periodic choking algorithm (every `unchoke_interval_secs` = 10s). A newly connected peer that sent `interested` waited for the **next** recompute to be unchoked — even when every upload slot was free and it was the only peer.

Simulated timeline (loopback, 1 seeder + 1 leecher, 64 MiB torrent):

```
t=0.13s  announce -> tracker
t=9.3s   tracker response, peer connects, bitfield exchanged
t=17.3s  unchoke finally arrives  <- 8s idle, pure timer wait
t=17.3s  first piece
```

Time-to-first-byte on a healthy loopback swarm: **up to 10s of pure dead time**, every download start. End-to-end for a 64 MiB torrent: ~8.1s, dominated by the wait.

## Fix

On receiving `interested`, if `p.am_choking` and fewer than `unchoke_slots` peers are currently unchoked, send `unchoke` immediately. The periodic tit-for-tat recompute is unchanged and still reclaims slots as needed (it can choke this peer again one cycle later if better candidates appear — same as any client's opportunistic unchoke).

## Measured

- TTFB (first piece verified): **17s → 0.12s** worst case
- 64 MiB loopback download: **8.1s → 1.2s** (~54 MiB/s), sha256 verified

`zig build test` passes. Found by the feature-simulation harness (scenario `s04_download_torrent` timing profile).