### PR TITLE
fix(peer): 90s connect timeout for .onion/.b32.i2p dials (Tor descriptor latency)

### DIFF
--- a/src/peer.zig
+++ b/src/peer.zig
@@ -192,6 +192,21 @@ pub const PeerConnection = struct {
     /// congested peers routinely need 5-10 s to complete a TCP handshake.
     pub const connect_timeout_secs: u32 = 15;
 
+    /// Connect timeout for anonymized-network dials (.onion via SOCKS,
+    /// .b32.i2p via SAM). Building a Tor circuit — and for a freshly published
+    /// hidden service, waiting for its descriptor to propagate to the HSDirs —
+    /// routinely takes 20-60 s. The plain-TCP timeout killed these dials
+    /// mid-handshake, which surfaced as intermittent total failure to reach
+    /// onion peers whose descriptors were simply a few seconds slow.
+    pub const anon_connect_timeout_secs: u32 = 90;
+
+    /// The timeout that applies to this peer's pending connect: anonymized
+    /// transports get `anon_connect_timeout_secs`, clearnet TCP gets
+    /// `connect_timeout_secs`.
+    pub fn currentConnectTimeout(self: *const PeerConnection) u32 {
+        return if (self.connect_host != null) anon_connect_timeout_secs else connect_timeout_secs;
+    }
+
     /// Disable Nagle on a peer socket (best-effort). Wire requests are tiny
     /// and latency-sensitive; letting the kernel coalesce them behind delayed
     /// ACKs stalls the request pipeline. Also applied to proxy/SAM bridge

--- a/src/peer.zig
+++ b/src/peer.zig
@@ -200,9 +200,11 @@ pub const PeerConnection = struct {
     /// onion peers whose descriptors were simply a few seconds slow.
     pub const anon_connect_timeout_secs: u32 = 90;
 
-    /// The timeout that applies to this peer's pending connect: anonymized
-    /// transports get `anon_connect_timeout_secs`, clearnet TCP gets
-    /// `connect_timeout_secs`.
+    /// The timeout that applies to this peer's pending connect. `connect_host`
+    /// is set only by `initOnion`/`initI2p`, i.e. exactly the dials that go by
+    /// hostname through Tor or SAM, so it doubles as the "this is an
+    /// anonymized transport" test. A clearnet peer dialed through a plain
+    /// SOCKS proxy goes through `init` and keeps the 15s timeout.
     pub fn currentConnectTimeout(self: *const PeerConnection) u32 {
         return if (self.connect_host != null) anon_connect_timeout_secs else connect_timeout_secs;
     }
@@ -742,4 +744,19 @@ test "peer handshake serialization" {
 
     try peer.sendHandshake([_]u8{0xAA} ** 20, [_]u8{0xBB} ** 20);
     try std.testing.expectEqual(@as(usize, 68), peer.send_buf.items.len);
+}
+
+test "connect timeout is per-transport" {
+    const a = std.testing.allocator;
+
+    var clearnet = PeerConnection.init(a, std.net.Address.initIp4(.{ 1, 2, 3, 4 }, 6881));
+    defer clearnet.deinit();
+    try std.testing.expectEqual(PeerConnection.connect_timeout_secs, clearnet.currentConnectTimeout());
+
+    // A hostname dial (Tor/SAM) must survive circuit build plus descriptor
+    // propagation, which routinely outlasts the clearnet TCP timeout.
+    var onion = try PeerConnection.initOnion(a, "examplepeer.onion", 6881);
+    defer onion.deinit();
+    try std.testing.expectEqual(PeerConnection.anon_connect_timeout_secs, onion.currentConnectTimeout());
+    try std.testing.expect(onion.currentConnectTimeout() > clearnet.currentConnectTimeout());
 }

--- a/src/session.zig
+++ b/src/session.zig
@@ -1935,7 +1935,7 @@ pub const Session = struct {
                 // A clearnet peer stuck in the non-blocking connect phase past
                 // the connect timeout is a dead host — reclaim its poll slot so
                 // it doesn't squat against the max_peers cap.
-                if ((p.state == .connecting or p.state == .socks_connecting) and now - p.connect_started_at > peer_mod.PeerConnection.connect_timeout_secs) {
+                if ((p.state == .connecting or p.state == .socks_connecting) and now - p.connect_started_at > p.currentConnectTimeout()) {
                     p.disconnect();
                     i += 1;
                     continue;


### PR DESCRIPTION
## Problem

All peer connects shared one 15s timeout. But an onion dial through Tor must build a circuit and — for a freshly published hidden service — wait for its descriptor to propagate to the HSDirs, which routinely takes **20-60s** (sometimes minutes). carl aborted these dials at 15s.

Observed in the simulation harness (scenario `s14_tor_onion`): the *identical* scenario intermittently timed out at 300s or passed in 40s, run to run. The failing runs' dials were being killed at 15s while the fresh onion's descriptor was still propagating — every retry hit the same wall. Same risk applies to I2P SAM dials (tunnel establishment).

## Fix

`PeerConnection.currentConnectTimeout()`: **90s** when the dial is host-based (`.onion` via SOCKS, `.b32.i2p` via SAM — `connect_host` set), **15s** unchanged for clearnet TCP. The maintenance-loop reclaim uses the per-peer value, so dead anonymized peers are still reclaimed (just given realistic time), and poll-slot squatting stays bounded.

`zig build test` passes. Found by the feature-simulation harness (s14 flakiness analysis).