### PR TITLE
fix(dht): bootstrap robustness — wider router list, deeper walk, persisted node cache

### DIFF
--- a/src/dht.zig
+++ b/src/dht.zig
@@ -24,11 +24,20 @@ pub const Node = struct {
     address: std.net.Address,
 };
 
-/// Well-known bootstrap nodes.
+/// Well-known bootstrap nodes. Kept deliberately broad: routers die or
+/// degrade (observed in the wild: router.bittorrent.com and router.utorrent.com
+/// timing out for whole residential networks while transmissionbt answers with
+/// a single dead-end node). A client starting with an empty table needs
+/// several live, generous routers to have a chance.
 const bootstrap_nodes = [_]struct { host: []const u8, port: u16 }{
     .{ .host = "router.bittorrent.com", .port = 6881 },
     .{ .host = "dht.transmissionbt.com", .port = 6881 },
     .{ .host = "router.utorrent.com", .port = 6881 },
+    .{ .host = "dht.libtorrent.org", .port = 25401 },
+    .{ .host = "dht.bluetigers.club", .port = 6881 },
+    .{ .host = "dht.anacrolix.link", .port = 6881 },
+    .{ .host = "router.silotis.us", .port = 6881 },
+    .{ .host = "dht.aelitis.com", .port = 6881 },
 };
 
 /// XOR distance between two node IDs.
@@ -192,7 +201,7 @@ pub const Dht = struct {
         const sock = self.sock orelse return peers.toOwnedSlice(allocator) catch return error.OutOfMemory;
 
         var iterations: usize = 0;
-        while (iterations < 3) : (iterations += 1) {
+        while (iterations < 8) : (iterations += 1) {
             if (cancelled(cancel)) break;
             // Drain responses for this iteration
             var rounds: usize = 0;
@@ -437,4 +446,175 @@ test "add compact nodes" {
         total += b.items.len;
     }
     try std.testing.expectEqual(@as(usize, 1), total);
+}
+
+// --- Routing-table persistence ------------------------------------------------
+//
+// A fresh client with an empty table is at the mercy of the well-known
+// routers; several of them are chronically dead or answer with a single
+// dead-end node (observed in the wild). Persisting learned nodes across
+// sessions gives every later lookup a warm table, exactly like libtorrent's
+// dht_state. Format: u32 LE count, then per node 20B id + 4B IPv4 + 2B BE port.
+//
+// All file I/O here goes through raw syscalls (std.posix.system) instead of
+// std.fs: the cache is a pure optimization and must never be able to abort
+// the process. std.fs wrappers contain `unreachable` branches for errno paths
+// they consider impossible (EFAULT/BADF) and an inline length assert in
+// toPosixPath — under the detached DHT worker a corrupted slice hit exactly
+// that assert once and killed a seeder mid-lookup. Raw syscalls let us treat
+// every failure as "no cache this time".
+
+/// Max nodes written to the cache file.
+pub const node_cache_max: usize = 64;
+
+/// NUL-terminate `path` into `buf`; null when it does not fit.
+fn pathZ(buf: []u8, path: []const u8) ?[*:0]const u8 {
+    if (path.len + 1 > buf.len) return null;
+    @memcpy(buf[0..path.len], path);
+    buf[path.len] = 0;
+    return @ptrCast(buf.ptr);
+}
+
+/// Write up to `node_cache_max` routing-table nodes to `path`. Best-effort:
+/// every failure is silently ignored.
+pub fn saveNodeCache(self: *const Dht, path: []const u8) void {
+    const c = std.posix.system;
+
+    var buf: [4 + node_cache_max * 26]u8 = undefined;
+    var n: usize = 0;
+    outer: for (&self.buckets) |*b| {
+        for (b.items) |node| {
+            if (n >= node_cache_max) break :outer;
+            if (node.address.any.family != std.posix.AF.INET) continue;
+            @memcpy(buf[4 + n * 26 ..][0..20], &node.id);
+            const ip4: [4]u8 = @bitCast(node.address.in.sa.addr);
+            buf[4 + n * 26 + 20] = ip4[0];
+            buf[4 + n * 26 + 21] = ip4[1];
+            buf[4 + n * 26 + 22] = ip4[2];
+            buf[4 + n * 26 + 23] = ip4[3];
+            const port = node.address.getPort();
+            buf[4 + n * 26 + 24] = @intCast(port >> 8);
+            buf[4 + n * 26 + 25] = @intCast(port & 0xff);
+            n += 1;
+        }
+    }
+    if (n == 0) return;
+    std.mem.writeInt(u32, buf[0..4], @intCast(n), .little);
+
+    const total = 4 + n * 26;
+
+    // Write to "<path>.tmp" and rename over the destination. Opening the real
+    // path with TRUNC would destroy a good cache the moment anything after the
+    // open fails, leaving the next session to cold-start — the opposite of
+    // what the cache is for.
+    var tpbuf: [512]u8 = undefined;
+    var tmp_path_buf: [512]u8 = undefined;
+    const tmp_path = std.fmt.bufPrint(&tmp_path_buf, "{s}.tmp", .{path}) catch return;
+    const tp = pathZ(&tpbuf, tmp_path) orelse return;
+
+    var pbuf: [512]u8 = undefined;
+    const p = pathZ(&pbuf, path) orelse return;
+
+    const oflags: c.O = .{ .ACCMODE = .WRONLY, .CREAT = true, .TRUNC = true };
+    const fd = c.openat(std.posix.AT.FDCWD, tp, oflags, @as(c.mode_t, 0o644));
+    if (fd < 0) return;
+    var ok = false;
+    defer {
+        _ = c.close(fd);
+        if (!ok) _ = c.unlinkat(std.posix.AT.FDCWD, tp, 0);
+    }
+
+    var off: usize = 0;
+    while (off < total) {
+        // `total - off`, NOT `buf[off..].len`: buf is `undefined` past the
+        // payload, so writing its full length would append the uninitialized
+        // tail of a stack buffer to a file on disk.
+        const rc = c.write(fd, buf[off..].ptr, total - off);
+        if (rc <= 0) return; // error or nothing written; best-effort
+        off += @intCast(rc);
+    }
+    if (c.renameat(std.posix.AT.FDCWD, tp, std.posix.AT.FDCWD, p) != 0) return;
+    ok = true;
+}
+
+/// Load a previously saved node cache into the routing table. Returns how
+/// many nodes were inserted. Missing/corrupt file is not an error.
+pub fn loadNodeCache(self: *Dht, path: []const u8) usize {
+    const c = std.posix.system;
+
+    var pbuf: [512]u8 = undefined;
+    const p = pathZ(&pbuf, path) orelse return 0;
+    const oflags: c.O = .{ .ACCMODE = .RDONLY };
+    const fd = c.openat(std.posix.AT.FDCWD, p, oflags, @as(c.mode_t, 0));
+    if (fd < 0) return 0;
+    defer _ = c.close(fd);
+
+    var hdr: [4]u8 = undefined;
+    if (!readFull(c, fd, &hdr)) return 0;
+    const count = std.mem.readInt(u32, &hdr, .little);
+    if (count == 0 or count > 4096) return 0;
+
+    var inserted: usize = 0;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        var entry: [26]u8 = undefined;
+        if (!readFull(c, fd, &entry)) break;
+        const port = (@as(u16, entry[24]) << 8) | @as(u16, entry[25]);
+        if (port == 0) continue;
+        var id: [id_len]u8 = undefined;
+        @memcpy(&id, entry[0..20]);
+        const addr = std.net.Address.initIp4(.{ entry[20], entry[21], entry[22], entry[23] }, port);
+        self.addNode(.{ .id = id, .address = addr });
+        inserted += 1;
+    }
+    return inserted;
+}
+
+fn readFull(c: anytype, fd: c_int, buf: []u8) bool {
+    var off: usize = 0;
+    while (off < buf.len) {
+        const rc = c.read(fd, buf[off..].ptr, buf[off..].len);
+        if (rc <= 0) return false;
+        off += @intCast(rc);
+    }
+    return true;
+}
+
+test "saveNodeCache writes only the payload, not the stack tail" {
+    const a = std.testing.allocator;
+    var d = Dht.init(a, 16999);
+    defer d.deinit();
+
+    // Two IPv4 nodes -> header(4) + 2*26 = 56 bytes on disk. Writing
+    // buf[off..].len instead of total-off produced the full 1668-byte buffer,
+    // i.e. 1612 bytes of uninitialized stack memory appended to the file.
+    const id1: [id_len]u8 = [_]u8{1} ** id_len;
+    const id2: [id_len]u8 = [_]u8{2} ** id_len;
+    d.buckets[0].append(a, .{
+        .id = id1,
+        .address = std.net.Address.initIp4(.{ 10, 0, 0, 1 }, 6881),
+    }) catch unreachable;
+    d.buckets[0].append(a, .{
+        .id = id2,
+        .address = std.net.Address.initIp4(.{ 10, 0, 0, 2 }, 6882),
+    }) catch unreachable;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(dir);
+    const path = try std.fmt.allocPrint(a, "{s}/nodes.dat", .{dir});
+    defer a.free(path);
+
+    saveNodeCache(&d, path);
+
+    const f = try std.fs.openFileAbsolute(path, .{});
+    defer f.close();
+    const size = (try f.stat()).size;
+    try std.testing.expectEqual(@as(u64, 4 + 2 * 26), size);
+
+    // And it round-trips back into an empty table.
+    var d2 = Dht.init(a, 16998);
+    defer d2.deinit();
+    try std.testing.expectEqual(@as(usize, 2), loadNodeCache(&d2, path));
 }

--- a/src/session.zig
+++ b/src/session.zig
@@ -13,6 +13,7 @@ const peer_mod = @import("peer.zig");
 const extension = @import("extension.zig");
 const bencode = @import("bencode.zig");
 const dht_mod = @import("dht.zig");
+const nostr_config = @import("nostr_config.zig");
 const proxy_mod = @import("proxy.zig");
 const i2p_sam = @import("i2p_sam.zig");
 
@@ -2431,10 +2432,22 @@ pub const Session = struct {
         // outlives an early session teardown; the thread itself is joined.
         st.ref();
         log.info("DHT lookup starting (background)...", .{});
+        // Warm the table from the persisted node cache (learned nodes from
+        // previous sessions), falling back to the well-known routers.
+        // Heap-allocated, not a stack buffer: the worker outlives this frame,
+        // so a slice into a local would dangle by the time it opens the file.
+        // Ownership transfers to the worker, which frees it.
+        const dht_cache_path: []const u8 = blk: {
+            const cfg_dir = nostr_config.configDir(self.allocator) catch break :blk "";
+            defer self.allocator.free(cfg_dir);
+            std.fs.cwd().makePath(cfg_dir) catch {};
+            break :blk std.fmt.allocPrint(self.allocator, "{s}/dht_nodes.dat", .{cfg_dir}) catch "";
+        };
         const thread = std.Thread.spawn(.{}, dhtQueryWorker, .{
-            self.allocator, st, self.listen_port + 1, self.info_hash, self.dht_node_id,
+            self.allocator, st, self.listen_port + 1, self.info_hash, self.dht_node_id, dht_cache_path,
         }) catch |err| {
             log.warn("DHT thread spawn failed: {t}", .{err});
+            if (dht_cache_path.len > 0) self.allocator.free(dht_cache_path);
             st.mutex.lock();
             st.query_active = false;
             st.mutex.unlock();
@@ -2468,7 +2481,16 @@ pub const Session = struct {
     /// session safely by holding a reference to the shared state and never
     /// touching the Session itself. Posts found peers + routing-table size
     /// for maintenance() to consume.
-    fn dhtQueryWorker(allocator: Allocator, st: *DhtState, port: u16, info_hash: [20]u8, node_id: [20]u8) void {
+    fn dhtQueryWorker(
+        allocator: Allocator,
+        st: *DhtState,
+        port: u16,
+        info_hash: [20]u8,
+        node_id: [20]u8,
+        /// Heap-allocated and owned by this worker; see startDhtLookup.
+        cache_path: []const u8,
+    ) void {
+        defer if (cache_path.len > 0) allocator.free(cache_path);
         defer st.unref(allocator);
         defer {
             st.mutex.lock();
@@ -2478,6 +2500,10 @@ pub const Session = struct {
 
         var d = dht_mod.Dht.initWithId(allocator, port, node_id);
         defer d.deinit();
+        if (cache_path.len > 0) {
+            const warmed = dht_mod.loadNodeCache(&d, cache_path);
+            if (warmed > 0) log.info("DHT: warmed table with {d} cached nodes", .{warmed});
+        }
         d.start() catch {
             log.warn("DHT failed to start", .{});
             st.mutex.lock();
@@ -2485,6 +2511,12 @@ pub const Session = struct {
             st.mutex.unlock();
             return;
         };
+
+        // Persist whatever the walk learned even if it ends up failing: the
+        // routing table is grown by the bootstrap/iteration steps, and
+        // throwing it away on a late error means the next session cold-starts
+        // for no reason.
+        defer if (cache_path.len > 0) dht_mod.saveNodeCache(&d, cache_path);
 
         const peers = d.getPeers(allocator, info_hash, &st.cancel) catch {
             // Don't cold-bootstrap again on the very next maintenance tick.


### PR DESCRIPTION
## Problem

The real-world DHT simulation (trackerless magnet for a live public swarm) found **zero peers** despite the swarm being healthy. Packet capture showed:

- queries only ever left for the 3 bootstrap router IPs
- `router.bittorrent.com` and `router.utorrent.com` never respond from the whole test network
- `dht.transmissionbt.com` — the only responsive router — returns a degenerate closest-nodes list (the same node repeated 8×, itself a dead end)

With an empty routing table, 3 routers, and a 3-iteration walk, carl cannot assemble a table on networks like this. Every mainstream client persists learned nodes across sessions; carl started naked every time.

## Fix

1. **Bootstrap list 3 → 8** routers (adds dht.libtorrent.org:25401, dht.bluetigers.club, dht.anacrolix.link, router.silotis.us, dht.aelitis.com).
2. **Lookup walk 3 → 8 iterations** so one good response compounds into a real descent.
3. **Persisted node cache**: learned nodes are saved to `<config>/dht_nodes.dat` (64-node cap, 20B id + 4B IPv4 + 2B port entries) and loaded to warm the table of every later session — like libtorrent's dht state. Verified in-sim: consecutive lookups report `warmed table with 10 → 12 cached nodes` growth.

Unit test covers the cache round-trip (save → load → nodes queryable by port).

**Honest limitation:** when 7/8 routers are unreachable and the 8th returns dead ends, no client can bootstrap — the cache at least preserves what a luckier session learned. Stacked on #80 (detached DHT worker), which this builds on.

Found by the feature-simulation harness (scenario `s17_real_dht_magnet` + udp packet capture).