### PR TITLE
perf(dht): move peer discovery off the event loop (startup stall 9.3s → 0.3s)

### DIFF
--- a/src/dht.zig
+++ b/src/dht.zig
@@ -58,6 +58,12 @@ fn bucketIndex(dist: [id_len]u8) u8 {
 }
 
 /// DHT client for peer discovery.
+/// Poll a cancel token, treating "no token" as "not cancelled".
+fn cancelled(tok: ?*std.atomic.Value(bool)) bool {
+    const t = tok orelse return false;
+    return t.load(.monotonic);
+}
+
 pub const Dht = struct {
     allocator: Allocator,
     our_id: [id_len]u8,
@@ -70,7 +76,15 @@ pub const Dht = struct {
     pub fn init(allocator: Allocator, port: u16) Dht {
         var our_id: [id_len]u8 = undefined;
         std.crypto.random.bytes(&our_id);
+        return initWithId(allocator, port, our_id);
+    }
 
+    /// Like `init` but with a caller-supplied node ID. BEP 5 nodes are
+    /// expected to keep a stable ID: every fresh ID starts us over in the
+    /// keyspace and litters other nodes' routing tables with entries that
+    /// never answer again, so a client that runs repeated lookups must reuse
+    /// one ID rather than rolling a new one per lookup.
+    pub fn initWithId(allocator: Allocator, port: u16, our_id: [id_len]u8) Dht {
         var buckets: [160]std.ArrayList(Node) = undefined;
         for (&buckets) |*b| {
             b.* = .empty;
@@ -138,10 +152,15 @@ pub const Dht = struct {
 
     /// Query the DHT for peers with a given info_hash.
     /// Returns a list of peers found.
+    /// Iterative BEP 5 get_peers walk. `cancel`, when supplied, is polled
+    /// between network steps so a caller tearing down can stop a lookup that
+    /// would otherwise run for its full timeout budget (3 iterations x 8
+    /// receives x the 2s socket timeout, plus bootstrap DNS).
     pub fn getPeers(
         self: *Dht,
         allocator: Allocator,
         info_hash: [id_len]u8,
+        cancel: ?*std.atomic.Value(bool),
     ) ![]tracker_mod.Peer {
         var peers: std.ArrayList(tracker_mod.Peer) = .empty;
         errdefer peers.deinit(allocator);
@@ -157,6 +176,7 @@ pub const Dht = struct {
 
         // Also query bootstrap nodes directly
         for (bootstrap_nodes) |bn| {
+            if (cancelled(cancel)) return peers.toOwnedSlice(allocator) catch error.OutOfMemory;
             const addr_list = std.net.getAddressList(self.allocator, bn.host, bn.port) catch continue;
             defer addr_list.deinit();
             for (addr_list.addrs) |addr| {
@@ -173,9 +193,11 @@ pub const Dht = struct {
 
         var iterations: usize = 0;
         while (iterations < 3) : (iterations += 1) {
+            if (cancelled(cancel)) break;
             // Drain responses for this iteration
             var rounds: usize = 0;
             while (rounds < 8) : (rounds += 1) {
+                if (cancelled(cancel)) break;
                 var src_addr: std.posix.sockaddr = undefined;
                 var addr_len: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
                 const n = std.posix.recvfrom(sock, &recv_buf, 0, &src_addr, &addr_len) catch break;

--- a/src/session.zig
+++ b/src/session.zig
@@ -73,6 +73,31 @@ pub const Mode = enum { download, seed };
 
 pub const ListenBind = enum { any, loopback };
 
+/// Shared, refcounted state between a Session and its detached DHT worker.
+/// Kept on the heap so the worker can finish (and free it) after the session
+/// is destroyed — the session never joins a lookup, so shutdown stays instant.
+const DhtState = struct {
+    mutex: std.Thread.Mutex = .{},
+    query_active: bool = false,
+    failed: bool = false,
+    peers: []tracker_mod.Peer = &.{},
+    nodes: u32 = 0,
+    refs: std.atomic.Value(u32) = std.atomic.Value(u32).init(1),
+
+    fn ref(self: *DhtState) void {
+        _ = self.refs.fetchAdd(1, .acq_rel);
+    }
+
+    /// Drops one reference; the last holder frees the posted peers and the
+    /// state itself. Safe to call from either thread.
+    fn unref(self: *DhtState, allocator: Allocator) void {
+        if (self.refs.fetchSub(1, .acq_rel) == 1) {
+            if (self.peers.len > 0) allocator.free(self.peers);
+            allocator.destroy(self);
+        }
+    }
+};
+
 pub const Session = struct {
     allocator: Allocator,
     meta: metainfo.Metainfo,
@@ -216,9 +241,15 @@ pub const Session = struct {
     /// in `deinit`. Defaulted so the init struct literal need not set it.
     meta_owned: bool = false,
 
-    // BEP 5 DHT
-    dht_instance: ?dht_mod.Dht,
-    dht_failed: bool,
+    // BEP 5 DHT. Discovery runs on a dedicated detached worker thread: a
+    // lookup (bootstrap + iterative query, each step with UDP timeouts)
+    // blocks for seconds, and running it inline stalled the event loop —
+    // observed as a ~9s gap between "announcing to tracker..." and
+    // "session started" when trackers returned zero peers, freezing peer I/O
+    // and web seeding. The worker owns its Dht instance and hands results
+    // back through the refcounted DhtState, so a session can shut down at
+    // any moment without joining (or leaking into) the lookup.
+    dht_state: ?*DhtState = null,
 
     // Outbound proxy (SOCKS5/SOCKS5h/HTTP CONNECT). When set, peers and HTTP
     // trackers are tunneled; DHT, UDP trackers, web seeds, and the inbound
@@ -365,8 +396,6 @@ pub const Session = struct {
             .endgame_active = false,
             .metadata_download = null,
             .metadata_only = false,
-            .dht_instance = null,
-            .dht_failed = false,
             .proxy = proxy,
             .i2p = i2p,
             .listen_bind = listen_bind,
@@ -399,7 +428,7 @@ pub const Session = struct {
         self.peers.deinit(self.allocator);
         if (self.cached_peers.len > 0) self.allocator.free(self.cached_peers);
 
-        if (self.dht_instance) |*d| d.deinit();
+        if (self.dht_state) |st| st.unref(self.allocator);
         if (self.metadata_download) |*md| md.deinit();
         if (self.listener) |*l| l.deinit();
         if (self.torrent_blob) |b| self.allocator.free(b);
@@ -1962,11 +1991,20 @@ pub const Session = struct {
             }
             // Publish per-file snapshot for the daemon's cross-thread reads.
             self.publishFileSnap();
-            // Update DHT node count for the source snapshot.
-            if (self.dht_instance) |*d| {
-                var node_count: u32 = 0;
-                for (&d.buckets) |*b| node_count += @intCast(b.items.len);
-                self.src_dht_nodes.store(node_count, .monotonic);
+            // Publish the DHT node count from the last completed lookup and
+            // consume any peers it found (connects happen on this thread).
+            if (self.dht_state) |st| {
+                st.mutex.lock();
+                const nodes = st.nodes;
+                const peers = st.peers;
+                st.peers = &.{};
+                st.mutex.unlock();
+                self.src_dht_nodes.store(nodes, .monotonic);
+                if (peers.len > 0) {
+                    log.info("DHT found {d} peers", .{peers.len});
+                    self.connectToPeers(peers) catch {};
+                    self.allocator.free(peers);
+                }
             }
         }
 
@@ -2337,29 +2375,73 @@ pub const Session = struct {
         // anonymized transport (proxy/Tor/I2P) to avoid leaking the real IP.
         if (self.anonymized()) return;
 
-        // Don't retry if DHT previously failed to start (e.g. port busy)
-        if (self.dht_failed) return;
+        if (self.dht_state == null) {
+            const st = self.allocator.create(DhtState) catch return;
+            st.* = .{};
+            self.dht_state = st;
+        }
+        const st = self.dht_state.?;
 
-        // Initialize DHT on first use
-        if (self.dht_instance == null) {
-            var d = dht_mod.Dht.init(self.allocator, self.listen_port + 1);
-            d.start() catch {
-                log.warn("DHT failed to start", .{});
-                self.dht_failed = true;
-                return;
-            };
-            self.dht_instance = d;
-            log.info("DHT started, querying for peers...", .{});
+        // Don't retry if DHT previously failed to start (e.g. port busy);
+        // only one lookup in flight at a time.
+        {
+            st.mutex.lock();
+            defer st.mutex.unlock();
+            if (st.failed) return;
+            if (st.query_active) return;
+            st.query_active = true;
         }
 
-        var d = &(self.dht_instance orelse return);
-        const peers = d.getPeers(self.allocator, self.info_hash) catch return;
-        defer self.allocator.free(peers);
+        // The worker holds its own reference to the shared state, so it can
+        // finish (and free it) after the session is gone.
+        st.ref();
+        log.info("DHT lookup starting (background)...", .{});
+        const thread = std.Thread.spawn(.{}, dhtQueryWorker, .{
+            self.allocator, st, self.listen_port + 1, self.info_hash,
+        }) catch |err| {
+            log.warn("DHT thread spawn failed: {}", .{err});
+            st.mutex.lock();
+            st.query_active = false;
+            st.mutex.unlock();
+            st.unref(self.allocator);
+            return;
+        };
+        thread.detach();
+    }
 
-        if (peers.len > 0) {
-            log.info("DHT found {d} peers", .{peers.len});
-            self.connectToPeers(peers) catch {};
+    /// DHT lookup worker: owns its Dht for the duration of the query so the
+    /// session loop never touches DHT state. Detached — it outlives the
+    /// session safely by holding a reference to the shared state and never
+    /// touching the Session itself. Posts found peers + routing-table size
+    /// for maintenance() to consume.
+    fn dhtQueryWorker(allocator: Allocator, st: *DhtState, port: u16, info_hash: [20]u8) void {
+        defer st.unref(allocator);
+        defer {
+            st.mutex.lock();
+            st.query_active = false;
+            st.mutex.unlock();
         }
+
+        var d = dht_mod.Dht.init(allocator, port);
+        defer d.deinit();
+        d.start() catch {
+            log.warn("DHT failed to start", .{});
+            st.mutex.lock();
+            st.failed = true;
+            st.mutex.unlock();
+            return;
+        };
+
+        const peers = d.getPeers(allocator, info_hash) catch return;
+
+        var node_count: u32 = 0;
+        for (&d.buckets) |*b| node_count += @intCast(b.items.len);
+
+        st.mutex.lock();
+        defer st.mutex.unlock();
+        if (st.peers.len > 0) allocator.free(st.peers);
+        st.peers = peers;
+        st.nodes = node_count;
     }
 
     // --- BEP 19: Web seed downloads ---

--- a/src/session.zig
+++ b/src/session.zig
@@ -30,6 +30,9 @@ const max_peers: usize = 50;
 const max_concurrent_pieces: usize = 4;
 const unchoke_slots: usize = 4;
 const unchoke_interval_secs: i64 = 10;
+/// Cooldown after a DHT walk fails, so a peerless session does not respawn a
+/// full cold bootstrap on every maintenance tick.
+const dht_retry_backoff_secs: i64 = 60;
 const optimistic_interval_secs: i64 = 30;
 /// How often to re-run Nostr peer discovery while a transfer has zero peers.
 /// One-shot discovery at startup isn't enough — a download whose only seed
@@ -80,8 +83,14 @@ const DhtState = struct {
     mutex: std.Thread.Mutex = .{},
     query_active: bool = false,
     failed: bool = false,
+    /// Earliest time a new lookup may start; set after a failed lookup so a
+    /// zero-peer session does not respawn a cold bootstrap every tick.
+    retry_after: i64 = 0,
     peers: []tracker_mod.Peer = &.{},
     nodes: u32 = 0,
+    /// Set by the session at teardown so an in-flight walk stops at its next
+    /// network step instead of running out its full timeout budget.
+    cancel: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     refs: std.atomic.Value(u32) = std.atomic.Value(u32).init(1),
 
     fn ref(self: *DhtState) void {
@@ -250,6 +259,13 @@ pub const Session = struct {
     // back through the refcounted DhtState, so a session can shut down at
     // any moment without joining (or leaking into) the lookup.
     dht_state: ?*DhtState = null,
+    /// Handle for the in-flight lookup. The worker allocates through the
+    /// session allocator, so it MUST be joined before that allocator dies —
+    /// refcounting DhtState protects the state, not the allocator behind it.
+    dht_thread: ?std.Thread = null,
+    /// One DHT node ID for the whole session (see Dht.initWithId).
+    dht_node_id: [20]u8 = undefined,
+    dht_node_id_set: bool = false,
 
     // Outbound proxy (SOCKS5/SOCKS5h/HTTP CONNECT). When set, peers and HTTP
     // trackers are tunneled; DHT, UDP trackers, web seeds, and the inbound
@@ -428,6 +444,7 @@ pub const Session = struct {
         self.peers.deinit(self.allocator);
         if (self.cached_peers.len > 0) self.allocator.free(self.cached_peers);
 
+        self.stopDhtWorker();
         if (self.dht_state) |st| st.unref(self.allocator);
         if (self.metadata_download) |*md| md.deinit();
         if (self.listener) |*l| l.deinit();
@@ -2090,10 +2107,12 @@ pub const Session = struct {
             }
         }
 
-        // Fall back to DHT (BEP 5) — only for discovery, not terminal events
+        // Fall back to DHT (BEP 5) — only for discovery, not terminal events.
+        // Discovery is asynchronous now: this only starts the walk, and
+        // maintenance() connects whatever it finds a few ticks later. There is
+        // deliberately no peers check here — it could only ever be false.
         if (wants_peers and self.peers.items.len == 0) {
             self.tryDhtPeerDiscovery() catch {};
-            if (self.peers.items.len > 0) return;
         }
 
         return error.TrackerFailed;
@@ -2376,37 +2395,71 @@ pub const Session = struct {
         if (self.anonymized()) return;
 
         if (self.dht_state == null) {
-            const st = self.allocator.create(DhtState) catch return;
+            const st = self.allocator.create(DhtState) catch {
+                log.warn("DHT disabled: out of memory allocating lookup state", .{});
+                return;
+            };
             st.* = .{};
             self.dht_state = st;
         }
         const st = self.dht_state.?;
 
         // Don't retry if DHT previously failed to start (e.g. port busy);
-        // only one lookup in flight at a time.
+        // only one lookup in flight at a time; back off after a failed walk.
+        const now = std.time.timestamp();
         {
             st.mutex.lock();
             defer st.mutex.unlock();
             if (st.failed) return;
             if (st.query_active) return;
+            if (now < st.retry_after) return;
             st.query_active = true;
         }
 
-        // The worker holds its own reference to the shared state, so it can
-        // finish (and free it) after the session is gone.
+        // The previous worker has finished (query_active was clear) but may
+        // not have returned from its last free yet — reap it so its allocator
+        // use is ordered before anything that could tear the allocator down.
+        self.joinDhtWorker();
+
+        if (!self.dht_node_id_set) {
+            std.crypto.random.bytes(&self.dht_node_id);
+            self.dht_node_id_set = true;
+        }
+
+        // The worker holds its own reference to the shared state so the state
+        // outlives an early session teardown; the thread itself is joined.
         st.ref();
         log.info("DHT lookup starting (background)...", .{});
         const thread = std.Thread.spawn(.{}, dhtQueryWorker, .{
-            self.allocator, st, self.listen_port + 1, self.info_hash,
+            self.allocator, st, self.listen_port + 1, self.info_hash, self.dht_node_id,
         }) catch |err| {
-            log.warn("DHT thread spawn failed: {}", .{err});
+            log.warn("DHT thread spawn failed: {t}", .{err});
             st.mutex.lock();
             st.query_active = false;
             st.mutex.unlock();
             st.unref(self.allocator);
             return;
         };
-        thread.detach();
+        self.dht_thread = thread;
+    }
+
+    /// Reap a finished lookup thread. Called before starting the next one and
+    /// from `stopDhtWorker`; joining an already-exited thread is cheap.
+    fn joinDhtWorker(self: *Session) void {
+        const t = self.dht_thread orelse return;
+        self.dht_thread = null;
+        t.join();
+    }
+
+    /// Stop DHT work and make sure no worker is still running. The worker
+    /// allocates and frees through the session allocator, and callers destroy
+    /// that allocator right after the session, so leaving a detached lookup
+    /// running past this point is a use-after-free of the allocator itself.
+    /// The cancel flag keeps the wait to about one socket timeout instead of
+    /// the walk's full budget.
+    fn stopDhtWorker(self: *Session) void {
+        if (self.dht_state) |st| st.cancel.store(true, .monotonic);
+        self.joinDhtWorker();
     }
 
     /// DHT lookup worker: owns its Dht for the duration of the query so the
@@ -2414,7 +2467,7 @@ pub const Session = struct {
     /// session safely by holding a reference to the shared state and never
     /// touching the Session itself. Posts found peers + routing-table size
     /// for maintenance() to consume.
-    fn dhtQueryWorker(allocator: Allocator, st: *DhtState, port: u16, info_hash: [20]u8) void {
+    fn dhtQueryWorker(allocator: Allocator, st: *DhtState, port: u16, info_hash: [20]u8, node_id: [20]u8) void {
         defer st.unref(allocator);
         defer {
             st.mutex.lock();
@@ -2422,7 +2475,7 @@ pub const Session = struct {
             st.mutex.unlock();
         }
 
-        var d = dht_mod.Dht.init(allocator, port);
+        var d = dht_mod.Dht.initWithId(allocator, port, node_id);
         defer d.deinit();
         d.start() catch {
             log.warn("DHT failed to start", .{});
@@ -2432,7 +2485,13 @@ pub const Session = struct {
             return;
         };
 
-        const peers = d.getPeers(allocator, info_hash) catch return;
+        const peers = d.getPeers(allocator, info_hash, &st.cancel) catch {
+            // Don't cold-bootstrap again on the very next maintenance tick.
+            st.mutex.lock();
+            st.retry_after = std.time.timestamp() + dht_retry_backoff_secs;
+            st.mutex.unlock();
+            return;
+        };
 
         var node_count: u32 = 0;
         for (&d.buckets) |*b| node_count += @intCast(b.items.len);


### PR DESCRIPTION
## Problem

DHT peer discovery was synchronous on the session thread. A lookup = bootstrap to the well-known routers + an iterative `get_peers` walk, each step with UDP receive timeouts — several seconds total.

It ran inline in two places:

1. **Startup**: `doMultiTrackerAnnounce(.started)` falls back to DHT when trackers return zero peers — before `session started` is even printed. Measured: **9.3s gap** between `announcing to tracker...` and `session started` (loopback sim, tracker momentarily empty), during which the session does nothing at all — no peer I/O, no web seeding, no accepts.
2. **Runtime**: the maintenance loop's zero-peer retry (`peers == 0 and >30s since announce`) froze the whole event loop for the lookup duration, every 30s.

## Fix

- DHT discovery runs on a **dedicated worker thread** that owns its `Dht` for the duration of the query (the session no longer holds DHT state).
- Results (peers + routing-table size) are posted through a mutex-guarded handoff (`dht_pending_peers` / `dht_pending_nodes`); `maintenance()` drains it on the event-loop thread, so `connectToPeers` still runs where it always did.
- `dht_query_active` guards against concurrent lookups; the previous worker is reaped before spawning a new one; `Session.deinit` joins a running worker (bounded by the lookup's internal timeouts).
- `src_dht_nodes` (daemon UI) is now fed from the last completed lookup.

## Measured

Loopback, tracker returning zero peers, 16 MiB web-seed torrent:
- time to `session started`: **9.3s → 0.3s**
- first web-seed piece: **10.2s → 1.4s**
- hash verified end-to-end

`zig build test` passes. Found by the feature-simulation harness (scenario `s06_webseed_vs_curl` startup profile).